### PR TITLE
Added getElementBehaviorType method

### DIFF
--- a/src/elements/MITCShell.h
+++ b/src/elements/MITCShell.h
@@ -72,6 +72,7 @@ class MITCShell : public TACSShell {
   // ------------------------------------
   int numNodes();
   int numVariables();
+  ElementBehaviorType getElementBehaviorType(){ return type; }
 
   // Compute the kinetic and potential energy within the element
   // -----------------------------------------------------------
@@ -1303,7 +1304,7 @@ void MITCShell<order, tying_order>::getMatType( ElementMatrixType matType,
 template <int order, int tying_order>
 void MITCShell<order, tying_order>::addAdjResProduct( double time,
                                                       double scale,
-                                                      TacsScalar fdvSens[], 
+                                                      TacsScalar fdvSens[],
                                                       int dvLen,
                                                       const TacsScalar psi[],
                                                       const TacsScalar Xpts[],

--- a/src/elements/TACSElement.h
+++ b/src/elements/TACSElement.h
@@ -201,7 +201,8 @@ enum ElementMatrixType { STIFFNESS_MATRIX,
 // Element behavior types
 enum ElementBehaviorType{ LINEAR,
                           NONLINEAR,
-                          LARGE_ROTATION };
+                          LARGE_ROTATION,
+                          NONE };
 
 // The TACSElement base class
 class TACSElement : public TACSOptObject {
@@ -419,10 +420,11 @@ class TACSElement : public TACSOptObject {
   // ------------------------------
   virtual const char *TACSObjectName(){ return this->elementName(); }
 
-  // Get the number of extras and element type information
+  // Get the number of extras, element type, and element behavior type
   // -----------------------------------------------------
   virtual int numExtras(){ return 0; }
   virtual enum ElementType getElementType(){ return TACS_ELEMENT_NONE; }
+  virtual enum ElementBehaviorType getElementBehaviorType(){ return NONE; }
 
   // Functions for retrieving data from the element for visualization
   // ----------------------------------------------------------------


### PR DESCRIPTION
I'm implementing a geometrically nonlinear version of RLT and as a result I need to be able to tell whether an element is geometrically linear or nonlinear so I added a getter method for the `ElementBehaviorType` property of an element in the same style as the current `getElementType` method.

I've added `NONE` as a new `ElementBehaviorType` option which is the default output of `getElementBehaviorType` and each child element class would then need to redefine it's own `getElementBehaviorType` method. So far I have only done this for the MITCShell class.

Please let me know if there's a better way of implementing this.

