### PR TITLE
Added thermal shell elements to the python interface and added tests

### DIFF
--- a/src/elements/shell/TACSDirector.h
+++ b/src/elements/shell/TACSDirector.h
@@ -313,9 +313,7 @@ class TACSLinearizedRotation {
     Given the partial derivatives of the Lagrangian with respect to the
     director and the time derivative of the vector, compute
 
-    dTdot = d/dt(dT/d(dot{d}))
-    dT = dT/d(dot{d})
-    dd = -dL/dd
+    dd = d/dt(dT/d(dot{d})) - dL/dd
 
     In general, the residual contribution is:
 
@@ -327,7 +325,7 @@ class TACSLinearizedRotation {
     For the linearized rotation director these expressions are:
 
     d = q^{x} t
-    dot{d} = - t^{x} \dot{q}
+    dot{d} = - t^{x} dot{q}
     d(dot{d})/d(dot{q}) = - t^{x}
     d/dt(d(dot{d})/d(dot{q})) = 0
 
@@ -335,7 +333,6 @@ class TACSLinearizedRotation {
     @param dvars The first time derivative of the variables
     @param ddvars The second derivatives of the variables
     @param t The normal direction
-    @param dTdot Time deriv. of the deriv. of the kinetic energy w.r.t. d
     @param dd The contribution from the derivative of the director
     @param res The output residual
   */
@@ -344,18 +341,15 @@ class TACSLinearizedRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    TacsScalar res[] ){
     TacsScalar *r = &res[offset];
 
     for ( int i = 0; i < num_nodes; i++ ){
       crossProductAdd(1.0, t, dd, r);
-      crossProductAdd(1.0, t, dTdot, r);
 
       r += vars_per_node;
       dd += 3;
-      dTdot += 3;
       t += 3;
     }
   }
@@ -371,7 +365,6 @@ class TACSLinearizedRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    const TacsScalar d2Tdotd[],
                                    const TacsScalar d2Tdotu[],
@@ -980,8 +973,6 @@ class TACSQuadraticRotation {
     @param dvars The first time derivative of the variables
     @param ddvars The second derivatives of the variables
     @param t The normal direction
-    @param dTdot Time deriv. of the deriv. of the kinetic energy w.r.t. d
-    @param dT The derivative of the kinetic energy w.r.t. director
     @param dd The contribution from the derivative of the director
     @param res The output residual
   */
@@ -990,7 +981,6 @@ class TACSQuadraticRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    TacsScalar res[] ){
     TacsScalar *r = &res[offset];
@@ -1018,16 +1008,11 @@ class TACSQuadraticRotation {
       r[1] += D[3]*dd[0] + D[4]*dd[1] + D[5]*dd[2];
       r[2] += D[6]*dd[0] + D[7]*dd[1] + D[8]*dd[2];
 
-      r[0] += D[0]*dTdot[0] + D[1]*dTdot[1] + D[2]*dTdot[2];
-      r[1] += D[3]*dTdot[0] + D[4]*dTdot[1] + D[5]*dTdot[2];
-      r[2] += D[6]*dTdot[0] + D[7]*dTdot[1] + D[8]*dTdot[2];
-
       r += vars_per_node;
       q += vars_per_node;
       qdot += vars_per_node;
 
       dd += 3;
-      dTdot += 3;
       t += 3;
     }
   }
@@ -1043,7 +1028,6 @@ class TACSQuadraticRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    const TacsScalar d2Tdotd[],
                                    const TacsScalar d2Tdotu[],
@@ -1118,10 +1102,6 @@ class TACSQuadraticRotation {
         r[1] += D[3]*dd[0] + D[4]*dd[1] + D[5]*dd[2];
         r[2] += D[6]*dd[0] + D[7]*dd[1] + D[8]*dd[2];
 
-        r[0] += D[0]*dTdot[0] + D[1]*dTdot[1] + D[2]*dTdot[2];
-        r[1] += D[3]*dTdot[0] + D[4]*dTdot[1] + D[5]*dTdot[2];
-        r[2] += D[6]*dTdot[0] + D[7]*dTdot[1] + D[8]*dTdot[2];
-
         r += vars_per_node;
       }
 
@@ -1172,9 +1152,9 @@ class TACSQuadraticRotation {
 
         if (i == j){
           TacsScalar tmp[3];
-          tmp[0] = alpha*(dd[0] + dTdot[0]);
-          tmp[1] = alpha*(dd[1] + dTdot[1]);
-          tmp[2] = alpha*(dd[2] + dTdot[2]);
+          tmp[0] = alpha*dd[0];
+          tmp[1] = alpha*dd[1];
+          tmp[2] = alpha*dd[2];
 
           jac[0] -= tmp[1]*t[1] + tmp[2]*t[2];
           jac[1] += 0.5*(tmp[0]*t[1] + tmp[1]*t[0]);
@@ -1200,7 +1180,6 @@ class TACSQuadraticRotation {
       qdot += vars_per_node;
 
       dd += 3;
-      dTdot += 3;
       t += 3;
       m += vars_per_node*size;
     }
@@ -1951,8 +1930,7 @@ class TACSQuaternionRotation {
     Given the partial derivatives of the Lagrangian with respect to the
     director and the time derivative of the vector, compute
 
-    dTdot = d/dt(dT/d(dot{d}))
-    dd = -dL/dd
+    dd =  d/dt(dT/d(dot{d})) - dL/dd
 
     In general, the residual contribution is:
 
@@ -1963,7 +1941,6 @@ class TACSQuaternionRotation {
     @param dvars The first time derivative of the variables
     @param ddvars The second derivatives of the variables
     @param t The normal direction
-    @param dTdot Time deriv. of the deriv. of the kinetic energy w.r.t. d
     @param dd The contribution from the derivative of the director
     @param res The output residual
   */
@@ -1972,7 +1949,6 @@ class TACSQuaternionRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    TacsScalar res[] ){
     TacsScalar *r = &res[offset];
@@ -1997,11 +1973,6 @@ class TACSQuaternionRotation {
       D[10] = 2.0*(q[3]*t[1] - q[0]*t[0] - 2.0*q[2]*t[2]);
       D[11] = 2.0*(q[1]*t[0] + q[2]*t[1]);
 
-      r[0] += dTdot[0]*D[0] + dTdot[1]*D[4] + dTdot[2]*D[8];
-      r[1] += dTdot[0]*D[1] + dTdot[1]*D[5] + dTdot[2]*D[9];
-      r[2] += dTdot[0]*D[2] + dTdot[1]*D[6] + dTdot[2]*D[10];
-      r[3] += dTdot[0]*D[3] + dTdot[1]*D[7] + dTdot[2]*D[11];
-
       r[0] += dd[0]*D[0] + dd[1]*D[4] + dd[2]*D[8];
       r[1] += dd[0]*D[1] + dd[1]*D[5] + dd[2]*D[9];
       r[2] += dd[0]*D[2] + dd[1]*D[6] + dd[2]*D[10];
@@ -2012,7 +1983,6 @@ class TACSQuaternionRotation {
       qdot += vars_per_node;
 
       dd += 3;
-      dTdot += 3;
       t += 3;
     }
   }
@@ -2028,7 +1998,6 @@ class TACSQuaternionRotation {
                                    const TacsScalar dvars[],
                                    const TacsScalar ddvars[],
                                    const TacsScalar t[],
-                                   const TacsScalar dTdot[],
                                    const TacsScalar dd[],
                                    const TacsScalar d2Tdotd[],
                                    const TacsScalar d2Tdotu[],
@@ -2109,11 +2078,6 @@ class TACSQuaternionRotation {
     const TacsScalar *Di = D;
     for ( int i = 0; i < num_nodes; i++, Di += 12 ){
       if (res){
-        r[0] += dTdot[0]*Di[0] + dTdot[1]*Di[4] + dTdot[2]*Di[8];
-        r[1] += dTdot[0]*Di[1] + dTdot[1]*Di[5] + dTdot[2]*Di[9];
-        r[2] += dTdot[0]*Di[2] + dTdot[1]*Di[6] + dTdot[2]*Di[10];
-        r[3] += dTdot[0]*Di[3] + dTdot[1]*Di[7] + dTdot[2]*Di[11];
-
         r[0] += dd[0]*Di[0] + dd[1]*Di[4] + dd[2]*Di[8];
         r[1] += dd[0]*Di[1] + dd[1]*Di[5] + dd[2]*Di[9];
         r[2] += dd[0]*Di[2] + dd[1]*Di[6] + dd[2]*Di[10];
@@ -2173,9 +2137,9 @@ class TACSQuaternionRotation {
 
         if (i == j){
           TacsScalar tmp[3];
-          tmp[0] = alpha*(dd[0] + dTdot[0]);
-          tmp[1] = alpha*(dd[1] + dTdot[1]);
-          tmp[2] = alpha*(dd[2] + dTdot[2]);
+          tmp[0] = alpha*dd[0];
+          tmp[1] = alpha*dd[1];
+          tmp[2] = alpha*dd[2];
 
           jac[1] += 2.0*(tmp[2]*t[1] - tmp[1]*t[2]);
           jac[2] += 2.0*(tmp[0]*t[2] - tmp[2]*t[0]);
@@ -2208,7 +2172,6 @@ class TACSQuaternionRotation {
       qdot += vars_per_node;
 
       dd += 3;
-      dTdot += 3;
       t += 3;
       m += vars_per_node*size;
     }
@@ -2989,7 +2952,7 @@ int TacsTestDirector( double dh=1e-7,
   director::template
     addDirectorJacobian<vars_per_node, offset, num_nodes>(alpha, beta, gamma,
                                                           vars, dvars, ddvars, t,
-                                                          dTdot, dd, d2Tdotd, d2Tdotu,
+                                                          dd, d2Tdotd, d2Tdotu,
                                                           d2d, d2du, res, mat);
 
   if (alpha != 0.0){

--- a/src/elements/shell/TACSDirector.h
+++ b/src/elements/shell/TACSDirector.h
@@ -269,8 +269,9 @@ class TACSLinearizedRotation {
     @param d The director values
     @param ddot The first time derivative of the director
     @param dddot The second time derivative of the director
-    @param Cd The derivative of the rotation matrices at each point
-    @param dd The derivator of the director values
+    @param dd The derivative of the director values
+    @param ddt The derivative of the first time derivative of the director
+    @param ddtt The derivative of the second time derivative of the director
   */
   template <int vars_per_node, int offset, int num_nodes>
   static void computeDirectorRatesDeriv( const TacsScalar vars[],
@@ -281,7 +282,9 @@ class TACSLinearizedRotation {
                                          TacsScalar d[],
                                          TacsScalar ddot[],
                                          TacsScalar dddot[],
-                                         TacsScalar dd[] ){
+                                         TacsScalar dd[],
+                                         TacsScalar ddt[],
+                                         TacsScalar ddtt[] ){
     const TacsScalar *q = &vars[offset];
     const TacsScalar *qdot = &dvars[offset];
     const TacsScalar *qddot = &ddvars[offset];
@@ -293,12 +296,16 @@ class TACSLinearizedRotation {
 
       // Cd = - qd^{x}
       crossProduct(qd, t, dd);
+      crossProduct(qd, t, ddt);
+      crossProduct(qd, t, ddtt);
 
       t += 3;
       d += 3;
       dd += 3;
       ddot += 3;
+      ddt += 3;
       dddot += 3;
+      ddtt += 3;
 
       q += vars_per_node;
       qdot += vars_per_node;
@@ -900,8 +907,9 @@ class TACSQuadraticRotation {
     @param d The director values
     @param ddot The first time derivative of the director
     @param dddot The second time derivative of the director
-    @param Cd The derivative of the rotation matrices at each point
-    @param dd The derivator of the director values
+    @param dd The derivative of the director values
+    @param ddt The derivative of the first time derivative of the director
+    @param ddtt The derivative of the second time derivative of the director
   */
   template <int vars_per_node, int offset, int num_nodes>
   static void computeDirectorRatesDeriv( const TacsScalar vars[],
@@ -912,7 +920,9 @@ class TACSQuadraticRotation {
                                          TacsScalar d[],
                                          TacsScalar ddot[],
                                          TacsScalar dddot[],
-                                         TacsScalar dd[] ){
+                                         TacsScalar dd[],
+                                         TacsScalar ddt[],
+                                         TacsScalar ddtt[] ){
     const TacsScalar *q = &vars[offset];
     const TacsScalar *qdot = &dvars[offset];
     const TacsScalar *qddot = &ddvars[offset];
@@ -1824,8 +1834,9 @@ class TACSQuaternionRotation {
     @param d The director values
     @param ddot The first time derivative of the director
     @param dddot The second time derivative of the director
-    @param Cd The derivative of the rotation matrices at each point
-    @param dd The derivator of the director values
+    @param dd The derivative of the director values
+    @param ddt The derivative of the first time derivative of the director
+    @param ddtt The derivative of the second time derivative of the director
   */
   template <int vars_per_node, int offset, int num_nodes>
   static void computeDirectorRatesDeriv( const TacsScalar vars[],
@@ -1836,7 +1847,9 @@ class TACSQuaternionRotation {
                                          TacsScalar d[],
                                          TacsScalar ddot[],
                                          TacsScalar dddot[],
-                                         TacsScalar dd[] ){
+                                         TacsScalar dd[],
+                                         TacsScalar ddt[],
+                                         TacsScalar ddtt[] ){
     const TacsScalar *q = &vars[offset];
     const TacsScalar *qdot = &dvars[offset];
     const TacsScalar *qddot = &ddvars[offset];

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -687,12 +687,10 @@ void TACSShellElement<quadrature, basis, director, model>::
     transform, Xdn, fn, vars, psi, XdinvTn, Tn, u0xn, Ctn, etn, etnd);
 
   // Compute the director rates and their derivatives
-  TacsScalar d[dsize], ddot[dsize], dddot[dsize];
-  TacsScalar dd[dsize], ddt[dsize], ddtt[dsize];
+  TacsScalar d[dsize], ddot[dsize], dddot[dsize], dd[dsize];
   director::template
     computeDirectorRatesDeriv<vars_per_node, offset, num_nodes>(vars, dvars, ddvars, psi, fn,
-                                                                d, ddot, dddot,
-                                                                dd, ddt, ddtt);
+                                                                d, ddot, dddot, dd);
 
   // Set the total number of tying points needed for this element
   TacsScalar ety[basis::NUM_TYING_POINTS], etyd[basis::NUM_TYING_POINTS];
@@ -752,7 +750,7 @@ void TACSShellElement<quadrature, basis, director, model>::
 
     TacsScalar du0ddot[3], dd0ddot[3];
     basis::template interpFields<vars_per_node, 3>(pt, psi, du0ddot);
-    basis::template interpFields<3, 3>(pt, ddtt, dd0ddot);
+    basis::template interpFields<3, 3>(pt, dd, dd0ddot);
 
     TacsScalar coef[3];
     coef[0] = scale*detXd*vec3Dot(u0ddot, du0ddot);

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -305,9 +305,8 @@ void TACSShellElement<quadrature, basis, director, model>::
   const int nquad = quadrature::getNumQuadraturePoints();
 
   // Derivative of the director field and matrix at each point
-  TacsScalar dd[dsize], dTdot[dsize];
+  TacsScalar dd[dsize];
   memset(dd, 0, 3*num_nodes*sizeof(TacsScalar));
-  memset(dTdot, 0, 3*num_nodes*sizeof(TacsScalar));
 
   // Compute the node normal directions
   TacsScalar fn[3*num_nodes], Xdn[9*num_nodes];
@@ -415,7 +414,7 @@ void TACSShellElement<quadrature, basis, director, model>::
     dd0dot[0] = detXd*(moments[1]*u0ddot[0] + moments[2]*d0ddot[0]);
     dd0dot[1] = detXd*(moments[1]*u0ddot[1] + moments[2]*d0ddot[1]);
     dd0dot[2] = detXd*(moments[1]*u0ddot[2] + moments[2]*d0ddot[2]);
-    basis::template addInterpFieldsTranspose<3, 3>(pt, dd0dot, dTdot);
+    basis::template addInterpFieldsTranspose<3, 3>(pt, dd0dot, dd);
   }
 
   // Add the contribution to the residual from the drill strain
@@ -429,8 +428,7 @@ void TACSShellElement<quadrature, basis, director, model>::
 
   // Add the contributions to the director field
   director::template
-    addDirectorResidual<vars_per_node, offset, num_nodes>(vars, dvars, ddvars, fn,
-                                                          dTdot, dd, res);
+    addDirectorResidual<vars_per_node, offset, num_nodes>(vars, dvars, ddvars, fn, dd, res);
 
   // Add the contribution from the rotation constraint (defined by the
   // rotational parametrization) - if any
@@ -458,9 +456,8 @@ void TACSShellElement<quadrature, basis, director, model>::
   const int nquad = quadrature::getNumQuadraturePoints();
 
   // Derivative of the director field
-  TacsScalar dd[dsize], dTdot[dsize];
+  TacsScalar dd[dsize];
   memset(dd, 0, dsize*sizeof(TacsScalar));
-  memset(dTdot, 0, dsize*sizeof(TacsScalar));
 
   // Second derivatives required for the director
   TacsScalar d2d[dsize*dsize], d2du[usize*dsize];
@@ -616,7 +613,7 @@ void TACSShellElement<quadrature, basis, director, model>::
     dd0dot[0] = detXd*(moments[1]*u0ddot[0] + moments[2]*d0ddot[0]);
     dd0dot[1] = detXd*(moments[1]*u0ddot[1] + moments[2]*d0ddot[1]);
     dd0dot[2] = detXd*(moments[1]*u0ddot[2] + moments[2]*d0ddot[2]);
-    basis::template addInterpFieldsTranspose<3, 3>(pt, dd0dot, dTdot);
+    basis::template addInterpFieldsTranspose<3, 3>(pt, dd0dot, dd);
 
     TacsScalar d2u0dot[9];
     memset(d2u0dot, 0, 9*sizeof(TacsScalar));
@@ -651,7 +648,7 @@ void TACSShellElement<quadrature, basis, director, model>::
   director::template
     addDirectorJacobian<vars_per_node, offset, num_nodes>(alpha, beta, gamma,
                                                           vars, dvars, ddvars,
-                                                          fn, dTdot, dd,
+                                                          fn, dd,
                                                           d2Tdotd, d2Tdotu, d2d, d2du,
                                                           res, mat);
 
@@ -920,9 +917,8 @@ void TACSShellElement<quadrature, basis, director, model>::
                           TacsScalar dfdu[] ){
   if (quantityType == TACS_FAILURE_INDEX){
     // Derivative of the director field
-    TacsScalar dd[dsize], dTdot[dsize];
+    TacsScalar dd[dsize];
     memset(dd, 0, 3*num_nodes*sizeof(TacsScalar));
-    memset(dTdot, 0, 3*num_nodes*sizeof(TacsScalar));
 
     // Zero the contributions to the tying strain derivatives
     TacsScalar dety[basis::NUM_TYING_POINTS];
@@ -997,7 +993,7 @@ void TACSShellElement<quadrature, basis, director, model>::
     // Add the contributions to the director field
     director::template
       addDirectorResidual<vars_per_node, offset, num_nodes>(vars, dvars, ddvars, fn,
-                                                            dTdot, dd, dfdu);
+                                                            dd, dfdu);
   }
 }
 

--- a/src/elements/shell/TACSShellElementDefs.h
+++ b/src/elements/shell/TACSShellElementDefs.h
@@ -39,6 +39,9 @@ typedef TACSThermalShellElement<TACSQuadQuadraticQuadrature, TACSShellQuadBasis<
 typedef TACSThermalShellElement<TACSQuadCubicQuadrature, TACSShellQuadBasis<4>,
                                 TACSLinearizedRotation, TACSShellLinearModel> TACSQuad16ThermalShell;
 
+typedef TACSThermalShellElement<TACSTriLinearQuadrature, TACSShellTriLinearBasis,
+                                TACSLinearizedRotation, TACSShellInplaneLinearModel> TACSTri3ThermalShell;
+
 /*
   Shell elements with a linearized rotation and nonlinear strain expressions
 */
@@ -66,13 +69,20 @@ typedef TACSShellElement<TACSQuadCubicQuadrature, TACSShellQuadBasis<4>,
 typedef TACSShellElement<TACSTriLinearQuadrature, TACSShellTriLinearBasis,
                          TACSQuadraticRotation, TACSShellInplaneLinearModel> TACSTri3ShellModRot;
 
-// typedef TACSShellElement<TACSQuadLinearQuadrature, TACSShellQuadBasis<2>,
-//                          TACSQuadraticRotation, TACSShellNonlinearModel> TACSQuad4NonlinearShellModRot;
 
-// typedef TACSShellElement<TACSQuadQuadraticQuadrature, TACSShellQuadBasis<3>,
-//                          TACSQuadraticRotation, TACSShellNonlinearModel> TACSQuad9NonlinearShellModRot;
+/*
+  Quaternion shell elements
+*/
+typedef TACSShellElement<TACSQuadLinearQuadrature, TACSShellQuadBasis<2>,
+                         TACSQuaternionRotation, TACSShellLinearModel> TACSQuad4ShellQuaternion;
 
-// typedef TACSShellElement<TACSQuadCubicQuadrature, TACSShellQuadBasis<4>,
-//                          TACSQuadraticRotation, TACSShellNonlinearModel> TACSQuad16NonlinearShellModRot;
+typedef TACSShellElement<TACSQuadQuadraticQuadrature, TACSShellQuadBasis<3>,
+                         TACSQuaternionRotation, TACSShellLinearModel> TACSQuad9ShellQuaternion;
+
+typedef TACSShellElement<TACSQuadCubicQuadrature, TACSShellQuadBasis<4>,
+                         TACSQuaternionRotation, TACSShellLinearModel> TACSQuad16ShellQuaternion;
+
+typedef TACSShellElement<TACSTriLinearQuadrature, TACSShellTriLinearBasis,
+                         TACSQuaternionRotation, TACSShellInplaneLinearModel> TACSTri3ShellQuaternion;
 
 #endif // TACS_SHELL_ELEMENT_DEFS_H

--- a/tacs/elements.pxd
+++ b/tacs/elements.pxd
@@ -200,11 +200,27 @@ cdef extern from "TACSShellElementDefs.h":
 
     cdef cppclass TACSQuad16Shell(TACSElement):
         TACSQuad16Shell(TACSShellTransform*,
-                       TACSShellConstitutive*)
+                        TACSShellConstitutive*)
 
     cdef cppclass TACSTri3Shell(TACSElement):
         TACSTri3Shell(TACSShellTransform*,
                       TACSShellConstitutive*)
+
+    cdef cppclass TACSQuad4ThermalShell(TACSElement):
+        TACSQuad4ThermalShell(TACSShellTransform*,
+                              TACSShellConstitutive*)
+
+    cdef cppclass TACSQuad9ThermalShell(TACSElement):
+        TACSQuad9ThermalShell(TACSShellTransform*,
+                              TACSShellConstitutive*)
+
+    cdef cppclass TACSQuad16ThermalShell(TACSElement):
+        TACSQuad16ThermalShell(TACSShellTransform*,
+                               TACSShellConstitutive*)
+
+    cdef cppclass TACSTri3ThermalShell(TACSElement):
+        TACSTri3ThermalShell(TACSShellTransform*,
+                             TACSShellConstitutive*)
 
 cdef extern from "TACSGibbsVector.h":
     cdef cppclass TACSGibbsVector(TACSObject):

--- a/tacs/elements.pyx
+++ b/tacs/elements.pyx
@@ -458,11 +458,15 @@ cdef class Quad4Shell(Element):
 
 cdef class Quad9Shell(Element):
     def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
         self.ptr = new TACSQuad9Shell(transform.ptr, con.cptr)
         self.ptr.incref()
 
 cdef class Quad16Shell(Element):
     def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
         self.ptr = new TACSQuad16Shell(transform.ptr, con.cptr)
         self.ptr.incref()
 
@@ -471,6 +475,34 @@ cdef class Tri3Shell(Element):
         if transform is None:
             transform = ShellNaturalTransform()
         self.ptr = new TACSTri3Shell(transform.ptr, con.cptr)
+        self.ptr.incref()
+
+cdef class Quad4ThermalShell(Element):
+    def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
+        self.ptr = new TACSQuad4ThermalShell(transform.ptr, con.cptr)
+        self.ptr.incref()
+
+cdef class Quad9ThermalShell(Element):
+    def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
+        self.ptr = new TACSQuad9ThermalShell(transform.ptr, con.cptr)
+        self.ptr.incref()
+
+cdef class Quad16ThermalShell(Element):
+    def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
+        self.ptr = new TACSQuad16ThermalShell(transform.ptr, con.cptr)
+        self.ptr.incref()
+
+cdef class Tri3ThermalShell(Element):
+    def __cinit__(self, ShellTransform transform, ShellConstitutive con):
+        if transform is None:
+            transform = ShellNaturalTransform()
+        self.ptr = new TACSTri3ThermalShell(transform.ptr, con.cptr)
         self.ptr.incref()
 
 cdef class GibbsVector:

--- a/tests/element_tests/shell_tests/test_shell_element.py
+++ b/tests/element_tests/shell_tests/test_shell_element.py
@@ -35,7 +35,7 @@ class ElementTest(unittest.TestCase):
         self.ddvars = self.vars.copy()
 
         # Create the isotropic material
-        rho = 0.0 # 2700.0
+        rho = 2700.0
         specific_heat = 921.096
         E = 70e3
         nu = 0.3


### PR DESCRIPTION
The following changes were made:

- simplified the director residual to contain a single director argument for the residual
- added tests for the thermal shell element in tests/element_tests/shell_tests
- fixed adjResProduct code for the quaternion and quadratic rotational parametrizations