### PR TITLE
Adding check in meshloader for unattached nodes

### DIFF
--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -682,26 +682,26 @@ class pyMeshLoader(BaseUI):
         Notify the user and throw an error if we find any.
         This must be checked before creating the TACS assembler or a SegFault may occur.
         """
-        num_unattached = 0
+        numUnattached = 0
         if self.comm.rank == 0:
             # Flatten conectivity to single list
-            flattened_conn = it.chain.from_iterable(self.elemConnectivity)
+            flattenedConn = it.chain.from_iterable(self.elemConnectivity)
             # uniqueify and order all element-attached nodes
-            attached_nodes = set(flattened_conn)
+            attachedNodes = set(flattenedConn)
             # Loop through each node in the bdf and check if it's in the element node set
             for nastranNodeID in self.bdfInfo.node_ids:
                 tacsNodeID = self.idMap(nastranNodeID, self.nastranToTACSNodeIDDict)
-                if tacsNodeID not in attached_nodes:
-                    if num_unattached < 100:
+                if tacsNodeID not in attachedNodes:
+                    if numUnattached < 100:
                         self.TACSWarning(f'Node ID {nastranNodeID} (Nastran ordering) is not attached to any element in the model. '
                                          f'Please remove this node from the mesh and try again.')
-                    num_unattached += 1
+                    numUnattached += 1
 
         # Broadcast number of found unattached nodes
-        num_unattached = self.comm.bcast(num_unattached, root=0)
+        numUnattached = self.comm.bcast(numUnattached, root=0)
         # Raise an error if any unattached nodes were found
-        if num_unattached > 0:
-            raise self.TACSError(f'{num_unattached} unattached node(s) were detected in model. '
+        if numUnattached > 0:
+            raise self.TACSError(f'{numUnattached} unattached node(s) were detected in model. '
                            f'Please make sure that all nodes are attached to at least one element.')
 
     def isDOFInString(self, dofString, numDOFs):

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -11,6 +11,7 @@ functionality.
 # Imports
 # =============================================================================
 import numpy as np
+import itertools as it
 import tacs.TACS, tacs.elements, tacs.constitutive
 from pyNastran.bdf.bdf import read_bdf
 from .utilities import BaseUI
@@ -679,19 +680,27 @@ class pyMeshLoader(BaseUI):
         Notify the user and throw an error if we find any.
         This must be checked before creating the TACS assembler or a SegFault may occur.
         """
-        flattened_conn = self._flatten(self.elemConnectivity)
         num_unattached = 0
-        for nastranNodeID in self.bdfInfo.node_ids:
-            tacsNodeID = self.idMap(nastranNodeID, self.nastranToTACSNodeIDDict)
-            if tacsNodeID not in flattened_conn:
-                if num_unattached < 100:
-                    self.TACSWarning(f'Node ID {nastranNodeID} (Nastran ordering) is not attached to any element in the model. '
-                                     f'Please remove this node from the mesh and try again.')
-                num_unattached += 1
+        if self.comm.rank == 0:
+            # Flatten conectivity to single list
+            flattened_conn = it.chain.from_iterable(self.elemConnectivity)
+            # uniqueify and order all element-attached nodes
+            attached_nodes = set(flattened_conn)
+            # Loop through each node in the bdf and check if it's in the element node set
+            for nastranNodeID in self.bdfInfo.node_ids:
+                tacsNodeID = self.idMap(nastranNodeID, self.nastranToTACSNodeIDDict)
+                if tacsNodeID not in attached_nodes:
+                    if num_unattached < 100:
+                        self.TACSWarning(f'Node ID {nastranNodeID} (Nastran ordering) is not attached to any element in the model. '
+                                         f'Please remove this node from the mesh and try again.')
+                    num_unattached += 1
+
+        # Broadcast number of found unattached nodes
+        num_unattached = self.comm.bcast(num_unattached, root=0)
+        # Raise an error if any unattached nodes were found
         if num_unattached > 0:
             raise self.TACSError(f'{num_unattached} unattached node(s) were detected in model. '
                            f'Please make sure that all nodes are attached to at least one element.')
-
 
     def isDOFInString(self, dofString, numDOFs):
         """

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -454,7 +454,9 @@ class pyMeshLoader(BaseUI):
         if self.comm.rank == 0:
             # Set connectivity for all elements
             ptr = np.array(self.elemConnectivityPointer, dtype=np.intc)
-            conn = np.array(self._flatten(self.elemConnectivity), dtype=np.intc)
+            # Flatten nested connectivity list to single list
+            conn = it.chain.from_iterable(self.elemConnectivity)
+            conn = np.array([*conn], dtype=np.intc)
             objectNums = np.array(self.elemObjectNumByElem, dtype=np.intc)
             self.creator.setGlobalConnectivity(self.bdfInfo.nnodes, ptr, conn, objectNums)
 


### PR DESCRIPTION
- Adding automatic check in mesh loading procedure for any nodes not belonging to at least one element
- A detailed error message will be printed out if any unattached nodes are found
- This check is run before the TACS assembler is created in order to prevent a segfault occur from occurring