### PR TITLE
Automating output type in pyTACS

### DIFF
--- a/examples/battery/battery_runaway.py
+++ b/examples/battery/battery_runaway.py
@@ -26,17 +26,11 @@ This example demonstrates a number of useful pyTACS features, including:
 
 comm = MPI.COMM_WORLD
 
-# Optional arguments: these to output the f5 file to visualize the solution and which element type to use
-structOptions = {
-    'writeSolution': True,
-    'outputElement': TACS.PLANE_STRESS_ELEMENT,
-}
-
 # Name of the bdf file to get the mesh
 bdfFile = os.path.join(os.path.dirname(__file__), 'battery_pack.bdf')
 
 # Instantiate the pyTACS object
-FEAAssembler = pyTACS(bdfFile, comm, options=structOptions)
+FEAAssembler = pyTACS(bdfFile, comm)
 
 # Specify the plate thickness
 tplate = 0.065

--- a/examples/thermal_plate/analysis.py
+++ b/examples/thermal_plate/analysis.py
@@ -40,9 +40,7 @@ comm = MPI.COMM_WORLD
 
 # Instantiate FEAAssembler
 structOptions = {
-    'printtiming':True,
-    # Specify what type of elements we want in the f5
-    'outputElement': TACS.PLANE_STRESS_ELEMENT,
+    'printtiming':True
 }
 
 bdfFile = os.path.join(os.path.dirname(__file__), 'circ-plate-dirichlet-bcs.bdf')

--- a/src/elements/TACSElement.h
+++ b/src/elements/TACSElement.h
@@ -227,6 +227,15 @@ class TACSElement : public TACSObject {
   }
 
   /**
+    Get the output element type for visualization
+
+    @return The output element type for this element
+  */
+  virtual ElementType getElementType(){
+    return TACS_ELEMENT_NONE;
+  }
+
+  /**
     Get the number of design variables per node.
 
     The value defaults to one, unless over-ridden by the model

--- a/src/elements/TACSElement2D.cpp
+++ b/src/elements/TACSElement2D.cpp
@@ -47,6 +47,10 @@ ElementLayout TACSElement2D::getLayoutType(){
   return basis->getLayoutType();
 }
 
+ElementType TACSElement2D::getElementType(){
+  return TACS_PLANE_STRESS_ELEMENT;
+}
+
 TACSElementBasis* TACSElement2D::getElementBasis(){
   return basis;
 }

--- a/src/elements/TACSElement2D.h
+++ b/src/elements/TACSElement2D.h
@@ -31,6 +31,7 @@ class TACSElement2D : public TACSElement {
   int getNumNodes();
   int getDesignVarsPerNode();
   ElementLayout getLayoutType();
+  ElementType getElementType();
   TACSElementBasis* getElementBasis();
   TACSElementModel* getElementModel();
   TACSElement* createElementTraction( int faceIndex, TacsScalar t[] );

--- a/src/elements/TACSElement3D.cpp
+++ b/src/elements/TACSElement3D.cpp
@@ -67,6 +67,10 @@ ElementLayout TACSElement3D::getLayoutType(){
   return basis->getLayoutType();
 }
 
+ElementType TACSElement3D::getElementType(){
+  return TACS_SOLID_ELEMENT;
+}
+
 TACSElementBasis* TACSElement3D::getElementBasis(){
   return basis;
 }

--- a/src/elements/TACSElement3D.h
+++ b/src/elements/TACSElement3D.h
@@ -32,6 +32,7 @@ class TACSElement3D : public TACSElement {
   int getNumNodes();
   int getDesignVarsPerNode();
   ElementLayout getLayoutType();
+  ElementType getElementType();
   TACSElementBasis* getElementBasis();
   TACSElementModel* getElementModel();
   TACSElement* createElementTraction( int faceIndex, TacsScalar t[] );

--- a/src/elements/shell/TACSMassElement.cpp
+++ b/src/elements/shell/TACSMassElement.cpp
@@ -33,7 +33,7 @@ int TACSMassElement::getVarsPerNode() { return NUM_DISPS; }
 
 int TACSMassElement::getNumNodes() { return NUM_NODES; }
 
-enum ElementType TACSMassElement::getElementType(){ return TACS_MASS_ELEMENT; }
+ElementType TACSMassElement::getElementType(){ return TACS_MASS_ELEMENT; }
 
 /*
   The element name, variable, stress and strain names.

--- a/src/elements/shell/TACSMassElement.h
+++ b/src/elements/shell/TACSMassElement.h
@@ -15,7 +15,7 @@ class TACSMassElement : public TACSElement {
   const char * getObjectName();
   int getVarsPerNode();
   int getNumNodes();
-  enum ElementType getElementType();
+  ElementType getElementType();
   int getDesignVarsPerNode(){ return 0; }
   int getNumQuadraturePoints(){ return 1; }
   double getQuadratureWeight( int n ){ return 1.0; }

--- a/src/elements/shell/TACSMassInertialForce.h
+++ b/src/elements/shell/TACSMassInertialForce.h
@@ -15,7 +15,6 @@ class TACSMassInertialForce : public TACSElement {
   const char * getObjectName();
   int getVarsPerNode();
   int getNumNodes();
-  enum ElementType getElementType();
   int getDesignVarsPerNode(){ return 0; }
   int getNumQuadraturePoints(){ return 1; }
   double getQuadratureWeight( int n ){ return 1.0; }

--- a/src/elements/shell/TACSRBE2.cpp
+++ b/src/elements/shell/TACSRBE2.cpp
@@ -98,7 +98,7 @@ int TACSRBE2::getNumNodes() { return NUM_NODES; }
 
 int TACSRBE2::numExtras() { return NUM_EXTRAS; }
 
-enum ElementType TACSRBE2::getElementType(){ return TACS_RIGID_ELEMENT; }
+ElementType TACSRBE2::getElementType(){ return TACS_RIGID_ELEMENT; }
 
 /*
   Returns the multiplier index

--- a/src/elements/shell/TACSRBE2.h
+++ b/src/elements/shell/TACSRBE2.h
@@ -36,7 +36,7 @@ class TACSRBE2 : public TACSElement {
   int getVarsPerNode();
   int getNumNodes();
   int numExtras();
-  enum ElementType getElementType();
+  ElementType getElementType();
   int getDesignVarsPerNode(){ return 0; }
   int getNumQuadraturePoints(){ return 0; }
   double getQuadratureWeight( int n ){ return 0.0; }

--- a/src/elements/shell/TACSRBE3.cpp
+++ b/src/elements/shell/TACSRBE3.cpp
@@ -111,7 +111,7 @@ int TACSRBE3::getNumNodes() { return NUM_NODES; }
 
 int TACSRBE3::numExtras() { return NUM_EXTRAS; }
 
-enum ElementType TACSRBE3::getElementType(){ return TACS_RIGID_ELEMENT; }
+ElementType TACSRBE3::getElementType(){ return TACS_RIGID_ELEMENT; }
 
 /*
   Returns the multiplier index

--- a/src/elements/shell/TACSRBE3.h
+++ b/src/elements/shell/TACSRBE3.h
@@ -37,7 +37,7 @@ class TACSRBE3 : public TACSElement {
   int getVarsPerNode();
   int getNumNodes();
   int numExtras();
-  enum ElementType getElementType();
+  ElementType getElementType();
   int getDesignVarsPerNode(){ return 0; }
   int getNumQuadraturePoints(){ return 0; }
   double getQuadratureWeight( int n ){ return 0.0; }

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -58,6 +58,10 @@ class TACSShellElement : public TACSElement {
     return basis::getLayoutType();
   }
 
+  ElementType getElementType(){
+    return TACS_BEAM_OR_SHELL_ELEMENT;
+  }
+
   int getNumQuadraturePoints(){
     return quadrature::getNumQuadraturePoints();
   }

--- a/src/elements/shell/TACSShellPressure.h
+++ b/src/elements/shell/TACSShellPressure.h
@@ -33,10 +33,6 @@ class TACSShellPressure : public TACSElement {
     return basis::NUM_NODES;
   }
 
-  ElementLayout getLayoutType(){
-    return basis::getLayoutType();
-  }
-
   int getNumQuadraturePoints(){
     return quadrature::getNumQuadraturePoints();
   }

--- a/src/elements/shell/TACSShellTraction.h
+++ b/src/elements/shell/TACSShellTraction.h
@@ -36,10 +36,6 @@ class TACSShellTraction : public TACSElement {
     return basis::NUM_NODES;
   }
 
-  ElementLayout getLayoutType(){
-    return basis::getLayoutType();
-  }
-
   int getNumQuadraturePoints(){
     return quadrature::getNumQuadraturePoints();
   }

--- a/src/elements/shell/TACSSpringElement.cpp
+++ b/src/elements/shell/TACSSpringElement.cpp
@@ -45,7 +45,7 @@ int TACSSpringElement::getNumNodes(){
   return NUM_NODES;
 }
 
-enum ElementType TACSSpringElement::getElementType(){ return TACS_SPRING_ELEMENT; }
+ElementType TACSSpringElement::getElementType(){ return TACS_SPRING_ELEMENT; }
 
 double TACSSpringElement::getQuadraturePoint( int n, double pt[] ){
   pt[0] = pt[1] = pt[2] = 0.0;

--- a/src/elements/shell/TACSSpringElement.h
+++ b/src/elements/shell/TACSSpringElement.h
@@ -34,7 +34,7 @@ class TACSSpringElement : public TACSElement {
   const char * getObjectName();
   int getVarsPerNode();
   int getNumNodes();
-  enum ElementType getElementType();
+  ElementType getElementType();
   int getDesignVarsPerNode(){ return 0; }
   int getNumQuadraturePoints(){ return 2; }
   double getQuadratureWeight( int n ){ return 0.5; }

--- a/src/elements/shell/TACSThermalShellElement.h
+++ b/src/elements/shell/TACSThermalShellElement.h
@@ -58,6 +58,10 @@ class TACSThermalShellElement : public TACSElement {
     return basis::getLayoutType();
   }
 
+  ElementType getElementType(){
+    return TACS_BEAM_OR_SHELL_ELEMENT;
+  }
+
   int getNumQuadraturePoints(){
     return quadrature::getNumQuadraturePoints();
   }

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -370,6 +370,7 @@ cdef extern from "TACSElement.h":
         int getDesignVarRange(int, int, TacsScalar*, TacsScalar*)
         TACSElementBasis* getElementBasis()
         TACSElementModel* getElementModel()
+        ElementType getElementType()
         TACSElement* createElementTraction(int, TacsScalar*)
         TACSElement* createElementPressure(int, TacsScalar)
         TACSElement* createElementInertialForce(TacsScalar*)

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -308,6 +308,11 @@ cdef class Element:
             return _init_ElementBasis(self.ptr.getElementBasis())
         return None
 
+    def getElementType(self):
+        if self.ptr:
+            return self.ptr.getElementType()
+        return ELEMENT_NONE
+
     def createElementTraction(self, int faceIndex, np.ndarray[TacsScalar, ndim=1] trac):
         cdef TACSElement *tracElem = NULL
         if self.ptr:

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -53,7 +53,7 @@ class pyTACS(BaseUI):
 
         # Output Options
         'outputElement': [int, None, 'Specifies which element type should be written out in the f5 file.\n'
-                                     '\t If None, the type be inferred from the first element in the model.\n'
+                                     '\t If None, the type will be inferred from the first element in the model.\n'
                                      '\t Acceptable values are:\n'
                                      f'\t\t tacs.TACS.ELEMENT_NONE = {tacs.TACS.ELEMENT_NONE}\n'
                                      f'\t\t tacs.TACS.SCALAR_2D_ELEMENT = {tacs.TACS.SCALAR_2D_ELEMENT}\n'

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -53,7 +53,7 @@ class pyTACS(BaseUI):
 
         # Output Options
         'outputElement': [int, None, 'Specifies which element type should be written out in the f5 file.\n'
-                                     '\t If None, the type will try to be inferred from varsPerNode (not foolproof).\n'
+                                     '\t If None, the type be inferred from the first element in the model.\n'
                                      '\t Acceptable values are:\n'
                                      f'\t\t tacs.TACS.ELEMENT_NONE = {tacs.TACS.ELEMENT_NONE}\n'
                                      f'\t\t tacs.TACS.SCALAR_2D_ELEMENT = {tacs.TACS.SCALAR_2D_ELEMENT}\n'
@@ -1275,14 +1275,10 @@ class pyTACS(BaseUI):
         # Create actual viewer
         if self.getOption('outputElement') is not None:
             elementType = self.getOption('outputElement')
-        elif self.varsPerNode == 6 or self.varsPerNode == 7:
-            elementType = tacs.TACS.BEAM_OR_SHELL_ELEMENT
-        elif self.varsPerNode == 3:
-            elementType = tacs.TACS.SOLID_ELEMENT
         else:
-            self._TACSWarning("'outputElement' not specified in options. "
-                             "No elements will be written out in f5 file.")
-            elementType = tacs.TACS.ELEMENT_NONE
+            # Set the output type based on the first element in the model
+            elem = self.meshLoader.getElementObjectForElemID(0, nastranOrdering=False)
+            elementType = elem.getElementType()
 
         self.outputViewer = tacs.TACS.ToFH5(
             self.assembler, elementType, write_flag)


### PR DESCRIPTION
- Added virtual method to get element output types for each element class
- F5 output element type is now inferred from the first element type in the model, rather than based on `varsPerNode` (which was not unique)
- Users no longer have to specify element type in options, unless multiple element types are present in model