### PR TITLE
Modifying setup.py

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -62,7 +62,7 @@ jobs:
           echo "=============================================================";
           source $CONDA/etc/profile.d/conda.sh;
           echo $CONDA/bin >> $GITHUB_PATH;
-          conda create -n TACS python=3.8 numpy=1.18 scipy=1.4 -q -y;
+          conda create -n TACS python=3.8 -q -y;
           conda activate TACS;
           echo "=============================================================";
           echo "Install TACS";
@@ -77,15 +77,11 @@ jobs:
           conda install -c anaconda openblas -q -y;
           conda install -c conda-forge lapack -q -y;
           conda install -c conda-forge metis -q -y;
-          conda install -c conda-forge mpi4py  -q -y;
-          pip install cython;
-          pip install pynastran;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
-          export PYTHONPATH=$PYTHONPATH:$TACS_DIR;
           cd $TACS_DIR/examples;
           make ${{ matrix.EXAMPLES }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd $TACS_DIR;

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,20 @@ debug:
 	fi
 
 interface:
-	${PIP} install -e .
+	@if [ "${PIP}" = "" ]; then \
+		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
+		${PYTHON} setup.py build_ext --inplace; \
+	else \
+		${PIP} install -e .; \
+	fi
 
 complex_interface:
-	CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .
+	@if [ "${PIP}" = "" ]; then \
+		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
+		${PYTHON} setup.py build_ext --inplace --define TACS_USE_COMPLEX; \
+	else \
+		CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .; \
+	fi
 
 complex: TACS_IS_COMPLEX=true
 complex: default

--- a/Makefile
+++ b/Makefile
@@ -91,11 +91,6 @@ complex: default
 complex_debug: TACS_IS_COMPLEX=true
 complex_debug: debug
 
-install:
-	@echo "installing libtacs.so in $(DESTDIR)$(PREFIX)/lib/"; \
-	install -d $(DESTDIR)$(PREFIX)/lib/ ; \
-	install -m 644 ${TACS_DIR}/lib/libtacs.so $(DESTDIR)$(PREFIX)/lib/
-
 clean:
 	${RM} lib/libtacs.a lib/libtacs.so
 	${RM} tacs/*.so tacs/*.cpp

--- a/Makefile
+++ b/Makefile
@@ -81,6 +81,11 @@ complex: default
 complex_debug: TACS_IS_COMPLEX=true
 complex_debug: debug
 
+install:
+	@echo "installing libtacs.so in $(DESTDIR)$(PREFIX)/lib/"; \
+	install -d $(DESTDIR)$(PREFIX)/lib/ ; \
+	install -m 644 ${TACS_DIR}/lib/libtacs.so $(DESTDIR)$(PREFIX)/lib/
+
 clean:
 	${RM} lib/libtacs.a lib/libtacs.so
 	${RM} tacs/*.so tacs/*.cpp

--- a/Makefile
+++ b/Makefile
@@ -70,10 +70,10 @@ debug:
 	fi
 
 interface:
-	${PYTHON} setup.py build_ext --inplace
+	${PIP} install -e .
 
 complex_interface:
-	${PYTHON} setup.py build_ext --inplace --define TACS_USE_COMPLEX
+	CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .
 
 complex: TACS_IS_COMPLEX=true
 complex: default

--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ interface:
 		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
 		${PYTHON} setup.py build_ext --inplace; \
 	else \
-		${PIP} install -e .; \
+		${PIP} install -e . --use-feature=in-tree-build; \
 	fi
 
 complex_interface:
@@ -82,7 +82,7 @@ complex_interface:
 		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
 		${PYTHON} setup.py build_ext --inplace --define TACS_USE_COMPLEX; \
 	else \
-		CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .; \
+		CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e . --use-feature=in-tree-build; \
 	fi
 
 complex: TACS_IS_COMPLEX=true

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -6,8 +6,6 @@
 
 # the full path to the root TACS directory
 TACS_DIR = ${HOME}/git/tacs
-# libtacs.so install directory
-PREFIX = /usr/local
 CXX = mpicxx
 RM = rm -f
 PYTHON = python

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -9,7 +9,6 @@ TACS_DIR = ${HOME}/git/tacs
 CXX = mpicxx
 RM = rm -f
 PYTHON = python
-PYTHON_CONFIG = python-config
 PIP = pip
 
 # Set up for parallel make

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -12,6 +12,7 @@ CXX = mpicxx
 RM = rm -f
 PYTHON = python
 PYTHON_CONFIG = python-config
+PIP = pip
 
 # Set up for parallel make
 MAKE = make -j 8

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -6,6 +6,8 @@
 
 # the full path to the root TACS directory
 TACS_DIR = ${HOME}/git/tacs
+# libtacs.so install directory
+PREFIX = /usr/local
 CXX = mpicxx
 RM = rm -f
 PYTHON = python

--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ Note that the default values can often be used without modification. Of all thes
 
 The python interface can be created with a call to setup.py. The setup.cfg.info contains the recommended defaults for the configuration script. For development, create a local development installation by executing
 
-python setup.py develop --user
+pip install -e .
 
-You can subsequently execute the following command to update the python interface after changes.
+This command is also executed by the command `make interface`.
 
-python setup.py build_ext --inplace 
+If the user does not intend to modify the source code and wishes to install the interface to their python site-packages, they can instead run
 
-This command is also executed by the command make interface.
+pip install .
 
 ### Converting FH5 files ###
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -145,8 +145,8 @@ or alternatively, you can use the shortcut in the ``Makefile`` and type:
 
 .. note::
   If the user is using an older version of pip (<21.3) and runs into a missing ``libtacs.so`` error when importing
-  tacs in python, they may need to add the following to their pip install command `pip install -e . --use-feature=in-tree-build`.
-  This option is on by default in newer pip versions and should therefore not be necessary.
+  tacs in python, they may need to add the following to their pip install command ``pip install -e . --use-feature=in-tree-build``.
+  This option is on by default in newer pip versions and therefore should not be necessary.
 
 Once this process is complete the python interface install should be complete and tacs should be importable from python.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -135,19 +135,20 @@ or you can type the following command in the root directory:
 
 ::
 
-    python setup.py build_ext --inplace
+    pip install -e .
 
-The ``--inplace`` option places the shared objects direclty in the source directories.
-There are several options to make the python ``tacs`` package visible to python.
-I recommend using the user install option which places a link to the library in a local directory that python looks in.
-This can be performed by typing:
-
-::
-
-    python setup.py develop --user
-
-Once you have installed TACS in this way, you can use the shortcut in the ``Makefile`` and type:
+or alternatively, you can use the shortcut in the ``Makefile`` and type:
 
 ::
 
     make interface
+
+.. note::
+  If the user is using an older version of pip (<21.3) and runs into a missing ``libtacs.so`` error when importing
+  tacs in python, they may need to add the following to their pip install command `pip install -e . --use-feature=in-tree-build`.
+  This option is on by default in newer pip versions and should therefore not be necessary.
+
+Once this process is complete the python interface install should be complete and tacs should be importable from python.
+
+
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,4 @@
+#pyproject.toml
 [build-system]
-requires = ['cython', 'numpy', 'mpi4py']
+# Minimum requirements for the build system to execute.
+requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy', 'mpi4py']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py>=3.0.2']
+requires = ['setuptools>=45.0', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy', 'mpi4py']
+requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy>=1.16.4', 'mpi4py>=3.0.2']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ['cython', 'numpy', 'mpi4py']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy==1.18', 'mpi4py>=3.0.2']
+requires = ['setuptools>=45.0', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py>=3.0.2']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy>=1.16.4', 'mpi4py>=3.0.2']
+requires = ['setuptools>=45.0', 'cython>=0.29', 'numpy==1.18', 'mpi4py>=3.0.2']

--- a/setup.py
+++ b/setup.py
@@ -98,9 +98,10 @@ setup(name='tacs',
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
       install_requires=[
-          'numpy>=1.16.4',
+          # Make sure the user's mpi4py and numpy version are at least more current than the build versions
+          f'numpy>={numpy.__version__}',
+          f'mpi4py>={mpi4py.__version__}',
           'scipy>=1.2.1',
-          'mpi4py>=3.0.2',
           'pynastran>=1.3.3'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,22 @@ import mpi4py
 # Import distutils
 from setuptools import setup, find_packages
 from distutils.core import Extension as Ext
+from distutils.sysconfig import parse_makefile
 from Cython.Build import cythonize
 from Cython.Compiler import Options
 
 Options.docstrings = True
+
+# Load in contents of Makefile.in
+mf_file = './Makefile.in'
+if os.path.exists(mf_file):
+    makefile_in = parse_makefile(mf_file)
+else:
+    raise RuntimeError('No Makefile.in found in tacs root.\n'
+                       'Create the Makefile.in by running the following command from tacs root directory:'
+                       '$ cp ./Makefile.in.info ./Makefile.in\n')
+
+tacs_root = makefile_in['TACS_DIR']
 
 # Convert from local to absolute directories
 def get_global_dir(files):
@@ -93,6 +105,7 @@ setup(name='tacs',
       ],
       extras_require={
         'testing': ['testflo'],
+        'docs': ['sphinx', 'breathe', 'sphinxcontrib-programoutput'],
         'mphys': ['mphys', 'openmdao'],
       },
       packages=find_packages(include=['tacs*']),

--- a/setup.py
+++ b/setup.py
@@ -9,22 +9,10 @@ import mpi4py
 # Import distutils
 from setuptools import setup, find_packages
 from distutils.core import Extension as Ext
-from distutils.sysconfig import parse_makefile
 from Cython.Build import cythonize
 from Cython.Compiler import Options
 
 Options.docstrings = True
-
-# Load in contents of Makefile.in
-mf_file = './Makefile.in'
-if os.path.exists(mf_file):
-    makefile_in = parse_makefile(mf_file)
-else:
-    raise RuntimeError('No Makefile.in found in tacs root.\n'
-                       'Create the Makefile.in by running the following command from tacs root directory:'
-                       '$ cp ./Makefile.in.info ./Makefile.in\n')
-
-tacs_root = makefile_in['TACS_DIR']
 
 # Convert from local to absolute directories
 def get_global_dir(files):
@@ -87,14 +75,14 @@ for e in exts:
                            'binding': True}
 
 tacs_root = os.path.abspath(os.path.dirname(__file__))
-with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
+with open(os.path.join(tacs_root, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 setup(name='tacs',
       version=0.1,
       description='Parallel finite-element analysis package',
       long_description=long_description,
-      long_description_content_type="text/markdown",
+      long_description_content_type='text/markdown',
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
       install_requires=[

--- a/setup.py
+++ b/setup.py
@@ -90,7 +90,10 @@ setup(name='tacs',
           f'numpy>={numpy.__version__}',
           'mpi4py>=3.0.2',
           'scipy>=1.2.1',
-          'pynastran>=1.3.3'
+          'pynastran>=1.3.3',
+          # This package isn't actually a requirement of tacs, but of pynastran
+          # Right now 2.0.0 breaks pynastran and the pip package hasn't been updated to fix this
+          'nptyping<2.0.0',
       ],
       extras_require={
         'testing': ['testflo'],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import numpy
 import mpi4py
 
 # Import distutils
-from setuptools import setup
+from setuptools import setup, find_packages
 from distutils.core import Extension as Ext
 from Cython.Build import cythonize
 from Cython.Compiler import Options
@@ -74,9 +74,15 @@ for e in exts:
     e.cython_directives = {'embedsignature': True,
                            'binding': True}
 
+tacs_root = os.path.abspath(os.path.dirname(__file__))
+with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
+    long_description = f.read()
+
 setup(name='tacs',
       version=0.1,
       description='Parallel finite-element analysis package',
+      long_description=long_description,
+      long_description_content_type="text/markdown",
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
       install_requires=[
@@ -85,4 +91,9 @@ setup(name='tacs',
           'mpi4py>=3.0.2',
           'pynastran>=1.3.3'
       ],
+      extras_require={
+        'testing': ['testflo'],
+        'mphys': ['mphys', 'openmdao'],
+      },
+      packages=find_packages(include=['tacs*']),
       ext_modules=cythonize(exts, include_path=inc_dirs))

--- a/setup.py
+++ b/setup.py
@@ -86,9 +86,9 @@ setup(name='tacs',
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
       install_requires=[
-          # Make sure the user's mpi4py and numpy version are at least more current than the build versions
+          # Make sure the user's numpy version are at least more current than the build versions
           f'numpy>={numpy.__version__}',
-          f'mpi4py>={mpi4py.__version__}',
+          'mpi4py>=3.0.2',
           'scipy>=1.2.1',
           'pynastran>=1.3.3'
       ],


### PR DESCRIPTION
- Updating setup.py to support traditional pip install procedure
- python interface can now be installed in place using (developer): `pip install -e .`
- python interface can now to site packages (user): `pip install .`
- Addresses #89 
- Adding temporary fix for broken pynastran dependency: nptyping (SteveDoyle2/pyNastran#691)