### PR TITLE
Fix for failing integration test

### DIFF
--- a/tests/integration_tests/static_analysis_base_test.py
+++ b/tests/integration_tests/static_analysis_base_test.py
@@ -85,7 +85,10 @@ class StaticTestCase:
             # Create GMRES solver object
             subspace = 100
             restarts = 2
+            atol = 1e-30
+            rtol = 1e-12
             self.gmres = TACS.KSM(self.mat, self.pc, subspace, restarts)
+            self.gmres.setTolerances(rtol, atol)
 
             # Create the function list
             self.func_list, self.func_ref = self.setup_funcs(self.assembler)


### PR DESCRIPTION
- Some of the integration tests are using a relative tolerance of 1e-8 for the cs sensitivities, which is the same as the default KSM linear solver accuracy
- Decreasing the KSM tolerance to 1e-12, so sensitivities will be more accurate and CI will pass 