### PR TITLE
Removing mphys github repo from setup.py dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -81,7 +81,7 @@ with open(os.path.join(tacs_root, 'README.md'), encoding='utf-8') as f:
 optional_dependencies = {
     'testing': ['testflo'],
     'docs': ['sphinx', 'breathe', 'sphinxcontrib-programoutput'],
-    'mphys': ['mphys @ git+https://github.com/OpenMDAO/mphys.git', 'openmdao'],
+    'mphys': ['mphys>=0.4.0', 'openmdao'],
 }
 
 # Add an optional dependency that concatenates all others


### PR DESCRIPTION
- mphys dependency was previously linked directly to github repo a ("mphys @ git+https://github.com/OpenMDAO/mphys.git"), we can now remove this since a [pypi package](https://pypi.org/project/mphys/) exists for the library
- Removing this will also fix an issue where mphys was always forcibly reinstalled with tacs, even if an existing install for mphys was already present