### PR TITLE
removing pip in-tree-build flag from makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ interface:
 		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
 		${PYTHON} setup.py build_ext --inplace; \
 	else \
-		${PIP} install -e .\[all\] --use-feature=in-tree-build; \
+		${PIP} install -e .\[all\]; \
 	fi
 
 complex_interface:
@@ -82,7 +82,7 @@ complex_interface:
 		echo "DeprecationWarning: PIP environment variable not set in Makefile.in. See Makefile.in.info for how to set this. Using setup.py install for now."; \
 		${PYTHON} setup.py build_ext --inplace --define TACS_USE_COMPLEX; \
 	else \
-		CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .\[all\] --use-feature=in-tree-build; \
+		CFLAGS=-DTACS_USE_COMPLEX ${PIP} install -e .\[all\]; \
 	fi
 
 complex: TACS_IS_COMPLEX=true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py']
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py']


### PR DESCRIPTION
- This option has officially been deprecated in the newest version of pip and has been a default in recent versions anyways