### PR TITLE
Making minimum required mpi4py 3.1.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py']
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py==3.1.0']

--- a/setup.py
+++ b/setup.py
@@ -97,9 +97,8 @@ setup(name='tacs',
       author='Graeme J. Kennedy',
       author_email='graeme.kennedy@ae.gatech.edu',
       install_requires=[
-          # Make sure the user's numpy version are at least more current than the build versions
-          f'numpy>={numpy.__version__}',
-          'mpi4py>=3.0.2',
+          'numpy',
+          'mpi4py>=3.1.0',
           'scipy>=1.2.1',
           'pynastran>=1.3.3'
       ],

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ with open(os.path.join(tacs_root, 'README.md'), encoding='utf-8') as f:
     long_description = f.read()
 
 optional_dependencies = {
-    'testing': ['testflo'],
+    'testing': ['testflo>=1.4.7'],
     'docs': ['sphinx', 'breathe', 'sphinxcontrib-programoutput'],
     'mphys': ['mphys>=0.4.0', 'openmdao'],
 }


### PR DESCRIPTION
- Also adding minimum version for optional dependency testflo