### PR TITLE
Moving lopen-pal flag to makefile.in with the rest of TECIO vars

### DIFF
--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -64,3 +64,5 @@ METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 
 # TECIO_INCLUDE = -I${TACS_DIR}/extern/tecio/teciosrc
 # TECIO_LIB = ${TACS_DIR}/extern/tecio/teciosrc/libtecio.a
+# This may be need to be added for OpenMPI implementations
+# TECIO_LIB = ${TECIO_LIB} -lopen-pal

--- a/extern/f5totec/Makefile
+++ b/extern/f5totec/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.in
 include ../../TACS_Common.mk
 
 default: TACS_CC_FLAGS=${TACS_OPT_CC_FLAGS} ${TECIO_INCLUDE}
-default: LD_FLAGS=${TACS_LD_FLAGS} -lopen-pal
+default: LD_FLAGS=${TACS_LD_FLAGS}
 default: f5totec
 
 f5totec: f5totec.o

--- a/extern/f5tovtk/Makefile
+++ b/extern/f5tovtk/Makefile
@@ -2,7 +2,7 @@ include ../../Makefile.in
 include ../../TACS_Common.mk
 
 default: TACS_CC_FLAGS=${TACS_DEBUG_CC_FLAGS}
-default: LD_FLAGS=${TACS_LD_FLAGS} -lopen-pal
+default: LD_FLAGS=${TACS_LD_FLAGS}
 default: f5tovtk f5tovtk_element
 
 f5tovtk: f5tovtk.o


### PR DESCRIPTION
-lopen-pal seems to be an OpenMPI specific library (doesn't work for MPICH), so I'm moving this flag from the makefile into the Makefile.in.info