### PR TITLE
Adding transient problem types to BDF parser

### DIFF
--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -865,7 +865,7 @@ class TACSProblem(BaseUI):
         This is an internal helper function for doing the addLoadFromBDF method for
         inherited TACSProblem classes. The function should NOT be called by the user should
         use the addLoadFromBDF method for the respective problem class. This method is 
-        used to add a load set defined in the BDF file to the problem.
+        used to add a fixed load set defined in the BDF file to the problem.
 
         Parameters
         ----------

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -860,7 +860,7 @@ class TACSProblem(BaseUI):
                 # Add new centrifugal force to auxiliary element object
                 auxElems.addElement(elemID, centrifugalObj)
 
-    def _addLoadFromBDF(self, FVec, auxElems, loadsID, setScale=1.0):
+    def _addLoadFromBDF(self, FVec, auxElems, loadID, setScale=1.0):
         """
         This is an internal helper function for doing the addLoadFromBDF method for
         inherited TACSProblem classes. The function should NOT be called by the user should
@@ -879,12 +879,12 @@ class TACSProblem(BaseUI):
         loadID : int
             Load identification number of load set in BDF file user wishes to add to problem.
 
-        scale : float
+        setScale : float
             Factor to scale the BDF loads by before adding to problem.
         """
         vpn = self.assembler.getVarsPerNode()
         # Get loads and scalers for this load case ID
-        loadSet, loadScale, _ = self.bdfInfo.get_reduced_loads(loadsID)
+        loadSet, loadScale, _ = self.bdfInfo.get_reduced_loads(loadID)
         # Loop through every load in set and add it to problem
         for loadInfo, scale in zip(loadSet, loadScale):
             scale *= setScale

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -26,7 +26,8 @@ class TACSProblem(BaseUI):
         # TACS pyMeshLoader object
         self.meshLoader = meshLoader
         # pyNastran BDF object
-        self.bdfInfo = self.meshLoader.getBDFInfo()
+        if self.meshLoader:
+            self.bdfInfo = self.meshLoader.getBDFInfo()
         # MPI communicator object
         self.comm = comm
 
@@ -866,6 +867,7 @@ class TACSProblem(BaseUI):
         inherited TACSProblem classes. The function should NOT be called by the user should
         use the addLoadFromBDF method for the respective problem class. This method is 
         used to add a fixed load set defined in the BDF file to the problem.
+        Currently, only supports LOAD, FORCE, MOMENT, GRAV, RFORCE, PLOAD2, and PLOAD4.
 
         Parameters
         ----------

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -510,7 +510,7 @@ class StaticProblem(TACSProblem):
 
     def addLoadFromBDF(self, loadID, scale=1.0):
         """
-        This method is used to add a load set defined in the BDF file to the problem.
+        This method is used to add a fixed load set defined in the BDF file to the problem.
 
         Parameters
         ----------

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -511,6 +511,7 @@ class StaticProblem(TACSProblem):
     def addLoadFromBDF(self, loadID, scale=1.0):
         """
         This method is used to add a fixed load set defined in the BDF file to the problem.
+        Currently, only supports LOAD, FORCE, MOMENT, GRAV, RFORCE, PLOAD2, and PLOAD4.
 
         Parameters
         ----------

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -268,7 +268,8 @@ class StaticProblem(TACSProblem):
         This method is used to add a *FIXED TOTAL LOAD* on one or more
         components, defined by COMPIDs. The purpose of this routine is to add loads that
         remain fixed throughout an optimization. An example would be an engine load.
-        This routine determines all the unique nodes in the FE model that are part of the         requested components, then takes the total 'force' by F and divides by the
+        This routine determines all the unique nodes in the FE model that are part of the
+        requested components, then takes the total 'force' by F and divides by the
         number of nodes. This average load is then applied to the nodes.
 
         Parameters
@@ -506,6 +507,21 @@ class StaticProblem(TACSProblem):
             Location of center of rotation used to define centrifugal load.
         """
         self._addCentrifugalLoad(self.auxElems, omegaVector, rotCenter)
+
+    def addLoadFromBDF(self, loadID, scale=1.0):
+        """
+        This method is used to add a load set defined in the BDF file to the problem.
+
+        Parameters
+        ----------
+
+        loadID : int
+            Load identification number of load set in BDF file user wishes to add to problem.
+
+        scale : float
+            Factor to scale the BDF loads by before adding to problem.
+        """
+        self._addLoadFromBDF(self.F, self.auxElems, loadID, scale)
 
     ####### Static solver methods ########
 

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -650,7 +650,8 @@ class TransientProblem(TACSProblem):
     def addLoadFromBDF(self, timeStep, loadID, timeStage=None, scale=1.0):
         """
         This method is used to add a fixed load set defined in the BDF file to the problem
-        at a specified time instance.
+        at a specified time instance. Currently, only supports LOAD, FORCE, MOMENT, GRAV,
+        RFORCE, PLOAD2, and PLOAD4.
 
         Parameters
         ----------

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -649,7 +649,7 @@ class TransientProblem(TACSProblem):
 
     def addLoadFromBDF(self, timeStep, loadID, timeStage=None, scale=1.0):
         """
-        This method is used to add a load set defined in the BDF file to the problem
+        This method is used to add a fixed load set defined in the BDF file to the problem
         at a specified time instance.
 
         Parameters

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -647,6 +647,38 @@ class TransientProblem(TACSProblem):
 
         self._addCentrifugalLoad(self.auxElems[timeIndex], omegaVector, rotCenter)
 
+    def addLoadFromBDF(self, timeStep, loadID, timeStage=None, scale=1.0):
+        """
+        This method is used to add a load set defined in the BDF file to the problem
+        at a specified time instance.
+
+        Parameters
+        ----------
+
+        timeStep : int
+            Time step index to apply load to.
+
+        loadID : int
+            Load identification number of load set in BDF file user wishes to add to problem.
+
+        timeStage : int or None
+            Time stage index to apply load to. Default is None, which is applicable only for
+            multi-step methods like BDF. For multi-stage methods like DIRK, this index must
+            be specified.
+
+        scale : float
+            Factor to scale the BDF loads by before adding to problem.
+        """
+        timeIndex = 0
+        if self.numStages is None:
+            timeIndex = timeStep
+        else:
+            assert timeStage is not None, "Time stage index must be specified for %s integrator type" % self.getOption(
+                'timeIntegrator').upper()
+            timeIndex = timeStep * self.numStages + timeStage
+
+        self._addLoadFromBDF(self.F[timeIndex], self.auxElems[timeIndex], loadID, scale)
+
     ####### Transient solver methods ########
 
     def setInitConditions(self, vars=None, dvars=None, ddvars=None):

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1155,6 +1155,7 @@ class pyTACS(BaseUI):
                     continue
                 problem = self.createTransientProblem(name, tInit=0.0, tFinal=dt*nSteps, numSteps=nSteps)
 
+                # Find dynamic load specified for this subcase
                 if 'DLOAD' in subCase:
                     dloadsID = subCase['DLOAD'][0]
                     dloadSet, dloadScale = self.bdfInfo.get_reduced_dloads(dloadsID)
@@ -1177,157 +1178,21 @@ class pyTACS(BaseUI):
                             continue
                         # Loop through each time step and add loads to problem
                         for timeIndex, scale in enumerate(loadScales):
-                            self._addLoadSetToProblem(problem, loadsID, scale, timeIndex)
+                            problem.addLoadFromBDF(timeIndex, loadsID, scale=scale)
 
             else:
                 problem = self.createStaticProblem(name)
 
+                # Find the static load specified for this test case
                 if 'LOAD' in subCase:
                     # Add loads to problem
                     loadsID = subCase['LOAD'][0]
-                    self._addLoadSetToProblem(problem, loadsID)
+                    problem.addLoadFromBDF(loadsID)
 
             # append to list of structural problems
             structProblems[subCase.id] = problem
 
         return structProblems
-
-    def _addLoadSetToProblem(self, problem, loadsID, setScale=1.0, timeStep=None):
-        """
-        Add all loads associated with a load set ID from the BDF to a
-        StaticProblem or TransientProblem class.
-        Should only be called by createTACSProbsFromBDF and not directly by user.
-        """
-        vpn = self.varsPerNode
-        # Get loads and scalers for this load case ID
-        loadSet, loadScale, _ = self.bdfInfo.get_reduced_loads(loadsID)
-        # Loop through every load in set and add it to problem
-        for loadInfo, scale in zip(loadSet, loadScale):
-            scale *= setScale
-            # Add any point force or moment cards
-            if loadInfo.type == 'FORCE' or loadInfo.type == 'MOMENT':
-                nodeID = loadInfo.node_ref.nid
-
-                loadArray = numpy.zeros(vpn)
-                if loadInfo.type == 'FORCE' and vpn >= 3:
-                    F = scale * loadInfo.scaled_vector
-                    loadArray[:3] += loadInfo.cid_ref.transform_vector_to_global(F)
-                elif loadInfo.type == 'MOMENT' and vpn >= 6:
-                    M = scale * loadInfo.scaled_vector
-                    loadArray[3:6] += loadInfo.cid_ref.transform_vector_to_global(M)
-                if isinstance(problem, tacs.problems.StaticProblem):
-                    problem.addLoadToNodes(nodeID, loadArray, nastranOrdering=True)
-                elif isinstance(problem, tacs.problems.TransientProblem):
-                    problem.addLoadToNodes(timeStep, nodeID, loadArray, nastranOrdering=True)
-
-            # Add any gravity loads
-            elif loadInfo.type == 'GRAV':
-                inertiaVec = np.zeros(3, dtype=self.dtype)
-                inertiaVec[:3] = scale * loadInfo.scale * loadInfo.N
-                # Convert acceleration to global coordinate system
-                inertiaVec = loadInfo.cid_ref.transform_vector_to_global(inertiaVec)
-                problem.addInertialLoad(inertiaVec)
-
-            # Add any centrifugal loads
-            elif loadInfo.type == 'RFORCE':
-                omegaVec = np.zeros(3, dtype=self.dtype)
-                if loadInfo.nid_ref:
-                    rotCenter = loadInfo.nid_ref.get_position()
-                else:
-                    rotCenter = np.zeros(3, dtype=self.dtype)
-                omegaVec[:3] = scale * loadInfo.scale * np.array(loadInfo.r123)
-                # Convert omega from rev/s to rad/s
-                omegaVec *= 2 * np.pi
-                # Convert omega to global coordinate system
-                omegaVec = loadInfo.cid_ref.transform_vector_to_global(omegaVec)
-                if isinstance(problem, tacs.problems.StaticProblem):
-                    problem.addCentrifugalLoad(omegaVec, rotCenter)
-                elif isinstance(problem, tacs.problems.TransientProblem):
-                    problem.addCentrifugalLoad(timeStep, omegaVec, rotCenter)
-            # Add any pressure loads
-            # Pressure load card specific to shell elements
-            elif loadInfo.type == 'PLOAD2':
-                elemIDs = loadInfo.eids
-                pressure = scale * loadInfo.pressure
-                if isinstance(problem, tacs.problems.StaticProblem):
-                    problem.addPressureToElements(elemIDs, pressure, nastranOrdering=True)
-                elif isinstance(problem, tacs.problems.TransientProblem):
-                    problem.addPressureToElements(timeStep, elemIDs, pressure, nastranOrdering=True)
-
-            # Alternate more general pressure load type
-            elif loadInfo.type == 'PLOAD4':
-                self._addPressureFromPLOAD4(problem, loadInfo, scale, timeStep)
-
-            else:
-                self._TACSWarning("Unsupported load type "
-                                  f" '{loadInfo.type}' specified for load set number {loadInfo.sid}, skipping load")
-
-    def _addPressureFromPLOAD4(self, problem, loadInfo, scale=1.0, timeStep=None):
-        """
-        Add pressure to tacs static/transient problem from pynastran PLOAD4 card.
-        Should only be called by createTACSProbsFromBDF and not directly by user.
-        """
-        # Dictionary mapping nastran element face indices to TACS equivilent numbering
-        nastranToTACSFaceIDDict = {'CTETRA4': {1: 1, 2: 3, 3: 2, 4: 0},
-                                   'CTETRA': {2: 1, 4: 3, 3: 2, 1: 0},
-                                   'CHEXA': {1: 4, 2: 2, 3: 0, 4: 3, 5: 0, 6: 5}}
-
-        # We don't support pressure variation across elements, for now just average it
-        pressure = scale * np.mean(loadInfo.pressures)
-        for elemInfo in loadInfo.eids_ref:
-            elemID = elemInfo.eid
-
-            # Get the correct face index number based on element type
-            if 'CTETRA' in elemInfo.type:
-                for faceIndex in elemInfo.faces:
-                    if loadInfo.g1 in elemInfo.faces[faceIndex] and \
-                            loadInfo.g34 not in elemInfo.faces[faceIndex]:
-                        # For some reason CTETRA4 is the only element that doesn't
-                        # use ANSYS face numbering convention by default
-                        if len(elemInfo.nodes) == 4:
-                            faceIndex = nastranToTACSFaceIDDict['CTETRA4'][faceIndex]
-                        else:
-                            faceIndex = nastranToTACSFaceIDDict['CTETRA'][faceIndex]
-                        # Positive pressure is inward for solid elements, flip pressure if necessary
-                        # We don't flip it for face 0, because the normal for that face points inward by convention
-                        # while the rest point outward
-                        if faceIndex != 0:
-                            pressure *= -1.0
-                        break
-
-            elif 'CHEXA' in elemInfo.type:
-                for faceIndex in elemInfo.faces:
-                    if loadInfo.g1 in elemInfo.faces[faceIndex] and \
-                            loadInfo.g34 in elemInfo.faces[faceIndex]:
-                        faceIndex = nastranToTACSFaceIDDict['CHEXA'][faceIndex]
-                        # Pressure orientation is flipped for solid elements per Nastran convention
-                        pressure *= -1.0
-                        break
-
-            elif 'CQUAD' in elemInfo.type or 'CTRIA' in elemInfo.type:
-                # Face index doesn't matter for shells, just use 0
-                faceIndex = 0
-
-            else:
-                raise self._TACSError("Unsupported element type "
-                                      f"'{elemInfo.type}' specified for PLOAD4 load set number {loadInfo.sid}.")
-
-            # Figure out whether or not this is a traction based on if a vector is defined
-            if np.linalg.norm(loadInfo.nvector) == 0.0:
-                if isinstance(problem, tacs.problems.StaticProblem):
-                    problem.addPressureToElements(elemID, pressure, faceIndex,
-                                                  nastranOrdering=True)
-                elif isinstance(problem, tacs.problems.TransientProblem):
-                    problem.addPressureToElements(timeStep, elemID, pressure, faceIndex,
-                                                  nastranOrdering=True)
-            else:
-                trac = pressure * loadInfo.nvector
-                if isinstance(problem, tacs.problems.StaticProblem):
-                    problem.addTractionToElements(elemID, trac, faceIndex,
-                                                  nastranOrdering=True)
-                elif isinstance(problem, tacs.problems.TransientProblem):
-                    problem.addTractionToElements(timeStep, elemID, trac, faceIndex,
-                                                  nastranOrdering=True)
 
     def getNumComponents(self):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1247,7 +1247,6 @@ class pyTACS(BaseUI):
             elif loadInfo.type == 'PLOAD2':
                 elemIDs = loadInfo.eids
                 pressure = scale * loadInfo.pressure
-                problem.addPressureToElements(elemIDs, pressure, nastranOrdering=True)
                 if isinstance(problem, tacs.problems.StaticProblem):
                     problem.addPressureToElements(elemIDs, pressure, nastranOrdering=True)
                 elif isinstance(problem, tacs.problems.TransientProblem):
@@ -1263,7 +1262,7 @@ class pyTACS(BaseUI):
 
     def _addPressureFromPLOAD4(self, problem, loadInfo, scale=1.0, timeStep=None):
         """
-        Add pressure to tacs static problem from pynastran PLOAD4 card.
+        Add pressure to tacs static/transient problem from pynastran PLOAD4 card.
         Should only be called by createTACSProbsFromBDF and not directly by user.
         """
         # Dictionary mapping nastran element face indices to TACS equivilent numbering

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1150,6 +1150,8 @@ class pyTACS(BaseUI):
                     dt = tStep.DT[0]
                 # If no time step info was included, we'll skip this case
                 else:
+                    self._TACSWarning(f"No TSTEP entry found in control deck for subcase number {subCase.id}, "
+                                      "skipping case.")
                     continue
                 problem = self.createTransientProblem(name, tInit=0.0, tFinal=dt*nSteps, numSteps=nSteps)
 
@@ -1162,7 +1164,7 @@ class pyTACS(BaseUI):
                             if dloadInfo.type == 'TLOAD1':
                                 loadScales = dloadInfo.get_load_at_time(timeSteps, dscale)
                             elif dloadInfo.type == 'TLOAD2':
-                                loadScales = tload2_get_load_at_time(dloadInfo, timeSteps, dscale)
+                                loadScales = _tload2_get_load_at_time(dloadInfo, timeSteps, dscale)
                             if dloadInfo.Type != "LOAD":
                                 self._TACSWarning("Only 'LOAD' types are supported for "
                                                   f"'{dloadInfo.type}' card, but '{dloadInfo.type}' {dloadInfo.sid}, "
@@ -1596,7 +1598,7 @@ class pyTACS(BaseUI):
                                 "Assembler must created first by running 'initalize' method.")
         return error
 
-def tload2_get_load_at_time(tload2, time, scale=1.):
+def _tload2_get_load_at_time(tload2, time, scale=1.):
     """
     This is a function for interpolating the time series for the NASTRAN TLOAD2 card.
     Usually, this would be done through pyNastran, but there's bug in its implementation

--- a/tests/integration_tests/input_files/transient_beam.bdf
+++ b/tests/integration_tests/input_files/transient_beam.bdf
@@ -1,0 +1,68 @@
+INIT MASTER(S)
+NASTRAN SYSTEM(442)=-1,SYSTEM(319)=1
+ID FEMAP,FEMAP
+SOL SEDTRAN
+CEND
+  TITLE = Beam Test
+  ECHO = NONE
+  DISPLACEMENT(PLOT) = ALL
+  SPCFORCE(PLOT) = ALL
+  OLOAD(PLOT) = ALL
+  FORCE(PLOT,CORNER) = ALL
+  STRESS(PLOT,CORNER) = ALL
+  TSTEP = 1
+  SPC = 1
+SUBCASE 1
+  SUBTITLE = ramp
+  DLOAD = 1
+SUBCASE 2
+  SUBTITLE = sinusoid
+  DLOAD = 2
+BEGIN BULK
+$ ***************************************************************************
+$   Written by : Femap
+$   Version    : 2021.1.0
+$   Translator : Simcenter Nastran
+$   From Model : 
+$   Date       : Wed Apr 20 10:23:42 2022
+$   Output To  : C:\Users\trbrooks\AppData\Local\Temp\3\
+$ ***************************************************************************
+$
+PARAM,PRGPST,YES
+PARAM,POST,-1
+PARAM,OGEOM,NO
+PARAM,AUTOSPC,YES
+PARAM,K6ROT,100.
+PARAM,GRDPNT,0
+CORD2C         1       0      0.      0.      0.      0.      0.      1.+FEMAPC1
++FEMAPC1      1.      0.      1.        
+CORD2S         2       0      0.      0.      0.      0.      0.      1.+FEMAPC2
++FEMAPC2      1.      0.      1.        
+$ Femap Load Set 1 : Tip Load
+FORCE          1      6       0      1.      0.     10.      0.
+$ Femap Constraint Set 1 : Case 1
+SPC1           1  123456       1
+$ Femap Property 1 : Beam
+PBAR           1       1      .1      .2      .3      .4      0.        +
++             0.      0.      0.      0.      0.      0.      0.      0.+
++                             .1
+$ Femap Material 1 : Aluminum
+MAT1           1   7.0e3              .3     27.      0.      0.        +
++          0.027
+GRID           1       0      0.      0.      0.       0
+GRID           2       0      .2      0.      0.       0
+GRID           3       0      .4      0.      0.       0
+GRID           4       0      .6      0.      0.       0
+GRID           5       0      .8      0.      0.       0
+GRID           6       0      1.      0.      0.       0
+CBAR           1       1       1       2      0.      1.      0.
+CBAR           2       1       2       3      0.      1.      0.
+CBAR           3       1       3       4      0.      1.      0.
+CBAR           4       1       4       5      0.      1.      0.
+CBAR           5       1       5       6      0.      1.      0.
+TABLED1        1
+             0.0     0.0     1.0     0.5    ENDT
+TLOAD1         1       1     1.0               1
+TLOAD2         2       1     1.0             0.0     1.0
+TSTEP          1      20      .1
+ENDDATA e0194509

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -116,7 +116,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         tacs_probs = tacs_probs.values()
         # Set convergence to be tight for test
         for problem in tacs_probs:
-            problem.setOption('L2Convergence', 1e-20)
-            problem.setOption('L2ConvergenceRel', 1e-20)
+            problem.setOption('L2Convergence', 1e-15)
+            problem.setOption('L2ConvergenceRel', 1e-15)
 
         return tacs_probs

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -1,0 +1,120 @@
+import os
+import numpy as np
+from tacs import pytacs, constitutive, elements, functions
+from pytacs_analysis_base_test import PyTACSTestCase
+
+'''
+6 noded beam model 1 meter long in x direction with a two transient tip load cases:
+    1. linear ramp
+    2. sinusoidal
+The transient loads are read in from the BDF using the createTACSProbsFromBDF method. 
+We apply apply various tip loads test KSDisplacement and Compliance functions and sensitivities.
+'''
+
+base_dir = os.path.dirname(os.path.abspath(__file__))
+bdf_file = os.path.join(base_dir, "./input_files/transient_beam.bdf")
+
+FUNC_REFS = {'ramp_compliance': 10.507315462331803,
+             'ramp_x_disp': 0.06931471805599457,
+             'ramp_y_disp': 12.186052999423167,
+             'ramp_z_disp': 0.06931471805599457,
+
+             'sinusoid_compliance': 22.093569888841497,
+             'sinusoid_x_disp': 0.06931471805599457,
+             'sinusoid_y_disp': 25.654265895487846,
+             'sinusoid_z_disp': 0.06931471805599457}
+
+ksweight = 10.0
+
+class ProblemTest(PyTACSTestCase.PyTACSTest):
+    N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
+    def setup_pytacs(self, comm, dtype):
+        """
+        Setup mesh and pytacs object for problem we will be testing.
+        """
+
+        # Overwrite default check values
+        if dtype == complex:
+            self.rtol = 1e-6
+            self.atol = 1e-6
+            self.dh = 1e-50
+        else:
+            self.rtol = 2e-3
+            self.atol = 1e-3
+            self.dh = 1e-6
+
+        # Instantiate FEA Assembler
+        struct_options = {}
+
+        fea_assembler = pytacs.pyTACS(bdf_file, comm, options=struct_options)
+
+        # Material properties
+        rho = 27.0  # density kg/m^3
+        E = 70.0e2  # Young's modulus (Pa)
+        nu = 0.3  # Poisson's ratio
+        ys = 2.7e-2  # yield stress
+
+        # Beam dimensions
+        t = 0.2     # m
+        w = 0.5  # m
+
+        # Callback function used to setup TACS element objects and DVs
+        def elem_call_back(dv_num, comp_id, comp_descript, elem_descripts, global_dvs, **kwargs):
+            # Setup (isotropic) property and constitutive objects
+            prop = constitutive.MaterialProperties(rho=rho, E=E, nu=nu, ys=ys)
+            con = constitutive.IsoRectangleBeamConstitutive(prop, t=t, tNum=dv_num, w=w, wNum=dv_num+1)
+            refAxis = np.array([0.0, 1.0, 0.0])
+            transform = elements.BeamRefAxisTransform(refAxis)
+            # pass back the appropriate tacs element object
+            elem = elements.Beam2(transform, con)
+            return elem
+
+        # Instantiate FEA Assembler
+        struct_options = {}
+
+        fea_assembler = pytacs.pyTACS(bdf_file, comm, options=struct_options)
+
+        # Set up constitutive objects and elements
+        fea_assembler.initialize(elem_call_back)
+
+        return fea_assembler
+
+    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
+        """
+        Setup user-defined vectors for analysis and fd/cs sensitivity verification
+        """
+        # Create temporary dv vec for doing fd/cs
+        dv_pert_vec[:] = 1.0
+
+        # Define perturbation array that moves all nodes on shell
+        xpts = fea_assembler.getOrigNodes()
+        xpts_pert_vec[:] = xpts
+
+        return
+
+    def setup_funcs(self, fea_assembler, problems):
+        """
+        Create a list of functions to be tested and their reference values for the problem
+        """
+        # Add Functions
+        for problem in problems:
+            problem.addFunction('compliance', functions.Compliance)
+            problem.addFunction('x_disp', functions.KSDisplacement,
+                                ksWeight=ksweight, direction=[10.0, 0.0, 0.0])
+            problem.addFunction('y_disp', functions.KSDisplacement,
+                                ksWeight=ksweight, direction=[0.0, 10.0, 0.0])
+            problem.addFunction('z_disp', functions.KSDisplacement,
+                                ksWeight=ksweight, direction=[0.0, 0.0, 10.0])
+        func_list = ['compliance', 'x_disp', 'y_disp', 'z_disp']
+        return func_list, FUNC_REFS
+
+    def setup_tacs_problems(self, fea_assembler):
+        """
+        Setup pytacs object for problems we will be testing.
+        """
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+
+        return tacs_probs

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -70,9 +70,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
             return elem
 
         # Instantiate FEA Assembler
-        struct_options = {}
-
-        fea_assembler = pytacs.pyTACS(bdf_file, comm, options=struct_options)
+        fea_assembler = pytacs.pyTACS(bdf_file, comm)
 
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
@@ -116,5 +114,9 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         tacs_probs = fea_assembler.createTACSProbsFromBDF()
         # Convert from dict to list
         tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption('L2Convergence', 1e-20)
+            problem.setOption('L2ConvergenceRel', 1e-20)
 
         return tacs_probs


### PR DESCRIPTION
- Transient problems can now be read in and created directly from BDF using 'createTACSProbsFromBDF' method
- 'createTACSProbsFromBDF' method now supports reading:
    - StaticProblem
    - TransientProblem
    - ModalProblem
- Added new problem method to add loads from BDF manually (`addLoadFromBDF`)