### PR TITLE
Update extern installation to use SuiteSparse

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 syntax: glob
 
 extern/
-!extern/Makefile
+!extern/Makefile*
 !extern/f5to*/
 *~
 *.in

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -53,16 +53,20 @@ LAPACK_LIBS = -L/usr/lib/ -llapack -lpthread -lblas
 METIS_INCLUDE = -I${TACS_DIR}/extern/metis/include/
 METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 
-# AMD is a set of routines for ordering matrices. It is not required by default.
+# AMD is a set of routines for ordering matrices, included in the SuiteSparse package. It is not required by default.
 
-# AMD_DIR=${TACS_DIR}/extern/AMD
-# UFCONFIG_DIR=${TACS_DIR}/extern/UFconfig
-# AMD_INCLUDE = -I${AMD_DIR}/Include -I${UFCONFIG_DIR}
-# AMD_LIBS = ${AMD_DIR}/Lib/libamd.a ${UFCONFIG_DIR}/libufconfig.a
+# SUITESPARSE_DIR = ${TACS_DIR}/extern/SuiteSparse-5.13.0
+# The variables below should not need to be altered if you are installing SuiteSparse from the standard release tarball
+
+# SUITESPARSE_CONFIG_DIR = ${SUITESPARSE_DIR}/SuiteSparse_config
+# AMD_DIR = ${SUITESPARSE_DIR}/AMD
+# AMD_INCLUDE = -I${AMD_DIR}/Include -I${SUITESPARSE_CONFIG_DIR}
+# AMD_LIBS = ${AMD_DIR}/Lib/libamd.a ${SUITESPARSE_CONFIG_DIR}/libsuitesparseconfig.a
 
 # TECIO is a library for reading and writing tecplot data files, only required for building f5totec, can use either teciosrc or teciompisrc
+# TECIO_DIR = ${TACS_DIR}/extern/tecio/teciompisrc
+# TECIO_INCLUDE = -I${TECIO_DIR}
+# TECIO_LIB = ${TECIO_DIR}/libteciompi.a
 
-# TECIO_INCLUDE = -I${TACS_DIR}/extern/tecio/teciosrc
-# TECIO_LIB = ${TACS_DIR}/extern/tecio/teciosrc/libtecio.a
-# This may be need to be added for OpenMPI implementations
+# This may be need to be added to build f5totec with openmpi
 # TECIO_LIB = ${TECIO_LIB} -lopen-pal

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -50,7 +50,8 @@ LAPACK_LIBS = -L/usr/lib/ -llapack -lpthread -lblas
 # -DTACS_CPLUSPLUS_METIS to the TACS_DEF arguments below. If you
 # compile METIS using a C compiler, there should be no issues.
 
-METIS_INCLUDE = -I${TACS_DIR}/extern/metis/include/
+METIS_DIR = ${TACS_DIR}/extern/metis
+METIS_INCLUDE = -I${METIS_DIR}/include/
 METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 
 # AMD is a set of routines for ordering matrices, included in the SuiteSparse package. It is not required by default.
@@ -69,4 +70,4 @@ METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 # TECIO_LIB = ${TECIO_DIR}/libtecio*.a
 
 # This may be need to be added to build f5totec with openmpi
-# TECIO_LIB = ${TECIO_LIB} -lopen-pal
+# TECIO_LIB += -lopen-pal

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -66,7 +66,7 @@ METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 # TECIO is a library for reading and writing tecplot data files, only required for building f5totec, can use either teciosrc or teciompisrc
 # TECIO_DIR = ${TACS_DIR}/extern/tecio/teciompisrc
 # TECIO_INCLUDE = -I${TECIO_DIR}
-# TECIO_LIB = ${TECIO_DIR}/libteciompi.a
+# TECIO_LIB = ${TECIO_DIR}/libtecio*.a
 
 # This may be need to be added to build f5totec with openmpi
 # TECIO_LIB = ${TECIO_LIB} -lopen-pal

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -19,7 +19,7 @@ To use the python interface to TACS you will also require:
 
 Optional packages:
 
-* AMD - TACS can use the approximate minimum degree ordering routines from AMD/UFConfig
+* SuiteSparse - TACS can use the approximate minimum degree (AMD) ordering routines from SuiteSparse
 * TecIO - to convert TACS FH5 output files to tecplot-compatible files
 
 Basic steps to compile TACS
@@ -33,8 +33,9 @@ Basic steps to compile TACS
     * ``TACS_DIR``: the root director of TACS
     * ``CXX``: the C++ compiler, must be MPI-enabled
     * ``LAPACK_LIBS``: linking arguments for the LAPACK libraries
-    * ``METIS_INCLUDE`` and ``METIS_LIB``: set the include/linking arguments for METIS
-    * ``AMD_INCLUDE`` and ``AMD_LIBS``: *optional* set include/linking arguments for AMD
+    * ``METIS_DIR``: set the location of METIS
+    * ``SUITESPARSE_DIR``: *optional* set location of SuiteSparse
+    * ``TECIO_DIR`` and ``TECIO_LIB``: *optional* set location of TecIO
 
 #. To compile, from the base directory, run ``make`` then ``make interface``
 #. To set up the Python interface, run ``python setup.py develop --user``
@@ -74,7 +75,9 @@ Make sure to set the following:
 #. ``TACS_DIR``: the root director of TACS
 #. ``CXX``: the C++ compiler, must be MPI-enabled
 #. ``LAPACK_LIBS``: linking arguments for the LAPACK libraries
-#. ``METIS_INCLUDE`` and ``METIS_LIB``: set the include/linking arguments for METIS
+#. ``METIS_DIR``: set the location of METIS
+#. ``SUITESPARSE_DIR``: *optional* set location of SuiteSparse
+#. ``TECIO_DIR``: *optional* set location of TecIO (note you can use either the ``teciosrc`` or ``teciompisrc`` implementations)
 
 In addition, it is recommended to copy the default python settings by copying ``setup.cfg.info`` to ``setup.cfg``.
 The settings in ``setup.cfg.info`` are intended for development, if you are just going to use the code as-is,
@@ -87,10 +90,13 @@ These instructions direct you to install METIS and other dependencies in the dir
 This location for the dependencies is not required, and indeed may not be best.
 If you already have these libraries installed, simply adjust the variables in ``tacs/Makefile.in`` accordingly.
 
-Go to the directory ``tacs/extern``. Download ``metis-5.1.0`` from ``http://glaros.dtc.umn.edu/gkhome/metis/metis/download`` and place the file ``metis-5.1.0.tar.gz`` there.
+Go to the directory ``tacs/extern``. Download ``metis-5.1.0`` from `<http://glaros.dtc.umn.edu/gkhome/metis/metis/download>`_ and place the file ``metis-5.1.0.tar.gz`` there.
 Note that METIS needs CMake to build and install.
 
-Optionally, you can also place ``UFconfig-3.6.1.tar.gz`` and ``AMD-2.2.0.tar.gz`` in the same directory if you want to use the approximate minimum degree ordering routines from AMD/UFConfig.
+Optionally, you can also place ``SuiteSparse-5.13.0.tar.gz`` (available from `<https://github.com/DrTimothyAldenDavis/SuiteSparse/releases>`_) in the same directory if you want to use the approximate minimum degree ordering routines from SuiteSparse.
+
+Also optionally, place ``tecio.tgz`` (available from `<https://www.tecplot.com/products/tecio-library/>`_) in the same directory if you want to build ``f5totec``.
+Note that TecIO requires the boost library, which can be install with ``sudo apt-get install libboost-dev`` on debian systems.
 
 Then, to build the dependencies, simply run ``make``. If the build process ends with something like:
 
@@ -117,9 +123,7 @@ Install postprocessing tools
 ``f5tovtk`` and ``f5totec`` are executables that convert ``.f5`` files to Paraview ``.vtk`` and ``.plt`` formats compatible with Paraview and Tecplot respectively.
 After compiling the C++ TACS library, go to the subdirectory ``tacs/extern/f5tovtk`` and run ``make`` there.
 
-``f5totec`` requires Tecplot's ``tecio`` library, which can be downloaded `here <https://my.tecplot.com/portal/product-releases/tecio-library/>`_.
-After placing ``tecio.tgz`` in the ``tacs/extern`` directory, run ``make tecio`` there.
-Then run ``make`` in the ``tacs/extern/f5totec`` directory to build ``f5totec``.
+``f5totec`` requires Tecplot's ``tecio`` library, the installation of which is described above.
 
 
 It is useful to put these utilities on your path if possible.

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -35,7 +35,7 @@ Basic steps to compile TACS
     * ``LAPACK_LIBS``: linking arguments for the LAPACK libraries
     * ``METIS_DIR``: set the location of METIS
     * ``SUITESPARSE_DIR``: *optional* set location of SuiteSparse
-    * ``TECIO_DIR`` and ``TECIO_LIB``: *optional* set location of TecIO
+    * ``TECIO_DIR``: *optional* set location of TecIO
 
 #. To compile, from the base directory, run ``make`` then ``make interface``
 #. To set up the Python interface, run ``python setup.py develop --user``

--- a/extern/Makefile
+++ b/extern/Makefile
@@ -1,23 +1,25 @@
+include ../Makefile.in
+
 EXTERN_DIR=${shell pwd}
 
-default: ufconfig amd metis tecio
+default: suitesparse tecio metis
 
-ufconfig: # Allowed to fail since UFConfig/AMD is optional
-	tar -xzf UFconfig*.tar.gz && cd UFconfig && make CFLAGS="-O3 -fPIC -fexceptions" || exit 0;
+.phony: suitesparse
+suitesparse: # Allowed to fail since SuiteSparse/AMD is optional
+	tar -xzf suitesparse*.tar.gz && cd ${SUITESPARSE_CONFIG_DIR} && make CFLAGS="-O3 -fPIC -fexceptions" && cd ${AMD_DIR} && make CFLAGS="-O3 -fPIC -fexceptions" || exit 0;
 
-amd: # Allowed to fail since UFConfig/AMD is optional
-	tar -xzf AMD*.tar.gz && cd AMD && make CFLAGS="-O3 -fPIC -fexceptions" || exit 0;
-
+.phony: metis
 metis:
 	tar -xzf metis*.tar.gz;
-	cd `ls -d metis-*/` && make config prefix=${EXTERN_DIR}/metis CFLAGS="-O3 -fPIC" && make install;
+	cd `ls -d metis-*/` && make config prefix=${METIS_DIR} CFLAGS="-O3 -fPIC" && make install;
 
-tecio:
-	tar -xzf tecio*.tar.gz;
-	cd tecio/teciosrc && make -f Makefile.linux;
+.phony: tecio
+tecio: # Allowed to fail since TECIO is optional
+	tar -xzf tecio*.tgz;
+	cd ${TECIO_DIR} && make -f Makefile.linux || exit 0;
 
+.phony: clean
 clean:
+	rm -rf SuiteSparse*/
 	rm -rf metis*/
-	rm -rf UFconfig*/
-	rm -rf AMD*/
-	rm -rf tecio/teciosrc/*.o
+	rm -rf tecio*/


### PR DESCRIPTION
Since UFConfig and AMD are no longer available individually, I updated the extern makefile and installation instructions such that they work with the commonly available SuiteSparse tarball.