### PR TITLE
pyTACS Test refactor

### DIFF
--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -336,7 +336,7 @@ class TACSProblem(BaseUI):
             The components with added loads. Use pyTACS.selectCompIDs method
             to determine this.
 
-        F : numpy.ndarray 1d or 2d length (varsPerNodes) or (numNodeIDs, varsPerNodes)
+        F : numpy.ndarray 1d or 2d length (varsPerNodes) or (numCompIDs, varsPerNodes)
             Vector(s) of 'force' to apply to each components.  If only one force vector is provided,
             force will be copied uniformly across all components.
 

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -325,7 +325,7 @@ class StaticProblem(TACSProblem):
             The components with added loads. Use pyTACS selectCompIDs method
             to determine this.
 
-        F : numpy.ndarray 1d or 2d length (varsPerNodes) or (numNodeIDs, varsPerNodes)
+        F : numpy.ndarray 1d or 2d length (varsPerNodes) or (numCompIDs, varsPerNodes)
             Vector(s) of 'force' to apply to each components.  If only one force vector is provided,
             force will be copied uniformly across all components.
 

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -359,7 +359,7 @@ class TransientProblem(TACSProblem):
             The components with added loads. Use pyTACS.selectCompIDs method
             to determine this.
 
-        F : Numpy 1d or 2d array length (varsPerNodes) or (numNodeIDs, varsPerNodes)
+        F : Numpy 1d or 2d array length (varsPerNodes) or (numCompIDs, varsPerNodes)
             Vector(s) of 'force' to apply to each components.  If only one force vector is provided,
             force will be copied uniformly across all components.
 

--- a/tests/integration_tests/test_I_beam_mixed.py
+++ b/tests/integration_tests/test_I_beam_mixed.py
@@ -19,28 +19,28 @@ NOTE: Design variables are read in from BDF file.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/I_beam.bdf")
 
-FUNC_REFS = {
-    "load_set_000_compliance": 100430.19372545928,
-    "load_set_000_ks_vmfailure": 0.4486594909084844,
-    "load_set_000_mass": 5400.0,
-    "load_set_000_x_disp": 0.3558707399683029,
-    "load_set_000_y_disp": 1.2614949438778236,
-    "load_set_000_z_disp": 0.34011973816621555,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "load_set_000_compliance": 100430.19372545928,
+        "load_set_000_ks_vmfailure": 0.4486594909084844,
+        "load_set_000_mass": 5400.0,
+        "load_set_000_x_disp": 0.3558707399683029,
+        "load_set_000_y_disp": 1.2614949438778236,
+        "load_set_000_z_disp": 0.34011973816621555,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -57,27 +57,17 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
@@ -99,20 +89,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 ksWeight=ksweight,
                 direction=[0.0, 0.0, 10.0],
             )
-        func_list = ["mass", "compliance", "x_disp", "y_disp", "z_disp"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_beam_bend_coupling.py
+++ b/tests/integration_tests/test_beam_bend_coupling.py
@@ -18,66 +18,66 @@ and Compliance functions and sensitivities.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/beam_model.bdf")
 
-FUNC_REFS = {
-    "z-shear_compliance": 1.3200259999099195,
-    "z-shear_mass": 0.27,
-    "z-shear_x_disp": 0.0,
-    "z-shear_y_disp": -0.29391826170251795,
-    "z-shear_z_disp": 12.141597029011256,
-    "z-shear_I_xx": 0.0,
-    "z-shear_I_xy": 0.0,
-    "z-shear_I_xz": 0.0,
-    "z-shear_I_yy": 0.8325,
-    "z-shear_I_yz": 0.27,
-    "z-shear_I_zz": 0.5625,
-    "y-shear_compliance": 1.9800259997664378,
-    "y-shear_mass": 0.27,
-    "y-shear_x_disp": 0.0,
-    "y-shear_y_disp": 18.327400292118664,
-    "y-shear_z_disp": -0.2939182616984911,
-    "y-shear_I_xx": 0.0,
-    "y-shear_I_xy": 0.0,
-    "y-shear_I_xz": 0.0,
-    "y-shear_I_yy": 0.8325,
-    "y-shear_I_yz": 0.27,
-    "y-shear_I_zz": 0.5625,
-    "x-axial_compliance": 10.000000000000027,
-    "x-axial_mass": 0.27,
-    "x-axial_x_disp": 95.543244182597,
-    "x-axial_y_disp": 0.0,
-    "x-axial_z_disp": 0.0,
-    "x-axial_I_xx": 0.0,
-    "x-axial_I_xy": 0.0,
-    "x-axial_I_xz": 0.0,
-    "x-axial_I_yy": 0.8325,
-    "x-axial_I_yz": 0.27,
-    "x-axial_I_zz": 0.5625,
-    "x-torsion_compliance": 6.499999999999995,
-    "x-torsion_mass": 0.27,
-    "x-torsion_x_disp": 0.0,
-    "x-torsion_y_disp": 0.0,
-    "x-torsion_z_disp": 0.0,
-    "x-torsion_I_xx": 0.0,
-    "x-torsion_I_xy": 0.0,
-    "x-torsion_I_xz": 0.0,
-    "x-torsion_I_yy": 0.8325,
-    "x-torsion_I_yz": 0.27,
-    "x-torsion_I_zz": 0.5625,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "z-shear_compliance": 1.3200259999099195,
+        "z-shear_mass": 0.27,
+        "z-shear_x_disp": 0.0,
+        "z-shear_y_disp": -0.29391826170251795,
+        "z-shear_z_disp": 12.141597029011256,
+        "z-shear_I_xx": 0.0,
+        "z-shear_I_xy": 0.0,
+        "z-shear_I_xz": 0.0,
+        "z-shear_I_yy": 0.8325,
+        "z-shear_I_yz": 0.27,
+        "z-shear_I_zz": 0.5625,
+        "y-shear_compliance": 1.9800259997664378,
+        "y-shear_mass": 0.27,
+        "y-shear_x_disp": 0.0,
+        "y-shear_y_disp": 18.327400292118664,
+        "y-shear_z_disp": -0.2939182616984911,
+        "y-shear_I_xx": 0.0,
+        "y-shear_I_xy": 0.0,
+        "y-shear_I_xz": 0.0,
+        "y-shear_I_yy": 0.8325,
+        "y-shear_I_yz": 0.27,
+        "y-shear_I_zz": 0.5625,
+        "x-axial_compliance": 10.000000000000027,
+        "x-axial_mass": 0.27,
+        "x-axial_x_disp": 95.543244182597,
+        "x-axial_y_disp": 0.0,
+        "x-axial_z_disp": 0.0,
+        "x-axial_I_xx": 0.0,
+        "x-axial_I_xy": 0.0,
+        "x-axial_I_xz": 0.0,
+        "x-axial_I_yy": 0.8325,
+        "x-axial_I_yz": 0.27,
+        "x-axial_I_zz": 0.5625,
+        "x-torsion_compliance": 6.499999999999995,
+        "x-torsion_mass": 0.27,
+        "x-torsion_x_disp": 0.0,
+        "x-torsion_y_disp": 0.0,
+        "x-torsion_z_disp": 0.0,
+        "x-torsion_I_xx": 0.0,
+        "x-torsion_I_xy": 0.0,
+        "x-torsion_I_xz": 0.0,
+        "x-torsion_I_yy": 0.8325,
+        "x-torsion_I_yz": 0.27,
+        "x-torsion_I_zz": 0.5625,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
         Setup mesh and pytacs object for problem we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -94,27 +94,17 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction(
@@ -177,32 +167,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
-        func_list = [
-            "mass",
-            "compliance",
-            "x_disp",
-            "y_disp",
-            "z_disp",
-            "I_xx",
-            "I_xy",
-            "I_xz",
-            "I_yy",
-            "I_yz",
-            "I_zz",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_beam_point_mass.py
+++ b/tests/integration_tests/test_beam_point_mass.py
@@ -18,33 +18,33 @@ and Compliance functions and sensitivities.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/beam_tip_mass.bdf")
 
-FUNC_REFS = {
-    "centrifugal_compliance": 972.8974314464419,
-    "centrifugal_mass": 22.7,
-    "centrifugal_x_disp": 11.787207585847018,
-    "centrifugal_y_disp": 0.06931471805599453,
-    "centrifugal_z_disp": 0.06931471805599453,
-    "centrifugal_I_xx": 23.5,
-    "centrifugal_I_xy": 0.0,
-    "centrifugal_I_xz": 0.0,
-    "centrifugal_I_yy": 33.47596365638766,
-    "centrifugal_I_yz": 0.0,
-    "centrifugal_I_zz": 13.628713656387657,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "centrifugal_compliance": 972.8974314464419,
+        "centrifugal_mass": 22.7,
+        "centrifugal_x_disp": 11.787207585847018,
+        "centrifugal_y_disp": 0.06931471805599453,
+        "centrifugal_z_disp": 0.06931471805599453,
+        "centrifugal_I_xx": 23.5,
+        "centrifugal_I_xy": 0.0,
+        "centrifugal_I_xz": 0.0,
+        "centrifugal_I_yy": 33.47596365638766,
+        "centrifugal_I_yz": 0.0,
+        "centrifugal_I_zz": 13.628713656387657,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -91,27 +91,17 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction(
@@ -174,32 +164,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
-        func_list = [
-            "mass",
-            "compliance",
-            "x_disp",
-            "y_disp",
-            "z_disp",
-            "I_xx",
-            "I_xy",
-            "I_xz",
-            "I_yy",
-            "I_yz",
-            "I_zz",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_elast_beam_quadtetra_element_3d.py
+++ b/tests/integration_tests/test_elast_beam_quadtetra_element_3d.py
@@ -14,28 +14,28 @@ test StructuralMass and Compliance functions and sensitivities
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/solid_beam.bdf")
 
-FUNC_REFS = {
-    "AxialPressure_compliance": 14226.813534942703,
-    "AxialPressure_ks_disp": 0.3088436763967383,
-    "AxialPressure_mass": 27000.00000000002,
-    "Gravity_compliance": 33000.844246090586,
-    "Gravity_ks_disp": 0.3669703989454973,
-    "Gravity_mass": 27000.00000000002,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "AxialPressure_compliance": 14226.813534942703,
+        "AxialPressure_ks_disp": 0.3088436763967383,
+        "AxialPressure_mass": 27000.00000000002,
+        "Gravity_compliance": 33000.844246090586,
+        "Gravity_ks_disp": 0.3669703989454973,
+        "Gravity_mass": 27000.00000000002,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -52,27 +52,13 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction(
@@ -81,15 +67,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 ksWeight=ksweight,
                 direction=[-100.0, -100.0, -100.0],
             )
-        func_list = ["mass", "compliance", "ks_disp"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_elast_centrifugal_quadtetra_element_3d.py
+++ b/tests/integration_tests/test_elast_centrifugal_quadtetra_element_3d.py
@@ -14,12 +14,6 @@ test StructuralMass and Compliance functions and sensitivities
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/solid_beam.bdf")
 
-FUNC_REFS = {
-    "Centrifugal_compliance": 21447856.343444135,
-    "Centrifugal_ks_disp": 5.04476307317472,
-    "Centrifugal_mass": 27000.00000000002,
-}
-
 omega = 2 * np.pi * np.array([0.0, -10.0, 0.0])
 rotCenter = np.array([0.5, 0.5, 0.0])
 ksweight = 10.0
@@ -28,13 +22,19 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "Centrifugal_compliance": 21447856.343444135,
+        "Centrifugal_ks_disp": 5.04476307317472,
+        "Centrifugal_mass": 27000.00000000002,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -73,43 +73,18 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction("compliance", functions.Compliance)
-            problem.addFunction(
-                "ks_disp",
-                functions.KSDisplacement,
-                ksWeight=ksweight,
-                direction=[0.0, 0.0, 100.0],
-            )
-        func_list = ["mass", "compliance", "ks_disp"]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         # Add centrifugal load case
         static_prob = fea_assembler.createStaticProblem("Centrifugal")
         static_prob.addCentrifugalLoad(omega, rotCenter)
-        return [static_prob]
+
+        # Add Functions
+        static_prob.addFunction("mass", functions.StructuralMass)
+        static_prob.addFunction("compliance", functions.Compliance)
+        static_prob.addFunction(
+            "ks_disp",
+            functions.KSDisplacement,
+            ksWeight=ksweight,
+            direction=[0.0, 0.0, 100.0],
+        )
+
+        return [static_prob], fea_assembler

--- a/tests/integration_tests/test_point_mass_element.py
+++ b/tests/integration_tests/test_point_mass_element.py
@@ -18,17 +18,6 @@ Izz = 12.8 kg*m^2
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/point_mass.bdf")
 
-FUNC_REFS = {
-    "constant_force_mass": 200.0,
-    "constant_force_x_disp": 2.343553337720806,
-    "constant_force_y_disp": 2.343553337720806,
-    "constant_force_z_disp": 2.343553337720806,
-    "gravity_mass": 200.0,
-    "gravity_x_disp": 0.23025850929940442,
-    "gravity_y_disp": 0.23025850929940442,
-    "gravity_z_disp": 490.27400177252474,
-}
-
 # Force to apply
 f = np.ones(6)
 
@@ -38,13 +27,24 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 1  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "constant_force_mass": 200.0,
+        "constant_force_x_disp": 2.343553337720806,
+        "constant_force_y_disp": 2.343553337720806,
+        "constant_force_z_disp": 2.343553337720806,
+        "gravity_mass": 200.0,
+        "gravity_x_disp": 0.23025850929940442,
+        "gravity_y_disp": 0.23025850929940442,
+        "gravity_z_disp": 490.27400177252474,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -61,26 +61,25 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
+        # List to hold all problems
+        all_problems = []
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # This problem has no dvs
+        # Create case 1 transient problem
+        problem = fea_assembler.createTransientProblem("constant_force", 0.0, 10.0, 100)
+        timeSteps = problem.getTimeSteps()
+        for step_i, time in enumerate(timeSteps):
+            problem.addLoadToNodes(step_i, 0, f, nastranOrdering=False)
+        all_problems.append(problem)
 
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
+        # Create case 2 transient problem
+        problem = fea_assembler.createTransientProblem("gravity", 0.0, 10.0, 100)
+        g = np.array([0.0, 0.0, 9.81], dtype=TACS.dtype)
+        for step_i, time in enumerate(timeSteps):
+            problem.addInertialLoad(step_i, g)
+        all_problems.append(problem)
 
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in all_problems:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction(
                 "x_disp",
@@ -100,28 +99,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 ksWeight=ksweight,
                 direction=[0.0, 0.0, 1.0],
             )
-        func_list = ["mass", "x_disp", "y_disp", "z_disp"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # List to hold all problems
-        allProblems = []
-
-        # Create case 1 transient problem
-        problem = fea_assembler.createTransientProblem("constant_force", 0.0, 10.0, 100)
-        timeSteps = problem.getTimeSteps()
-        for step_i, time in enumerate(timeSteps):
-            problem.addLoadToNodes(step_i, 0, f, nastranOrdering=False)
-        allProblems.append(problem)
-
-        # Create case 2 transient problem
-        problem = fea_assembler.createTransientProblem("gravity", 0.0, 10.0, 100)
-        g = np.array([0.0, 0.0, 9.81], dtype=TACS.dtype)
-        for step_i, time in enumerate(timeSteps):
-            problem.addInertialLoad(step_i, g)
-        allProblems.append(problem)
-
-        return allProblems
+        return all_problems, fea_assembler

--- a/tests/integration_tests/test_rectangle_beam_rotated.py
+++ b/tests/integration_tests/test_rectangle_beam_rotated.py
@@ -19,7 +19,7 @@ We test KSDisplacement, KSFailure, StructuralMass, and Compliance functions and 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/beam_model_skewed.bdf")
 
-from test_rectangle_beam_tractions import FUNC_REFS
+from test_rectangle_beam_tractions import ProblemTest as PT
 
 ksweight = 10.0
 
@@ -32,13 +32,16 @@ z_prime = np.sqrt(0.5) * np.array([-1.0, 0.0, 1.0])
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    # Set reference functions to match unrotated case
+    FUNC_REFS = PT.FUNC_REFS
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -80,27 +83,23 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        grav_prob = fea_assembler.createStaticProblem("gravity")
+        grav_vec = -10.0 * x_prime + 3.0 * y_prime + 5.0 * z_prime
+        grav_prob.addInertialLoad(grav_vec)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
+        trac_prob = fea_assembler.createStaticProblem("traction")
+        trac_vec = 1.0 * x_prime - 2.0 * y_prime + 3.0 * z_prime
+        trac_prob.addTractionToComponents([0], trac_vec)
 
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
+        tacs_probs = [grav_prob, trac_prob]
 
-        return
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
@@ -123,26 +122,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 ksWeight=ksweight,
                 direction=10.0 * z_prime,
             )
-        func_list = ["mass", "compliance", "x_disp", "y_disp", "z_disp"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        grav_prob = fea_assembler.createStaticProblem("gravity")
-        grav_vec = -10.0 * x_prime + 3.0 * y_prime + 5.0 * z_prime
-        grav_prob.addInertialLoad(grav_vec)
-
-        trac_prob = fea_assembler.createStaticProblem("traction")
-        trac_vec = 1.0 * x_prime - 2.0 * y_prime + 3.0 * z_prime
-        trac_prob.addTractionToComponents([0], trac_vec)
-
-        tacs_probs = [grav_prob, trac_prob]
-
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_rectangle_beam_tractions.py
+++ b/tests/integration_tests/test_rectangle_beam_tractions.py
@@ -16,46 +16,46 @@ and Compliance functions and sensitivities.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/beam_model.bdf")
 
-FUNC_REFS = {
-    "gravity_compliance": 1941.637970569529,
-    "gravity_ks_vmfailure": 215.18186143357514,
-    "gravity_mass": 13.500000000000004,
-    "gravity_x_disp": -0.3750404568908798,
-    "gravity_y_disp": 656.1378755065329,
-    "gravity_z_disp": 275.45079293281793,
-    "gravity_I_xx": 0.0,
-    "gravity_I_xy": 0.0,
-    "gravity_I_xz": 0.0,
-    "gravity_I_yy": 1.13625,
-    "gravity_I_yz": 0.0,
-    "gravity_I_zz": 1.1278125,
-    "traction_compliance": 4.325878285719202,
-    "traction_ks_vmfailure": 9.71446798485217,
-    "traction_mass": 13.500000000000004,
-    "traction_x_disp": 0.009518432861763253,
-    "traction_y_disp": -0.7122094288145717,
-    "traction_z_disp": 12.02223266609341,
-    "traction_I_xx": 0.0,
-    "traction_I_xy": 0.0,
-    "traction_I_xz": 0.0,
-    "traction_I_yy": 1.13625,
-    "traction_I_yz": 0.0,
-    "traction_I_zz": 1.1278125,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "gravity_compliance": 1941.637970569529,
+        "gravity_ks_vmfailure": 215.18186143357514,
+        "gravity_mass": 13.500000000000004,
+        "gravity_x_disp": -0.3750404568908798,
+        "gravity_y_disp": 656.1378755065329,
+        "gravity_z_disp": 275.45079293281793,
+        "gravity_I_xx": 0.0,
+        "gravity_I_xy": 0.0,
+        "gravity_I_xz": 0.0,
+        "gravity_I_yy": 1.13625,
+        "gravity_I_yz": 0.0,
+        "gravity_I_zz": 1.1278125,
+        "traction_compliance": 4.325878285719202,
+        "traction_ks_vmfailure": 9.71446798485217,
+        "traction_mass": 13.500000000000004,
+        "traction_x_disp": 0.009518432861763253,
+        "traction_y_disp": -0.7122094288145717,
+        "traction_z_disp": 12.02223266609341,
+        "traction_I_xx": 0.0,
+        "traction_I_xy": 0.0,
+        "traction_I_xz": 0.0,
+        "traction_I_yy": 1.13625,
+        "traction_I_yz": 0.0,
+        "traction_I_zz": 1.1278125,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -97,27 +97,21 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        grav_prob = fea_assembler.createStaticProblem("gravity")
+        grav_prob.addInertialLoad([-10.0, 3.0, 5.0])
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
+        trac_prob = fea_assembler.createStaticProblem("traction")
+        trac_prob.addTractionToComponents([0], [1.0, -2.0, 3.0])
 
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
+        tacs_probs = [grav_prob, trac_prob]
 
-        return
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
@@ -181,36 +175,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
-        func_list = [
-            "mass",
-            "compliance",
-            "x_disp",
-            "y_disp",
-            "z_disp",
-            "I_xx",
-            "I_xy",
-            "I_xz",
-            "I_yy",
-            "I_yz",
-            "I_zz",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        grav_prob = fea_assembler.createStaticProblem("gravity")
-        grav_prob.addInertialLoad([-10.0, 3.0, 5.0])
-
-        trac_prob = fea_assembler.createStaticProblem("traction")
-        trac_prob.addTractionToComponents([0], [1.0, -2.0, 3.0])
-
-        tacs_probs = [grav_prob, trac_prob]
-
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_rigid_body_mass.py
+++ b/tests/integration_tests/test_rigid_body_mass.py
@@ -12,30 +12,30 @@ the system (StructuralMass, CenterOfMass, MomentOfInertia) and their sensitiviti
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/rigid_point_mass.bdf")
 
-FUNC_REFS = {
-    "rigid_body_Ixx": 760.2857142857142,
-    "rigid_body_Ixy": 10.5,
-    "rigid_body_Ixz": -210.5,
-    "rigid_body_Iyy": 478.14285714285717,
-    "rigid_body_Iyz": 72.85714285714286,
-    "rigid_body_Izz": 543.1428571428571,
-    "rigid_body_cgx": 3.0,
-    "rigid_body_cgy": -1.1428571428571428,
-    "rigid_body_cgz": 3.857142857142857,
-    "rigid_body_mass": 17.5,
-}
-
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 1  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "rigid_body_Ixx": 760.2857142857142,
+        "rigid_body_Ixy": 10.5,
+        "rigid_body_Ixz": -210.5,
+        "rigid_body_Iyy": 478.14285714285717,
+        "rigid_body_Iyz": 72.85714285714286,
+        "rigid_body_Izz": 543.1428571428571,
+        "rigid_body_cgx": 3.0,
+        "rigid_body_cgy": -1.1428571428571428,
+        "rigid_body_cgz": 3.857142857142857,
+        "rigid_body_mass": 17.5,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -52,97 +52,53 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # This problem has no dvs
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction(
-                "cgx", functions.CenterOfMass, direction=[1.0, 0.0, 0.0]
-            )
-            problem.addFunction(
-                "cgy", functions.CenterOfMass, direction=[0.0, 1.0, 0.0]
-            )
-            problem.addFunction(
-                "cgz", functions.CenterOfMass, direction=[0.0, 0.0, 1.0]
-            )
-            problem.addFunction(
-                "Ixx",
-                functions.MomentOfInertia,
-                direction1=[1.0, 0.0, 0.0],
-                direction2=[1.0, 0.0, 0.0],
-                aboutCM=True,
-            )
-            problem.addFunction(
-                "Ixy",
-                functions.MomentOfInertia,
-                direction1=[0.0, 1.0, 0.0],
-                direction2=[1.0, 0.0, 0.0],
-                aboutCM=True,
-            )
-            problem.addFunction(
-                "Ixz",
-                functions.MomentOfInertia,
-                direction1=[0.0, 0.0, 1.0],
-                direction2=[1.0, 0.0, 0.0],
-                aboutCM=True,
-            )
-            problem.addFunction(
-                "Iyy",
-                functions.MomentOfInertia,
-                direction1=[0.0, 1.0, 0.0],
-                direction2=[0.0, 1.0, 0.0],
-                aboutCM=True,
-            )
-            problem.addFunction(
-                "Iyz",
-                functions.MomentOfInertia,
-                direction1=[0.0, 0.0, 1.0],
-                direction2=[0.0, 1.0, 0.0],
-                aboutCM=True,
-            )
-            problem.addFunction(
-                "Izz",
-                functions.MomentOfInertia,
-                direction1=[0.0, 0.0, 1.0],
-                direction2=[0.0, 0.0, 1.0],
-                aboutCM=True,
-            )
-        func_list = [
-            "mass",
-            "cgx",
-            "cgy",
-            "cgz",
-            "Ixx",
-            "Ixy",
-            "Ixz",
-            "Iyy",
-            "Iyz",
-            "Izz",
-        ]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         # Create case 1 static problem
         problem = fea_assembler.createStaticProblem("rigid_body")
 
-        return [problem]
+        problem.addFunction("mass", functions.StructuralMass)
+        problem.addFunction("cgx", functions.CenterOfMass, direction=[1.0, 0.0, 0.0])
+        problem.addFunction("cgy", functions.CenterOfMass, direction=[0.0, 1.0, 0.0])
+        problem.addFunction("cgz", functions.CenterOfMass, direction=[0.0, 0.0, 1.0])
+        problem.addFunction(
+            "Ixx",
+            functions.MomentOfInertia,
+            direction1=[1.0, 0.0, 0.0],
+            direction2=[1.0, 0.0, 0.0],
+            aboutCM=True,
+        )
+        problem.addFunction(
+            "Ixy",
+            functions.MomentOfInertia,
+            direction1=[0.0, 1.0, 0.0],
+            direction2=[1.0, 0.0, 0.0],
+            aboutCM=True,
+        )
+        problem.addFunction(
+            "Ixz",
+            functions.MomentOfInertia,
+            direction1=[0.0, 0.0, 1.0],
+            direction2=[1.0, 0.0, 0.0],
+            aboutCM=True,
+        )
+        problem.addFunction(
+            "Iyy",
+            functions.MomentOfInertia,
+            direction1=[0.0, 1.0, 0.0],
+            direction2=[0.0, 1.0, 0.0],
+            aboutCM=True,
+        )
+        problem.addFunction(
+            "Iyz",
+            functions.MomentOfInertia,
+            direction1=[0.0, 0.0, 1.0],
+            direction2=[0.0, 1.0, 0.0],
+            aboutCM=True,
+        )
+        problem.addFunction(
+            "Izz",
+            functions.MomentOfInertia,
+            direction1=[0.0, 0.0, 1.0],
+            direction2=[0.0, 0.0, 1.0],
+            aboutCM=True,
+        )
+        return [problem], fea_assembler

--- a/tests/integration_tests/test_shell_cylinder_quad.py
+++ b/tests/integration_tests/test_shell_cylinder_quad.py
@@ -13,30 +13,30 @@ test StructuralMass and Compliance functions and sensitivities
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/cylinder.bdf")
 
-FUNC_REFS = {
-    "Axial_compliance": 0.004606292990644062,
-    "Axial_mass": 208.58647120309135,
-    "Shear-Bending_compliance": 0.32883253964394005,
-    "Shear-Bending_mass": 208.58647120309135,
-    "Moment-Bending_compliance": 0.03744304905762492,
-    "Moment-Bending_mass": 208.58647120309135,
-    "Torsion_compliance": 0.05100479047600847,
-    "Torsion_mass": 208.58647120309135,
-    "Combined_compliance": 0.4218866721681868,
-    "Combined_mass": 208.58647120309135,
-}
-
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "Axial_compliance": 0.004606292990644062,
+        "Axial_mass": 208.58647120309135,
+        "Shear-Bending_compliance": 0.32883253964394005,
+        "Shear-Bending_mass": 208.58647120309135,
+        "Moment-Bending_compliance": 0.03744304905762492,
+        "Moment-Bending_mass": 208.58647120309135,
+        "Torsion_compliance": 0.05100479047600847,
+        "Torsion_mass": 208.58647120309135,
+        "Combined_compliance": 0.4218866721681868,
+        "Combined_mass": 208.58647120309135,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -53,38 +53,14 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction("compliance", functions.Compliance)
-        func_list = ["mass", "compliance"]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         # Read in forces from BDF and create tacs struct problems
         tacs_probs = fea_assembler.createTACSProbsFromBDF()
         # Convert from dict to list
         tacs_probs = tacs_probs.values()
-        return tacs_probs
+
+        # Add Functions
+        for problem in tacs_probs:
+            problem.addFunction("mass", functions.StructuralMass)
+            problem.addFunction("compliance", functions.Compliance)
+
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_shell_hemisphere_mixed.py
+++ b/tests/integration_tests/test_shell_hemisphere_mixed.py
@@ -19,48 +19,6 @@ tests StructuralMass, MomentOfInertia, KSFailure, KSDisplacement and Compliance 
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/hemisphere.bdf")
 
-FUNC_REFS = {
-    "PLOAD4_cg_x": 0.0009653731820888509,
-    "PLOAD4_cg_y": -9.14227063766091e-05,
-    "PLOAD4_cg_z": 0.49758219135768283,
-    "PLOAD4_I_xx": 721.1210796251873,
-    "PLOAD4_I_xy": 0.02281438889615433,
-    "PLOAD4_I_xz": -0.13557311929923765,
-    "PLOAD4_I_yy": 718.9187282561999,
-    "PLOAD4_I_yz": 0.037711775302945186,
-    "PLOAD4_I_zz": 1152.580386827468,
-    "PLOAD4_compliance": 279300158.48951936,
-    "PLOAD4_ks_disp": 9.927842420503762,
-    "PLOAD4_ks_vmfailure": 29.307629374994303,
-    "PLOAD4_mass": 1737.357316694243,
-    "PLOAD2_cg_x": 0.0009653731820888509,
-    "PLOAD2_cg_y": -9.14227063766091e-05,
-    "PLOAD2_cg_z": 0.49758219135768283,
-    "PLOAD2_I_xx": 721.1210796251873,
-    "PLOAD2_I_xy": 0.02281438889615433,
-    "PLOAD2_I_xz": -0.13557311929923765,
-    "PLOAD2_I_yy": 718.9187282561999,
-    "PLOAD2_I_yz": 0.037711775302945186,
-    "PLOAD2_I_zz": 1152.580386827468,
-    "PLOAD2_compliance": 279300158.48951936,
-    "PLOAD2_ks_disp": 9.927842420503762,
-    "PLOAD2_ks_vmfailure": 29.307629374994303,
-    "PLOAD2_mass": 1737.357316694243,
-    "Centrifugal_cg_x": 0.0009653731820888509,
-    "Centrifugal_cg_y": -9.14227063766091e-05,
-    "Centrifugal_cg_z": 0.49758219135768283,
-    "Centrifugal_I_xx": 721.1210796251873,
-    "Centrifugal_I_xy": 0.022814388896140014,
-    "Centrifugal_I_xz": -0.13557311929923765,
-    "Centrifugal_I_yy": 718.9187282561999,
-    "Centrifugal_I_yz": 0.037711775302945186,
-    "Centrifugal_I_zz": 1152.580386827468,
-    "Centrifugal_compliance": 303.4866002859211,
-    "Centrifugal_ks_disp": 0.18580458183836876,
-    "Centrifugal_ks_vmfailure": 0.21309095365567654,
-    "Centrifugal_mass": 1737.357316694243,
-}
-
 omega = 2 * np.pi * np.array([0.0, 0.0, -10.0])
 rotCenter = np.zeros(3)
 
@@ -70,13 +28,55 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "PLOAD4_cg_x": 0.0009653731820888509,
+        "PLOAD4_cg_y": -9.14227063766091e-05,
+        "PLOAD4_cg_z": 0.49758219135768283,
+        "PLOAD4_I_xx": 721.1210796251873,
+        "PLOAD4_I_xy": 0.02281438889615433,
+        "PLOAD4_I_xz": -0.13557311929923765,
+        "PLOAD4_I_yy": 718.9187282561999,
+        "PLOAD4_I_yz": 0.037711775302945186,
+        "PLOAD4_I_zz": 1152.580386827468,
+        "PLOAD4_compliance": 279300158.48951936,
+        "PLOAD4_ks_disp": 9.927842420503762,
+        "PLOAD4_ks_vmfailure": 29.307629374994303,
+        "PLOAD4_mass": 1737.357316694243,
+        "PLOAD2_cg_x": 0.0009653731820888509,
+        "PLOAD2_cg_y": -9.14227063766091e-05,
+        "PLOAD2_cg_z": 0.49758219135768283,
+        "PLOAD2_I_xx": 721.1210796251873,
+        "PLOAD2_I_xy": 0.02281438889615433,
+        "PLOAD2_I_xz": -0.13557311929923765,
+        "PLOAD2_I_yy": 718.9187282561999,
+        "PLOAD2_I_yz": 0.037711775302945186,
+        "PLOAD2_I_zz": 1152.580386827468,
+        "PLOAD2_compliance": 279300158.48951936,
+        "PLOAD2_ks_disp": 9.927842420503762,
+        "PLOAD2_ks_vmfailure": 29.307629374994303,
+        "PLOAD2_mass": 1737.357316694243,
+        "Centrifugal_cg_x": 0.0009653731820888509,
+        "Centrifugal_cg_y": -9.14227063766091e-05,
+        "Centrifugal_cg_z": 0.49758219135768283,
+        "Centrifugal_I_xx": 721.1210796251873,
+        "Centrifugal_I_xy": 0.022814388896140014,
+        "Centrifugal_I_xz": -0.13557311929923765,
+        "Centrifugal_I_yy": 718.9187282561999,
+        "Centrifugal_I_yz": 0.037711775302945186,
+        "Centrifugal_I_zz": 1152.580386827468,
+        "Centrifugal_compliance": 303.4866002859211,
+        "Centrifugal_ks_disp": 0.18580458183836876,
+        "Centrifugal_ks_vmfailure": 0.21309095365567654,
+        "Centrifugal_mass": 1737.357316694243,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -127,27 +127,16 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = list(tacs_probs.values())
+        static_prob = fea_assembler.createStaticProblem("Centrifugal")
+        static_prob.addCentrifugalLoad(omega, rotCenter)
+        tacs_probs.append(static_prob)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction(
@@ -208,32 +197,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
-        func_list = [
-            "mass",
-            "compliance",
-            "ks_disp",
-            "ks_vmfailure",
-            "cg_x",
-            "cg_y",
-            "cg_z",
-            "I_xx",
-            "I_xy",
-            "I_xz",
-            "I_yy",
-            "I_yz",
-            "I_zz",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = list(tacs_probs.values())
-        static_prob = fea_assembler.createStaticProblem("Centrifugal")
-        static_prob.addCentrifugalLoad(omega, rotCenter)
-        tacs_probs.append(static_prob)
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_shell_plate_partitioned.py
+++ b/tests/integration_tests/test_shell_plate_partitioned.py
@@ -24,27 +24,6 @@ We use pyTACS selectCompIDs method to apply loads and eval functions specificall
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/partitioned_plate.bdf")
 
-FUNC_REFS = {
-    "load_compliance": 155663.05822283815,
-    "load_ks_disp": 38.52680169648463,
-    "load_ks_vmfailure": 20.170707090964743,
-    "load_mass": 0.78125,
-    "load_cgx": 0.25,
-    "load_cgy": 0.25,
-    "pressure_compliance": 73362.09834795444,
-    "pressure_ks_disp": 21.6030915592335,
-    "pressure_ks_vmfailure": 16.464960170504657,
-    "pressure_mass": 0.78125,
-    "pressure_cgx": 0.25,
-    "pressure_cgy": 0.25,
-    "traction_compliance": 735.6034203895599,
-    "traction_ks_disp": 1.821814969038552,
-    "traction_ks_vmfailure": 0.7396840173568021,
-    "traction_mass": 0.78125,
-    "traction_cgx": 0.25,
-    "traction_cgy": 0.25,
-}
-
 
 # KS function weight
 ksweight = 10.0
@@ -53,13 +32,34 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "load_compliance": 155663.05822283815,
+        "load_ks_disp": 38.52680169648463,
+        "load_ks_vmfailure": 20.170707090964743,
+        "load_mass": 0.78125,
+        "load_cgx": 0.25,
+        "load_cgy": 0.25,
+        "pressure_compliance": 73362.09834795444,
+        "pressure_ks_disp": 21.6030915592335,
+        "pressure_ks_vmfailure": 16.464960170504657,
+        "pressure_mass": 0.78125,
+        "pressure_cgx": 0.25,
+        "pressure_cgy": 0.25,
+        "traction_compliance": 735.6034203895599,
+        "traction_ks_disp": 1.821814969038552,
+        "traction_ks_vmfailure": 0.7396840173568021,
+        "traction_mass": 0.78125,
+        "traction_cgx": 0.25,
+        "traction_cgy": 0.25,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -98,27 +98,31 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        tacs_probs = []
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
+        # Distribute point force over all nodes in bottom left quadrant of plate
+        sp = fea_assembler.createStaticProblem(name="load")
+        F = np.array([0.0, 0.0, 1e6, 0.0, 0.0, 0.0])
+        compIDs = fea_assembler.selectCompIDs(include="PLATE.00")
+        sp.addLoadToComponents(compIDs, F)
+        tacs_probs.append(sp)
 
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
+        # Add pressure to bottom right quadrant of plate
+        sp = fea_assembler.createStaticProblem(name="pressure")
+        P = 100e5  # Pa
+        compIDs = fea_assembler.selectCompIDs(include="PLATE.01")
+        sp.addPressureToComponents(compIDs, P)
+        tacs_probs.append(sp)
 
-        return
+        # Add traction to upper right quadrant of plate
+        sp = fea_assembler.createStaticProblem(name="traction")
+        trac = [1e6, 1e6, 1e6]  # N/m^2
+        compIDs = fea_assembler.selectCompIDs(include="PLATE.02")
+        sp.addTractionToComponents(compIDs, trac)
+        tacs_probs.append(sp)
 
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             # Evaluate mass of bottom left quadrant of plate
             compIDs = fea_assembler.selectCompIDs(include="PLATE.00")
             problem.addFunction("mass", functions.StructuralMass, compIDs=compIDs)
@@ -145,34 +149,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
             problem.addFunction(
                 "cgy", functions.CenterOfMass, direction=[0.0, 1.0, 0.0]
             )
-        func_list = ["mass", "ks_vmfailure", "ks_disp", "compliance", "cgx", "cgy"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        tacs_probs = []
-
-        # Distribute point force over all nodes in bottom left quadrant of plate
-        sp = fea_assembler.createStaticProblem(name="load")
-        F = np.array([0.0, 0.0, 1e6, 0.0, 0.0, 0.0])
-        compIDs = fea_assembler.selectCompIDs(include="PLATE.00")
-        sp.addLoadToComponents(compIDs, F)
-        tacs_probs.append(sp)
-
-        # Add pressure to bottom right quadrant of plate
-        sp = fea_assembler.createStaticProblem(name="pressure")
-        P = 100e5  # Pa
-        compIDs = fea_assembler.selectCompIDs(include="PLATE.01")
-        sp.addPressureToComponents(compIDs, P)
-        tacs_probs.append(sp)
-
-        # Add traction to upper right quadrant of plate
-        sp = fea_assembler.createStaticProblem(name="traction")
-        trac = [1e6, 1e6, 1e6]  # N/m^2
-        compIDs = fea_assembler.selectCompIDs(include="PLATE.02")
-        sp.addTractionToComponents(compIDs, trac)
-        tacs_probs.append(sp)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_shell_plate_quad.py
+++ b/tests/integration_tests/test_shell_plate_quad.py
@@ -14,45 +14,6 @@ and Compliance functions and sensitivities
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/plate.bdf")
 
-FUNC_REFS = {
-    "point_load_compliance": 683.8571611640772,
-    "point_load_ks_vmfailure": 0.5757488025913641,
-    "point_load_mass": 12.5,
-    "point_load_cgx": 0.5,
-    "point_load_cgy": 0.5,
-    "point_load_cgz": 0.0,
-    "point_load_Ixx": 1.0416927083333238,
-    "point_load_Ixy": 0.0,
-    "point_load_Ixz": 0.0,
-    "point_load_Iyy": 1.0416927083333243,
-    "point_load_Iyz": 0.0,
-    "point_load_Izz": 2.08333333333333,
-    "pressure_compliance": 4679.345460326432,
-    "pressure_ks_vmfailure": 1.2938623156872926,
-    "pressure_mass": 12.5,
-    "pressure_cgx": 0.5,
-    "pressure_cgy": 0.5,
-    "pressure_cgz": 0.0,
-    "pressure_Ixx": 1.0416927083333238,
-    "pressure_Ixy": 0.0,
-    "pressure_Ixz": 0.0,
-    "pressure_Iyy": 1.0416927083333243,
-    "pressure_Iyz": 0.0,
-    "pressure_Izz": 2.08333333333333,
-    "gravity_compliance": 70.36280588344383,
-    "gravity_ks_vmfailure": 0.11707320009742483,
-    "gravity_mass": 12.5,
-    "gravity_cgx": 0.5,
-    "gravity_cgy": 0.5,
-    "gravity_cgz": 0.0,
-    "gravity_Ixx": 1.0416927083333238,
-    "gravity_Ixy": 0.0,
-    "gravity_Ixz": 0.0,
-    "gravity_Iyy": 1.0416927083333243,
-    "gravity_Iyz": 0.0,
-    "gravity_Izz": 2.08333333333333,
-}
-
 # KS function weight
 ksweight = 10.0
 
@@ -60,13 +21,52 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "point_load_compliance": 683.8571611640772,
+        "point_load_ks_vmfailure": 0.5757488025913641,
+        "point_load_mass": 12.5,
+        "point_load_cgx": 0.5,
+        "point_load_cgy": 0.5,
+        "point_load_cgz": 0.0,
+        "point_load_Ixx": 1.0416927083333238,
+        "point_load_Ixy": 0.0,
+        "point_load_Ixz": 0.0,
+        "point_load_Iyy": 1.0416927083333243,
+        "point_load_Iyz": 0.0,
+        "point_load_Izz": 2.08333333333333,
+        "pressure_compliance": 4679.345460326432,
+        "pressure_ks_vmfailure": 1.2938623156872926,
+        "pressure_mass": 12.5,
+        "pressure_cgx": 0.5,
+        "pressure_cgy": 0.5,
+        "pressure_cgz": 0.0,
+        "pressure_Ixx": 1.0416927083333238,
+        "pressure_Ixy": 0.0,
+        "pressure_Ixz": 0.0,
+        "pressure_Iyy": 1.0416927083333243,
+        "pressure_Iyz": 0.0,
+        "pressure_Izz": 2.08333333333333,
+        "gravity_compliance": 70.36280588344383,
+        "gravity_ks_vmfailure": 0.11707320009742483,
+        "gravity_mass": 12.5,
+        "gravity_cgx": 0.5,
+        "gravity_cgy": 0.5,
+        "gravity_cgz": 0.0,
+        "gravity_Ixx": 1.0416927083333238,
+        "gravity_Ixy": 0.0,
+        "gravity_Ixz": 0.0,
+        "gravity_Iyy": 1.0416927083333243,
+        "gravity_Iyz": 0.0,
+        "gravity_Izz": 2.08333333333333,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -105,27 +105,29 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        tacs_probs = []
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
+        # Add point force to node 81 (center of plate)
+        sp = fea_assembler.createStaticProblem(name="point_load")
+        F = np.array([0.0, 0.0, 1e4, 0.0, 0.0, 0.0])
+        sp.addLoadToNodes(81, F, nastranOrdering=True)
+        tacs_probs.append(sp)
 
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
+        # Add pressure to entire plate
+        sp = fea_assembler.createStaticProblem(name="pressure")
+        P = 100e3  # Pa
+        compIDs = fea_assembler.selectCompIDs(include="PLATE")
+        sp.addPressureToComponents(compIDs, P)
+        tacs_probs.append(sp)
 
-        return
+        # Add pressure to entire plate
+        sp = fea_assembler.createStaticProblem(name="gravity")
+        g = np.array([0.0, 0.0, -981.0], dtype=self.dtype)
+        sp.addInertialLoad(g)
+        tacs_probs.append(sp)
 
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
             problem.addFunction("compliance", functions.Compliance)
@@ -180,45 +182,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
-        func_list = [
-            "mass",
-            "ks_vmfailure",
-            "compliance",
-            "cgx",
-            "cgy",
-            "cgz",
-            "Ixx",
-            "Ixy",
-            "Ixz",
-            "Iyy",
-            "Iyz",
-            "Izz",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        tacs_probs = []
-
-        # Add point force to node 81 (center of plate)
-        sp = fea_assembler.createStaticProblem(name="point_load")
-        F = np.array([0.0, 0.0, 1e4, 0.0, 0.0, 0.0])
-        sp.addLoadToNodes(81, F, nastranOrdering=True)
-        tacs_probs.append(sp)
-
-        # Add pressure to entire plate
-        sp = fea_assembler.createStaticProblem(name="pressure")
-        P = 100e3  # Pa
-        compIDs = fea_assembler.selectCompIDs(include="PLATE")
-        sp.addPressureToComponents(compIDs, P)
-        tacs_probs.append(sp)
-
-        # Add pressure to entire plate
-        sp = fea_assembler.createStaticProblem(name="gravity")
-        g = np.array([0.0, 0.0, -981.0], dtype=self.dtype)
-        sp.addInertialLoad(g)
-        tacs_probs.append(sp)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_simple_spring.py
+++ b/tests/integration_tests/test_simple_spring.py
@@ -18,14 +18,6 @@ krz = 6 N/m
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/simple_spring.bdf")
 
-FUNC_REFS = {
-    "uniform_force_mass": 0.0,
-    "uniform_force_compliance": 24500.000000000007,
-    "uniform_force_x_disp": 99.93068528194402,
-    "uniform_force_y_disp": 49.930685281944015,
-    "uniform_force_z_disp": 33.264018615277344,
-}
-
 # Force to apply
 f = np.ones(6) * 100.0
 
@@ -35,13 +27,21 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 1  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "uniform_force_mass": 0.0,
+        "uniform_force_compliance": 24500.000000000007,
+        "uniform_force_x_disp": 99.93068528194402,
+        "uniform_force_y_disp": 49.930685281944015,
+        "uniform_force_z_disp": 33.264018615277344,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-8
             self.dh = 1e-50
@@ -55,8 +55,8 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
 
         fea_assembler = pytacs.pyTACS(bdf_file, comm, options=struct_options)
 
-        def elemCallBack(
-            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+        def elem_call_back(
+            dv_num, comp_id, comp_descript, elem_descripts, global_dvs, **kwargs
         ):
             # Set one thickness dv for every component
             k = np.arange(6) + 1
@@ -66,56 +66,32 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
             return elem
 
         # Set up constitutive objects and elements
-        fea_assembler.initialize(elemCallBack)
+        fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # This problem has no dvs
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction("compliance", functions.Compliance)
-            problem.addFunction(
-                "x_disp",
-                functions.KSDisplacement,
-                ksWeight=ksweight,
-                direction=[1.0, 0.0, 0.0],
-            )
-            problem.addFunction(
-                "y_disp",
-                functions.KSDisplacement,
-                ksWeight=ksweight,
-                direction=[0.0, 1.0, 0.0],
-            )
-            problem.addFunction(
-                "z_disp",
-                functions.KSDisplacement,
-                ksWeight=ksweight,
-                direction=[0.0, 0.0, 1.0],
-            )
-        func_list = ["mass", "compliance", "x_disp", "y_disp", "z_disp"]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         # Create tacs transient problem
         problem = fea_assembler.createStaticProblem("uniform_force")
         problem.addLoadToNodes(1, f, nastranOrdering=False)
-        return [problem]
+
+        # Add Functions
+        problem.addFunction("mass", functions.StructuralMass)
+        problem.addFunction("compliance", functions.Compliance)
+        problem.addFunction(
+            "x_disp",
+            functions.KSDisplacement,
+            ksWeight=ksweight,
+            direction=[1.0, 0.0, 0.0],
+        )
+        problem.addFunction(
+            "y_disp",
+            functions.KSDisplacement,
+            ksWeight=ksweight,
+            direction=[0.0, 1.0, 0.0],
+        )
+        problem.addFunction(
+            "z_disp",
+            functions.KSDisplacement,
+            ksWeight=ksweight,
+            direction=[0.0, 0.0, 1.0],
+        )
+
+        return [problem], fea_assembler

--- a/tests/integration_tests/test_thermal_initial_conditions.py
+++ b/tests/integration_tests/test_thermal_initial_conditions.py
@@ -14,15 +14,6 @@ https://kitchingroup.cheme.cmu.edu/blog/2013/03/07/Transient-heat-conduction-par
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/unit_plate.bdf")
 
-FUNC_REFS = {
-    "steady_state_avg_temp": 150.00000000000057,
-    "steady_state_ks_temp": 198.51811570667203,
-    "steady_state_mass": 0.9999999999999951,
-    "transient_avg_temp": 750.0000000001098,
-    "transient_ks_temp": 198.36960589918542,
-    "transient_mass": 4.999999999999405,
-}
-
 # Area of plate
 area = 1.0
 
@@ -33,10 +24,16 @@ ksweight = 10.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
-        """
-        Setup mesh and pytacs object for problem we will be testing.
-        """
+    FUNC_REFS = {
+        "steady_state_avg_temp": 150.00000000000057,
+        "steady_state_ks_temp": 198.51811570667203,
+        "steady_state_mass": 0.9999999999999951,
+        "transient_avg_temp": 750.0000000001098,
+        "transient_ks_temp": 198.36960589918542,
+        "transient_mass": 4.999999999999405,
+    }
+
+    def setup_tacs_problems(self, comm):
 
         # Instantiate FEA Assembler
         struct_options = {  # Finer tol needed to pass complex sens test
@@ -75,37 +72,6 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction("ks_temp", functions.KSTemperature, ksWeight=ksweight)
-            problem.addFunction("avg_temp", functions.AverageTemperature, volume=area)
-        func_list = ["mass", "ks_temp", "avg_temp"]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         tacs_probs = []
 
         # Create static problem, loads are already applied through BCs
@@ -120,4 +86,10 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         tp.setInitConditions(vars=150.0)
         tacs_probs.append(tp)
 
-        return tacs_probs
+        # Add Functions
+        for problem in tacs_probs:
+            problem.addFunction("mass", functions.StructuralMass)
+            problem.addFunction("ks_temp", functions.KSTemperature, ksWeight=ksweight)
+            problem.addFunction("avg_temp", functions.AverageTemperature, volume=area)
+
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -14,30 +14,30 @@ We apply apply various tip loads test KSDisplacement and Compliance functions an
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/transient_beam.bdf")
 
-FUNC_REFS = {
-    "ramp_compliance": 10.507315462331803,
-    "ramp_x_disp": 0.06931471805599457,
-    "ramp_y_disp": 12.186052999423167,
-    "ramp_z_disp": 0.06931471805599457,
-    "sinusoid_compliance": 22.093569888841497,
-    "sinusoid_x_disp": 0.06931471805599457,
-    "sinusoid_y_disp": 25.654265895487846,
-    "sinusoid_z_disp": 0.06931471805599457,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "ramp_compliance": 10.507315462331803,
+        "ramp_x_disp": 0.06931471805599457,
+        "ramp_y_disp": 12.186052999423167,
+        "ramp_z_disp": 0.06931471805599457,
+        "sinusoid_compliance": 22.093569888841497,
+        "sinusoid_x_disp": 0.06931471805599457,
+        "sinusoid_y_disp": 25.654265895487846,
+        "sinusoid_z_disp": 0.06931471805599457,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -82,27 +82,17 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-15)
+            problem.setOption("L2ConvergenceRel", 1e-15)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction(
                 "x_disp",
@@ -122,20 +112,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 ksWeight=ksweight,
                 direction=[0.0, 0.0, 10.0],
             )
-        func_list = ["compliance", "x_disp", "y_disp", "z_disp"]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-15)
-            problem.setOption("L2ConvergenceRel", 1e-15)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_trans_beam_dirk.py
+++ b/tests/integration_tests/test_trans_beam_dirk.py
@@ -13,13 +13,6 @@ convergence behavior.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/test_beam.bdf")
 
-FUNC_REFS = {
-    "load_coarse_ks_disp": 4.011613743975663,
-    "load_coarse_mass": 0.27000000000000035,
-    "load_fine_ks_disp": 5.113070671424432,
-    "load_fine_mass": 0.27000000000000396,
-}
-
 
 f_mag = 10.0
 
@@ -33,12 +26,19 @@ ksweight = 100.0
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "load_coarse_ks_disp": 4.011613743975663,
+        "load_coarse_mass": 0.27000000000000035,
+        "load_fine_ks_disp": 5.113070671424432,
+        "load_fine_mass": 0.27000000000000396,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-8
             self.atol = 1e-3
             self.dh = 1e-50
@@ -53,41 +53,6 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize()
 
-        return fea_assembler
-
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on plate
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
-        # Add Functions
-        for problem in problems:
-            problem.addFunction("mass", functions.StructuralMass)
-            problem.addFunction(
-                "ks_disp",
-                functions.KSDisplacement,
-                direction=[0.0, 0.0, 100.0],
-                ftype="discrete",
-            )
-        func_list = ["mass", "ks_disp"]
-        return func_list, FUNC_REFS
-
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
         # set transient problem options
         transientOptions = {"timeIntegrator": "DIRK", "integrationOrder": DIRK_order}
 
@@ -128,4 +93,13 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                         nastranOrdering=True,
                     )
 
-        return load_probs
+        for problem in load_probs:
+            problem.addFunction("mass", functions.StructuralMass)
+            problem.addFunction(
+                "ks_disp",
+                functions.KSDisplacement,
+                direction=[0.0, 0.0, 100.0],
+                ftype="discrete",
+            )
+
+        return load_probs, fea_assembler

--- a/tests/integration_tests/test_tube_beam.py
+++ b/tests/integration_tests/test_tube_beam.py
@@ -15,58 +15,58 @@ StructuralMass, and Compliance functions and sensitivities.
 base_dir = os.path.dirname(os.path.abspath(__file__))
 bdf_file = os.path.join(base_dir, "./input_files/beam_model.bdf")
 
-FUNC_REFS = {
-    "z-shear_cg_x": 0.5,
-    "z-shear_cg_y": 0.0,
-    "z-shear_cg_z": 0.0,
-    "z-shear_compliance": 2.1117936117524927,
-    "z-shear_ks_vmfailure": 6.631852693984316,
-    "z-shear_mass": 4.4532075864635265,
-    "z-shear_x_disp": 0.0,
-    "z-shear_y_disp": 0.0,
-    "z-shear_z_disp": 19.57107469646702,
-    "y-shear_cg_x": 0.5,
-    "y-shear_cg_y": 0.0,
-    "y-shear_cg_z": 0.0,
-    "y-shear_compliance": 2.1117936117524927,
-    "y-shear_ks_vmfailure": 6.631852693984316,
-    "y-shear_mass": 4.4532075864635265,
-    "y-shear_x_disp": 0.0,
-    "y-shear_y_disp": 19.57107469646702,
-    "y-shear_z_disp": 0.0,
-    "x-axial_cg_x": 0.5,
-    "x-axial_cg_y": 0.0,
-    "x-axial_cg_z": 0.0,
-    "x-axial_compliance": 0.008661493501599744,
-    "x-axial_ks_vmfailure": 0.17273633763874147,
-    "x-axial_mass": 4.4532075864635265,
-    "x-axial_x_disp": 0.04641402830875186,
-    "x-axial_y_disp": 0.0,
-    "x-axial_z_disp": 0.0,
-    "x-torsion_cg_x": 0.5,
-    "x-torsion_cg_y": 0.0,
-    "x-torsion_cg_z": 0.0,
-    "x-torsion_compliance": 8.151993883858584,
-    "x-torsion_ks_vmfailure": 8.447664369986043,
-    "x-torsion_mass": 4.4532075864635265,
-    "x-torsion_x_disp": 0.0,
-    "x-torsion_y_disp": 0.0,
-    "x-torsion_z_disp": 0.0,
-}
-
 ksweight = 10.0
 
 
 class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
-    def setup_pytacs(self, comm, dtype):
+    FUNC_REFS = {
+        "z-shear_cg_x": 0.5,
+        "z-shear_cg_y": 0.0,
+        "z-shear_cg_z": 0.0,
+        "z-shear_compliance": 2.1117936117524927,
+        "z-shear_ks_vmfailure": 6.631852693984316,
+        "z-shear_mass": 4.4532075864635265,
+        "z-shear_x_disp": 0.0,
+        "z-shear_y_disp": 0.0,
+        "z-shear_z_disp": 19.57107469646702,
+        "y-shear_cg_x": 0.5,
+        "y-shear_cg_y": 0.0,
+        "y-shear_cg_z": 0.0,
+        "y-shear_compliance": 2.1117936117524927,
+        "y-shear_ks_vmfailure": 6.631852693984316,
+        "y-shear_mass": 4.4532075864635265,
+        "y-shear_x_disp": 0.0,
+        "y-shear_y_disp": 19.57107469646702,
+        "y-shear_z_disp": 0.0,
+        "x-axial_cg_x": 0.5,
+        "x-axial_cg_y": 0.0,
+        "x-axial_cg_z": 0.0,
+        "x-axial_compliance": 0.008661493501599744,
+        "x-axial_ks_vmfailure": 0.17273633763874147,
+        "x-axial_mass": 4.4532075864635265,
+        "x-axial_x_disp": 0.04641402830875186,
+        "x-axial_y_disp": 0.0,
+        "x-axial_z_disp": 0.0,
+        "x-torsion_cg_x": 0.5,
+        "x-torsion_cg_y": 0.0,
+        "x-torsion_cg_z": 0.0,
+        "x-torsion_compliance": 8.151993883858584,
+        "x-torsion_ks_vmfailure": 8.447664369986043,
+        "x-torsion_mass": 4.4532075864635265,
+        "x-torsion_x_disp": 0.0,
+        "x-torsion_y_disp": 0.0,
+        "x-torsion_z_disp": 0.0,
+    }
+
+    def setup_tacs_problems(self, comm):
         """
-        Setup mesh and pytacs object for problem we will be testing.
+        Setup pytacs object for problems we will be testing.
         """
 
         # Overwrite default check values
-        if dtype == complex:
+        if self.dtype == complex:
             self.rtol = 1e-6
             self.atol = 1e-6
             self.dh = 1e-50
@@ -108,27 +108,17 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         # Set up constitutive objects and elements
         fea_assembler.initialize(elem_call_back)
 
-        return fea_assembler
+        # Read in forces from BDF and create tacs struct problems
+        tacs_probs = fea_assembler.createTACSProbsFromBDF()
+        # Convert from dict to list
+        tacs_probs = tacs_probs.values()
+        # Set convergence to be tight for test
+        for problem in tacs_probs:
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
 
-    def setup_tacs_vecs(self, fea_assembler, dv_pert_vec, xpts_pert_vec):
-        """
-        Setup user-defined vectors for analysis and fd/cs sensitivity verification
-        """
-        # Create temporary dv vec for doing fd/cs
-        dv_pert_vec[:] = 1.0
-
-        # Define perturbation array that moves all nodes on shell
-        xpts = fea_assembler.getOrigNodes()
-        xpts_pert_vec[:] = xpts
-
-        return
-
-    def setup_funcs(self, fea_assembler, problems):
-        """
-        Create a list of functions to be tested and their reference values for the problem
-        """
         # Add Functions
-        for problem in problems:
+        for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
             problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
@@ -159,29 +149,5 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
             problem.addFunction(
                 "cg_z", functions.CenterOfMass, direction=[0.0, 0.0, 1.0]
             )
-        func_list = [
-            "mass",
-            "compliance",
-            "x_disp",
-            "y_disp",
-            "z_disp",
-            "cg_x",
-            "cg_y",
-            "cg_z",
-        ]
-        return func_list, FUNC_REFS
 
-    def setup_tacs_problems(self, fea_assembler):
-        """
-        Setup pytacs object for problems we will be testing.
-        """
-        # Read in forces from BDF and create tacs struct problems
-        tacs_probs = fea_assembler.createTACSProbsFromBDF()
-        # Convert from dict to list
-        tacs_probs = tacs_probs.values()
-        # Set convergence to be tight for test
-        for problem in tacs_probs:
-            problem.setOption("L2Convergence", 1e-20)
-            problem.setOption("L2ConvergenceRel", 1e-20)
-
-        return tacs_probs
+        return tacs_probs, fea_assembler


### PR DESCRIPTION
- Refactoring pytacs integration tests to simplify test creation
- Reduces number redundant/unnecessary information that had to be defined by users in the past for these tests
- See test [here](https://github.com/timryanb/tacs/blob/test-refactor/tests/integration_tests/test_point_mass_element.py) for example