### PR TITLE
Tying pyTACS verbosity to `printLevel`

### DIFF
--- a/examples/battery/battery_runaway.py
+++ b/examples/battery/battery_runaway.py
@@ -86,7 +86,7 @@ FEAAssembler.initialize(elemCallBack)
 
 # Create a transient problem that will represent time-varying heat conduction
 transientProblem = FEAAssembler.createTransientProblem(
-    "Transient", tInit=0.0, tFinal=5.0, numSteps=50
+    "Transient", tInit=0.0, tFinal=5.0, numSteps=50, options={"printLevel": 1}
 )
 
 # Get the time steps and define the loads

--- a/tacs/utilities.py
+++ b/tacs/utilities.py
@@ -117,6 +117,14 @@ class BaseUI:
     def _info(self, message, maxLen=80, box=False):
         """Generic function for writing an info message."""
 
+        try:
+            printLevel = self.getOption("printLevel")
+            if printLevel <= 0:
+                # Don't print out info
+                return
+        except KeyError:
+            pass
+
         if self.comm.rank == 0:
             # Class name
             header = type(self).__name__

--- a/tacs/utilities.py
+++ b/tacs/utilities.py
@@ -122,7 +122,8 @@ class BaseUI:
             if printLevel <= 0:
                 # Don't print out info
                 return
-        except KeyError:
+        except AttributeError:
+            # printLevel option doesn't exist
             pass
 
         if self.comm.rank == 0:


### PR DESCRIPTION
- Tying pytacs info statement printing to "printLevel" option
- Should avoid excessive printing when users have to add loads repeatedly, like for `TransientProblem`