### PR TITLE
Changing test docstring to literal to suppress python string warning

### DIFF
--- a/tests/integration_tests/test_shell_plate_rbe2.py
+++ b/tests/integration_tests/test_shell_plate_rbe2.py
@@ -3,7 +3,7 @@ from mpi4py import MPI
 from tacs import TACS, elements, constitutive, functions
 from static_analysis_base_test import StaticTestCase
 
-"""
+r"""
 Create a two separate cantilevered plates connected by an RBE3 element.
 Apply a load at the RBE2 center node and test KSFailure, StructuralMass, 
 and Compliance functions and sensitivities

--- a/tests/integration_tests/test_shell_plate_rbe3.py
+++ b/tests/integration_tests/test_shell_plate_rbe3.py
@@ -3,7 +3,7 @@ from mpi4py import MPI
 from tacs import TACS, elements, constitutive, functions
 from static_analysis_base_test import StaticTestCase
 
-"""
+r"""
 Create a two separate cantilevered plates connected by an RBE3 element.
 Apply a load at the RBE3 center node and test KSFailure, StructuralMass, 
 and Compliance functions and sensitivities


### PR DESCRIPTION
Some characters in the docstring of a few of the tests lead to warnings like the following showing up:

```
/Users/trbrooks/git/tacs/tests/integration_tests/test_shell_plate_rbe3.py:6: DeprecationWarning: invalid escape sequence \
```
Making the docstring a literal fixes this