### PR TITLE
Avoid running format checks twice on PRs

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -1,6 +1,9 @@
 name: Lint
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   lint:

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,9 @@
 name: clang-format Check
 
-on: [push, pull_request]
+on: 
+  push:
+    branches: [ master ]
+  pull_request:
 
 jobs:
   formatting-check:


### PR DESCRIPTION
Currently, the formatting checks (black and clang-format) are setup to run on all pull requests and all pushes, this means that any commits that get pushed to a PR branch have the formatting checks run on them twice (e.g [here](https://github.com/smdogroup/tacs/pull/139/checks))

This PR fixes this by specifying that all PRs but only pushes to the master branch should have the formatting check run on them, which means that the checks will be run once on PRs and then again on the new master branch once a PR is merged. 

I also noticed that the unit testing action is only setup to run on PRs targeting the master branch, is this on-purpose or should we also enable that action for all PRs?