### PR TITLE
Adding maximum timeout of 30 min for unit tests CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -23,6 +23,7 @@ jobs:
     concurrency: ci-${{ github.ref }}
     # Run on Ubuntu
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     # Necessary to prevent mpi tests failing due to lack of slots
     env:
       OMPI_MCA_btl: self,tcp


### PR DESCRIPTION
- Should prevent cases with hanging runs