### PR TITLE
Adding TACS_DEF to make `real` recipe

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ default:
 	   echo "Building Real TACS"; \
 	   for subdir in $(TACS_SUBDIRS) ; do \
 	      echo "making $@ in $$subdir"; \
-	      echo; (cd $$subdir && $(MAKE) TACS_DIR=${TACS_DIR}) || exit 1; \
+	      echo; (cd $$subdir && $(MAKE) TACS_DIR=${TACS_DIR} TACS_DEF=${TACS_DEF}) || exit 1; \
             done \
 	fi
 	${CXX} ${SO_LINK_FLAGS} ${TACS_OBJS} ${TACS_EXTERN_LIBS} -o ${TACS_DIR}/lib/libtacs.${SO_EXT}

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ debug:
 	   echo "Building Real TACS"; \
 	   for subdir in $(TACS_SUBDIRS) ; do \
 	      echo "making $@ in $$subdir"; \
-	      echo; (cd $$subdir && $(MAKE) debug TACS_DIR=${TACS_DIR}) || exit 1; \
+	      echo; (cd $$subdir && $(MAKE) debug TACS_DIR=${TACS_DIR} TACS_DEF=${TACS_DEF}) || exit 1; \
             done \
 	fi
 	${CXX} ${SO_LINK_FLAGS} ${TACS_OBJS} ${TACS_EXTERN_LIBS} -o ${TACS_DIR}/lib/libtacs.${SO_EXT}

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -63,6 +63,7 @@ METIS_LIB = ${TACS_DIR}/extern/metis/lib/libmetis.a
 # AMD_DIR = ${SUITESPARSE_DIR}/AMD
 # AMD_INCLUDE = -I${AMD_DIR}/Include -I${SUITESPARSE_CONFIG_DIR}
 # AMD_LIBS = ${AMD_DIR}/Lib/libamd.a ${SUITESPARSE_CONFIG_DIR}/libsuitesparseconfig.a
+# TACS_DEF += -DTACS_HAS_AMD_LIBRARY
 
 # TECIO is a library for reading and writing tecplot data files, only required for building f5totec, can use either teciosrc or teciompisrc
 # TECIO_DIR = ${TACS_DIR}/extern/tecio/teciompisrc


### PR DESCRIPTION
- It appears TACS_DEF was only being passed for the complex build
- Also adding define flag for AMD library to `Makefile.in.info`