### PR TITLE
Adding decorator to protect pytacs pre/postinitialize methods

### DIFF
--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -43,7 +43,7 @@ def preinitialize_method(method):
         if self.assembler is not None:
             raise self._TACSError(
                 f"`{method.__name__}` is a pre-initialize method. "
-                "It may only be called before the 'initalize' method has been called."
+                "It may only be called before the 'initialize' method has been called."
             )
         else:
             return method(self, *args, **kwargs)
@@ -57,7 +57,7 @@ def postinitialize_method(method):
         if self.assembler is None:
             raise self._TACSError(
                 f"`{method.__name__}` is a post-initialize method. "
-                "It may only be called after the 'initalize' method has been called."
+                "It may only be called after the 'initialize' method has been called."
             )
         else:
             return method(self, *args, **kwargs)

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -37,6 +37,34 @@ from tacs.pymeshloader import pyMeshLoader
 warnings.simplefilter("default")
 
 
+# Define decorator functions for methods that must be called before initialize
+def preinitialize_method(method):
+    def wrapped_method(self, *args, **kwargs):
+        if self.assembler is not None:
+            raise self._TACSError(
+                f"`{method.__name__}` is a pre-initialize method. "
+                "It may only be called before the 'initalize' method has been called."
+            )
+        else:
+            return method(self, *args, **kwargs)
+
+    return wrapped_method
+
+
+# Define decorator functions for methods that must be called after initialize
+def postinitialize_method(method):
+    def wrapped_method(self, *args, **kwargs):
+        if self.assembler is None:
+            raise self._TACSError(
+                f"`{method.__name__}` is a post-initialize method. "
+                "It may only be called after the 'initalize' method has been called."
+            )
+        else:
+            return method(self, *args, **kwargs)
+
+    return wrapped_method
+
+
 class pyTACS(BaseUI):
     """
     The class for working with a TACS structure
@@ -232,6 +260,7 @@ class pyTACS(BaseUI):
             )
             self._pp("+--------------------------------------------------+")
 
+    @preinitialize_method
     def addGlobalDV(self, descript, value, lower=None, upper=None, scale=1.0):
         """
         This function allows adding design variables that are not
@@ -533,15 +562,13 @@ class pyTACS(BaseUI):
         nodeIDs : list
             List of unique nodeIDs that belong to the given list of compIDs
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         # Return all component ids
         if compIDs is None:
             compIDs = list(range(self.nComp))
 
         return self.meshLoader.getGlobalNodeIDsForComps(compIDs, nastranOrdering)
 
+    @postinitialize_method
     def getLocalNodeIDsForComps(self, compIDs):
         """
         return the local (partitioned) node IDs belonging to a given list of component IDs
@@ -557,9 +584,6 @@ class pyTACS(BaseUI):
         nodeIDs : list
             List of unique nodeIDs that belong to the given list of compIDs
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         # Return all component ids
         if compIDs is None:
             compIDs = list(range(self.nComp))
@@ -978,6 +1002,7 @@ class pyTACS(BaseUI):
 
         return elemCallBack
 
+    @postinitialize_method
     def getOrigDesignVars(self):
         """
         get the original design variables that were specified with
@@ -989,11 +1014,10 @@ class pyTACS(BaseUI):
             The current design variable vector set in tacs.
 
         """
-        if self.assembler is None:
-            raise self._initializeError()
 
         return self.x0.getArray().copy()
 
+    @postinitialize_method
     def createDesignVec(self, asBVec=False):
         """
         Create a new tacs distributed design vector.
@@ -1011,33 +1035,27 @@ class pyTACS(BaseUI):
         x : numpy.ndarray or TACS.Vec
             Distributed design variable vector
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         xVec = self.assembler.createDesignVec()
         if asBVec:
             return xVec
         else:
             return xVec.getArray()
 
+    @postinitialize_method
     def getNumDesignVars(self):
         """
         Return the number of design variables on this processor.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         return self.x0.getSize()
 
+    @postinitialize_method
     def getTotalNumDesignVars(self):
         """
         Return the number of design variables across all processors.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         return self.dvNum
 
+    @postinitialize_method
     def getOrigNodes(self):
         """
         Return the original mesh coordiantes read in from the meshLoader.
@@ -1048,11 +1066,9 @@ class pyTACS(BaseUI):
             Structural coordinate in array of size (N * 3) where N is
             the number of structural nodes on this processor.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         return self.Xpts0.getArray().copy()
 
+    @postinitialize_method
     def createNodeVec(self, asBVec=False):
         """
         Create a new tacs distributed node vector.
@@ -1070,8 +1086,6 @@ class pyTACS(BaseUI):
         xpts : numpy.ndarray or TACS.Vec
             Distributed node coordinate vector
         """
-        if self.assembler is None:
-            raise self._initializeError()
 
         xptVec = self.assembler.createNodeVec()
         if asBVec:
@@ -1079,31 +1093,28 @@ class pyTACS(BaseUI):
         else:
             return xptVec.getArray()
 
+    @postinitialize_method
     def getNumOwnedNodes(self):
         """
         Get the number of nodes owned by this processor.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         return self.assembler.getNumOwnedNodes()
 
+    @postinitialize_method
     def getNumOwnedMultiplierNodes(self):
         """
         Get number of multiplier nodes owned by this processor.
         """
-        if self.assembler is None:
-            raise self._initializeError()
         return len(self.meshLoader.getLocalMultiplierNodeIDs())
 
+    @postinitialize_method
     def getLocalMultiplierNodeIDs(self):
         """
         Get the tacs indices of multiplier nodes used to hold lagrange multipliers on this processor.
         """
-        if self.assembler is None:
-            raise self._initializeError()
         return self.meshLoader.getLocalMultiplierNodeIDs()
 
+    @postinitialize_method
     def createVec(self, asBVec=False):
         """
         Create a new tacs distributed state variable vector.
@@ -1121,31 +1132,24 @@ class pyTACS(BaseUI):
         vars : numpy.ndarray or TACS.Vec
             Distributed state variable vector
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         vars = self.assembler.createVec()
         if asBVec:
             return vars
         else:
             return vars.getArray()
 
+    @postinitialize_method
     def getVarsPerNode(self):
         """
         Get the number of variables per node for the model.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         return self.assembler.getVarsPerNode()
 
+    @postinitialize_method
     def applyBCsToVec(self, vec):
         """
         Applies zeros to boundary condition dofs in input vector.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         varVec = self.assembler.createVec()
         varArray = varVec.getArray()
 
@@ -1163,6 +1167,7 @@ class pyTACS(BaseUI):
             # Copy values back to array
             array[:] = vec.getArray()
 
+    @postinitialize_method
     def createStaticProblem(self, name, options={}):
         """
         Create a new staticProblem for modeling a static load cases.
@@ -1181,9 +1186,6 @@ class pyTACS(BaseUI):
         problem : StaticProblem
             StaticProblem object used for modeling and solving static cases.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         problem = tacs.problems.static.StaticProblem(
             name, self.assembler, self.comm, self.outputViewer, self.meshLoader, options
         )
@@ -1192,6 +1194,7 @@ class pyTACS(BaseUI):
         problem.setNodes(self.Xpts0)
         return problem
 
+    @postinitialize_method
     def createTransientProblem(self, name, tInit, tFinal, numSteps, options={}):
         """
         Create a new TransientProblem for modeling a transient load cases.
@@ -1216,9 +1219,6 @@ class pyTACS(BaseUI):
         problem : TransientProblem
             TransientProblem object used for modeling and solving transient cases.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         problem = tacs.problems.transient.TransientProblem(
             name,
             tInit,
@@ -1235,6 +1235,7 @@ class pyTACS(BaseUI):
         problem.setNodes(self.Xpts0)
         return problem
 
+    @postinitialize_method
     def createModalProblem(self, name, sigma, numEigs, options={}):
         """
         Create a new ModalProblem for performing modal analysis.
@@ -1258,9 +1259,6 @@ class pyTACS(BaseUI):
         problem : ModalProblem
             ModalProblem object used for performing modal eigenvalue analysis.
         """
-        if self.assembler is None:
-            raise self._initializeError()
-
         problem = tacs.problems.modal.ModalProblem(
             name,
             sigma,
@@ -1276,6 +1274,7 @@ class pyTACS(BaseUI):
         problem.setNodes(self.Xpts0)
         return problem
 
+    @postinitialize_method
     def createTACSProbsFromBDF(self):
         """
         Automatically define tacs problem classes with loads using information contained in BDF file.
@@ -1293,10 +1292,6 @@ class pyTACS(BaseUI):
         Currently only supports LOAD, FORCE, MOMENT, GRAV, RFORCE, PLOAD2, PLOAD4, TLOAD1, TLOAD2, and DLOAD cards.
         Currently only supports staticProblem (SOL 101), transientProblem (SOL 109), and modalProblems (SOL 103)
         """
-
-        if self.assembler is None:
-            raise self._initializeError()
-
         # Make sure cross-referencing is turned on in pynastran
         if self.bdfInfo.is_xrefed is False:
             self.bdfInfo.cross_reference()
@@ -1679,16 +1674,6 @@ class pyTACS(BaseUI):
         # Default to 6
         if self.varsPerNode is None:
             self.varsPerNode = 6
-
-    def _initializeError(self):
-        """
-        Standard error print out if the user tries to call certain pytacs methods before intializing.
-        """
-        error = self._TACSError(
-            "TACS assembler has not been created. "
-            "Assembler must created first by running 'initalize' method."
-        )
-        return error
 
 
 def _tload2_get_load_at_time(tload2, time, scale=1.0):

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1014,7 +1014,6 @@ class pyTACS(BaseUI):
             The current design variable vector set in tacs.
 
         """
-
         return self.x0.getArray().copy()
 
     @postinitialize_method
@@ -1150,9 +1149,6 @@ class pyTACS(BaseUI):
         """
         Applies zeros to boundary condition dofs in input vector.
         """
-        varVec = self.assembler.createVec()
-        varArray = varVec.getArray()
-
         # Check if input is a BVec or numpy array
         if isinstance(vec, tacs.TACS.Vec):
             self.assembler.applyBCs(vec)


### PR DESCRIPTION
The decorator automatically checks if the assembler is or isn't initialized before the method and raises an error correspondingly

Methods not protected by decorators are safe to call at any time