### PR TITLE
Improving RBE accuracy for static problems

### DIFF
--- a/src/elements/shell/TACSRBE2.cpp
+++ b/src/elements/shell/TACSRBE2.cpp
@@ -36,8 +36,7 @@
 /*
   Create the RBE2.
 */
-TACSRBE2::TACSRBE2(int _numNodes, int _dof_constrained[], double _C1,
-                   double _C2) {
+TACSRBE2::TACSRBE2(int _numNodes, int _dof_constrained[]) {
   NUM_NODES = _numNodes;  // Number of nodes (1 indep node + N dep nodes + N
                           // dummy nodes)
   NUM_DEP_NODES = (NUM_NODES - 1) / 2;
@@ -51,10 +50,6 @@ TACSRBE2::TACSRBE2(int _numNodes, int _dof_constrained[], double _C1,
       dof_constrained[j][i] = _dof_constrained[NUM_DISPS * j + i];
     }
   }
-
-  // Default scaling and artificial stiffness parameters
-  C1 = _C1;
-  C2 = _C2;
 }
 
 TACSRBE2::~TACSRBE2() {
@@ -64,6 +59,15 @@ TACSRBE2::~TACSRBE2() {
     }
     delete[] dof_constrained;
   }
+}
+
+// Default scaling and artificial stiffness parameters
+double TACSRBE2::C1 = 1e3;
+double TACSRBE2::C2 = 1e-3;
+
+void TACSRBE2::setScalingParameters(double _C1, double _C2) {
+  C1 = _C1;
+  C2 = _C2;
 }
 
 /*

--- a/src/elements/shell/TACSRBE2.h
+++ b/src/elements/shell/TACSRBE2.h
@@ -16,9 +16,10 @@
 
 class TACSRBE2 : public TACSElement {
  public:
-  TACSRBE2(int _numNodes, int _dof_constrained[], double _C1 = 1e3,
-           double _C2 = 1e-3);
+  TACSRBE2(int _numNodes, int _dof_constrained[]);
   ~TACSRBE2();
+
+  static void setScalingParameters(double _C1, double _C2);
 
   // Info for BDF writer
   // -------------------
@@ -94,9 +95,9 @@ class TACSRBE2 : public TACSElement {
   int** dof_constrained;
 
   // constraint matrix scaling factor, see ref [2]
-  double C1;
+  static double C1;
   // artificial stiffness scaling factor, see ref [2]
-  double C2;
+  static double C2;
 };
 
 #endif

--- a/src/elements/shell/TACSRBE3.cpp
+++ b/src/elements/shell/TACSRBE3.cpp
@@ -43,7 +43,7 @@
   Create the RBE3.
 */
 TACSRBE3::TACSRBE3(int numNodes, int _dep_dof_constrained[], double weights[],
-                   int _indep_dof_constrained[], double _C1, double _C2) {
+                   int _indep_dof_constrained[]) {
   NUM_NODES =
       numNodes;  // Number of nodes (1 dep node + N indep nodes + 1 dummy node)
   NUM_INDEP_NODES = NUM_NODES - 2;
@@ -62,10 +62,6 @@ TACSRBE3::TACSRBE3(int numNodes, int _dep_dof_constrained[], double weights[],
       indep_dof_constrained[j][i] = _indep_dof_constrained[NUM_DISPS * j + i];
     }
   }
-
-  // Default scaling and artificial stiffness parameters
-  C1 = _C1;
-  C2 = _C2;
 }
 
 TACSRBE3::~TACSRBE3() {
@@ -78,6 +74,15 @@ TACSRBE3::~TACSRBE3() {
     }
     delete[] indep_dof_constrained;
   }
+}
+
+// Default scaling and artificial stiffness parameters
+double TACSRBE3::C1 = 1e3;
+double TACSRBE3::C2 = 1e-3;
+
+void TACSRBE3::setScalingParameters(double _C1, double _C2) {
+  C1 = _C1;
+  C2 = _C2;
 }
 
 /*

--- a/src/elements/shell/TACSRBE3.h
+++ b/src/elements/shell/TACSRBE3.h
@@ -17,8 +17,10 @@
 class TACSRBE3 : public TACSElement {
  public:
   TACSRBE3(int numNodes, int _dep_dof_constrained[], double weights[],
-           int _indep_dof_constrained[], double _C1 = 1e3, double _C2 = 1e-3);
+           int _indep_dof_constrained[]);
   ~TACSRBE3();
+
+  static void setScalingParameters(double _C1, double _C2);
 
   // Info for BDF writer
   // -------------------
@@ -112,9 +114,9 @@ class TACSRBE3 : public TACSElement {
   int** indep_dof_constrained;
 
   // constraint matrix scaling factor, see ref [2]
-  double C1;
+  static double C1;
   // artificial stiffness scaling factor, see ref [2]
-  double C2;
+  static double C2;
   // Tolerance used in colinearity test
   static const double SMALL_NUM;
 };

--- a/tacs/elements.pxd
+++ b/tacs/elements.pxd
@@ -371,11 +371,15 @@ cdef extern from "TACSKinematicConstraints.h":
 
 cdef extern from "TACSRBE2.h":
     cdef cppclass TACSRBE2(TACSElement):
-        TACSRBE2(int, int*, double, double)
+        TACSRBE2(int, int*)
+        @ staticmethod
+        void setScalingParameters(double, double)
 
 cdef extern from "TACSRBE3.h":
     cdef cppclass TACSRBE3(TACSElement):
-        TACSRBE3(int, int*, double*, int*, double, double)
+        TACSRBE3(int, int*, double*, int*)
+        @staticmethod
+        void setScalingParameters(double, double)
 
 cdef extern from "TACSMassElement.h":
     cdef cppclass TACSMassElement(TACSElement):

--- a/tacs/elements.pxd
+++ b/tacs/elements.pxd
@@ -372,7 +372,7 @@ cdef extern from "TACSKinematicConstraints.h":
 cdef extern from "TACSRBE2.h":
     cdef cppclass TACSRBE2(TACSElement):
         TACSRBE2(int, int*)
-        @ staticmethod
+        @staticmethod
         void setScalingParameters(double, double)
 
 cdef extern from "TACSRBE3.h":

--- a/tacs/elements.pyx
+++ b/tacs/elements.pyx
@@ -1322,12 +1322,11 @@ cdef class RBE2(Element):
     Args:
         num_nodes (int): Total number of nodes associated with the element.
         constrained_dofs (numpy.ndarray[int]): Flags to determine which
-          dependent node dof's are attached to the eleemnt.
+          dependent node dof's are attached to the element.
     """
     cdef TACSRBE2 *cptr
     def __cinit__(self, int num_nodes,
-                  np.ndarray[int, ndim=1, mode='c'] constrained_dofs,
-                  double C1=1e3, double C2=1e-3):
+                  np.ndarray[int, ndim=1, mode='c'] constrained_dofs):
         num_dep = (num_nodes - 1) / 2
 
         assert len(constrained_dofs) == 6 or len(constrained_dofs) == 6 * num_dep
@@ -1336,10 +1335,23 @@ cdef class RBE2(Element):
         if len(constrained_dofs) == 6:
             constrained_dofs = np.tile(constrained_dofs, num_dep)
 
-        self.cptr = new TACSRBE2(num_nodes, <int*>constrained_dofs.data, C1, C2)
+        self.cptr = new TACSRBE2(num_nodes, <int*>constrained_dofs.data)
         # Increase the reference count to the underlying object
         self.ptr = self.cptr
         self.ptr.incref()
+        return
+
+    @classmethod
+    def setScalingParameters(cls, double C1=1e3, double C2=0.0):
+        """
+        Set scaling parameters used in Lagrange multiplier formulation of the element.
+
+        Args:
+            C1 (double): Constraint matrix scaling factor used in RBE Lagrange multiplier stiffness matrix.
+            C2 (double): Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix
+            to stabilize preconditioner.
+        """
+        TACSRBE2.setScalingParameters(C1, C2)
         return
 
 cdef class RBE3(Element):
@@ -1362,14 +1374,13 @@ cdef class RBE3(Element):
           dependent node dof's are attached to the eleemnt.
         weights (numpy.ndarray[float]): RBE weighting factor for each independent node.
         indep_constrained_dofs (numpy.ndarray[int]): Flags to determine which
-          independent node dof's are attached to the eleemnt.
+          independent node dof's are attached to the element.
     """
     cdef TACSRBE3 *cptr
     def __cinit__(self, int num_nodes,
                   np.ndarray[int, ndim=1, mode='c'] dep_constrained_dofs,
                   np.ndarray[double, ndim=1, mode='c'] weights,
-                  np.ndarray[int, ndim=1, mode='c'] indep_constrained_dofs,
-                  double C1=1e3, double C2=1e-3):
+                  np.ndarray[int, ndim=1, mode='c'] indep_constrained_dofs):
         num_indep = num_nodes - 2
 
         assert len(dep_constrained_dofs) == 6
@@ -1383,10 +1394,23 @@ cdef class RBE3(Element):
             indep_constrained_dofs = np.tile(indep_constrained_dofs, num_indep)
 
         self.cptr = new TACSRBE3(num_nodes, <int*>dep_constrained_dofs.data,
-                                 <double*>weights.data, <int*>indep_constrained_dofs.data, C1, C2)
+                                 <double*>weights.data, <int*>indep_constrained_dofs.data)
         # Increase the reference count to the underlying object
         self.ptr = self.cptr
         self.ptr.incref()
+        return
+
+    @classmethod
+    def setScalingParameters(cls, double C1=1e3, double C2=0.0):
+        """
+        Set scaling parameters used in Lagrange multiplier formulation of the element.
+
+        Args:
+            C1 (double): Constraint matrix scaling factor used in RBE Lagrange multiplier stiffness matrix.
+            C2 (double): Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix
+            to stabilize preconditioner.
+        """
+        TACSRBE3.setScalingParameters(C1, C2)
         return
 
 cdef class MassElement(Element):

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -316,7 +316,7 @@ class TACSProblem(BaseUI):
     ####### Load adding methods ########
 
     def _addLoadToComponents(self, FVec, compIDs, F, averageLoad=False):
-        """ "
+        """
         This is an internal helper function for doing the addLoadToComponents method for
         inherited TACSProblem classes. The function should NOT be called by the user should
         use the addLoadToComponents method for the respective problem class. The function is
@@ -521,7 +521,7 @@ class TACSProblem(BaseUI):
                 )
 
     def _addLoadToRHS(self, Frhs, Fapplied):
-        """ "
+        """
         This is an internal helper function for doing the addLoadToRHS method for
         inherited TACSProblem classes. The function should NOT be called by the user should
         use the addLoadToRHS method for the respective problem class.

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -348,7 +348,7 @@ class TACSProblem(BaseUI):
         -----
 
         The units of the entries of the 'force' vector F are not
-        necesarily physical forces and their interpretation depends
+        necessarily physical forces and their interpretation depends
         on the physics problem being solved and the dofs included
         in the model.
 
@@ -440,7 +440,7 @@ class TACSProblem(BaseUI):
         ----------
 
         The units of the entries of the 'force' vector F are not
-        necesarily physical forces and their interpretation depends
+        necessarily physical forces and their interpretation depends
         on the physics problem being solved and the dofs included
         in the model.
 

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -40,8 +40,8 @@ class ModalProblem(TACSProblem):
         "RBEArtificialStiffness": [
             float,
             1e-3,
-            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix "
-            "to stabilize preconditioner.",
+            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix \n"
+            "\t to stabilize preconditioner.",
         ],
         "subSpaceSize": [
             int,

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -64,8 +64,8 @@ class StaticProblem(TACSProblem):
         "RBEArtificialStiffness": [
             float,
             1e-3,
-            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix "
-            "to stabilize preconditioner.",
+            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix \n"
+            "\t to stabilize preconditioner.",
         ],
         "useMonitor": [
             bool,
@@ -344,7 +344,7 @@ class StaticProblem(TACSProblem):
     ####### Load adding methods ########
 
     def addLoadToComponents(self, compIDs, F, averageLoad=False):
-        """ "
+        """
         This method is used to add a *FIXED TOTAL LOAD* on one or more
         components, defined by COMPIDs. The purpose of this routine is to add loads that
         remain fixed throughout an optimization. An example would be an engine load.
@@ -434,7 +434,7 @@ class StaticProblem(TACSProblem):
         self._addLoadToNodes(self.F, nodeIDs, F, nastranOrdering)
 
     def addLoadToRHS(self, Fapplied):
-        """ "
+        """
         This method is used to add a *FIXED TOTAL LOAD* directly to the
         right hand side vector given the equation below:
 

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -163,7 +163,7 @@ class StaticProblem(TACSProblem):
         # State variable vector
         self.u = self.assembler.createVec()
         self.u_array = self.u.getArray()
-        # Auxillary element object for applying tractions/pressure
+        # Auxiliary element object for applying tractions/pressure
         self.auxElems = tacs.TACS.AuxElements()
         self.callCounter = -1
 
@@ -371,7 +371,7 @@ class StaticProblem(TACSProblem):
         ----------
 
         The units of the entries of the 'force' vector F are not
-        necesarily physical forces and their interpretation depends
+        necessarily physical forces and their interpretation depends
         on the physics problem being solved and the dofs included
         in the model.
 
@@ -413,7 +413,7 @@ class StaticProblem(TACSProblem):
         ----------
 
         The units of the entries of the 'force' vector F are not
-        necesarily physical forces and their interpretation depends
+        necessarily physical forces and their interpretation depends
         on the physics problem being solved and the dofs included
         in the model.
 
@@ -688,7 +688,7 @@ class StaticProblem(TACSProblem):
         # Set initnorm as the norm of rhs
         self.initNorm = np.real(self.rhs.norm())
 
-        # Starting Norm for this compuation
+        # Starting Norm for this computation
         self.startNorm = np.real(self.res.norm())
 
         initNormTime = time.time()

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -49,8 +49,8 @@ class TransientProblem(TACSProblem):
         "RBEArtificialStiffness": [
             float,
             1e-3,
-            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix "
-            "to stabilize preconditioner.",
+            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix \n"
+            "\t to stabilize preconditioner.",
         ],
         "jacAssemblyFreq": [
             int,
@@ -351,7 +351,7 @@ class TransientProblem(TACSProblem):
     def addLoadToComponents(
         self, timeStep, compIDs, F, timeStage=None, averageLoad=False
     ):
-        """ "
+        """
         This method is used to add a *FIXED TOTAL LOAD* on one or more
         components, defined by COMPIDs, at a specific time instance.
         The purpose of this routine is to add loads that remain fixed throughout
@@ -479,7 +479,7 @@ class TransientProblem(TACSProblem):
         self._addLoadToNodes(self.F[timeIndex], nodeIDs, F, nastranOrdering)
 
     def addLoadToRHS(self, timeStep, Fapplied, timeStage=None):
-        """ "
+        """
         This method is used to add a *FIXED TOTAL LOAD* directly to the
         right hand side vector given the equation below:
 

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -41,6 +41,17 @@ class TransientProblem(TACSProblem):
             1e-12,
             "Relative convergence tolerance for integrator based on l2 norm of residual.",
         ],
+        "RBEStiffnessScaleFactor": [
+            float,
+            1e3,
+            "Constraint matrix scaling factor used in RBE Lagrange multiplier stiffness matrix.",
+        ],
+        "RBEArtificialStiffness": [
+            float,
+            1e-3,
+            "Artificial constant added to diagonals of RBE Lagrange multiplier stiffness matrix "
+            "to stabilize preconditioner.",
+        ],
         "jacAssemblyFreq": [
             int,
             1,
@@ -864,6 +875,11 @@ class TransientProblem(TACSProblem):
         self.assembler.setInitConditions(
             vec=self.vars0, dvec=self.dvars0, ddvec=self.ddvars0
         )
+        # Set artificial stiffness factors in rbe class
+        c1 = self.getOption("RBEStiffnessScaleFactor")
+        c2 = self.getOption("RBEArtificialStiffness")
+        tacs.elements.RBE2.setScalingParameters(c1, c2)
+        tacs.elements.RBE3.setScalingParameters(c1, c2)
 
     def solve(self):
         """

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -282,7 +282,7 @@ class TransientProblem(TACSProblem):
 
     def getNumTimeSteps(self):
         """
-        Get the number of timesteps used in time integration for this problem.
+        Get the number of time steps used in time integration for this problem.
 
         Returns
         ----------
@@ -449,7 +449,7 @@ class TransientProblem(TACSProblem):
         -----
 
         The units of the entries of the 'force' vector F are not
-        necesarily physical forces and their interpretation depends
+        necessarily physical forces and their interpretation depends
         on the physics problem being solved and the dofs included
         in the model.
 

--- a/tests/element_tests/shell_tests/test_rbe2.py
+++ b/tests/element_tests/shell_tests/test_rbe2.py
@@ -15,8 +15,9 @@ class ElementTest(unittest.TestCase):
 
         # Set artificial stiffness term to zero,
         # since we know it adds error to the sensitivities
-        self.C1 = 1e6
-        self.C2 = 0.0
+        C1 = 1e6
+        C2 = 0.0
+        elements.RBE2.setScalingParameters(C1, C2)
 
         # fd/cs step size
         if TACS.dtype is complex:
@@ -75,7 +76,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and test Jacobian
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 fail = elements.TestElementJacobian(
                     element,
                     self.elem_index,
@@ -96,7 +97,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and test adjoint residual-dvsens product
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 dvs = element.getDesignVars(self.elem_index)
                 fail = elements.TestAdjResProduct(
                     element,
@@ -118,7 +119,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and test adjoint residual-xptsens product
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 fail = elements.TestAdjResXptProduct(
                     element,
                     self.elem_index,
@@ -138,7 +139,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and element matrix inner product sens
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 dvs = element.getDesignVars(self.elem_index)
                 for matrix_type in self.matrix_types:
                     with self.subTest(matrix_type=matrix_type):
@@ -161,7 +162,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and element matrix inner product sens
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 for matrix_type in self.matrix_types:
                     with self.subTest(matrix_type=matrix_type):
                         fail = elements.TestElementMatXptSens(
@@ -182,7 +183,7 @@ class ElementTest(unittest.TestCase):
         # Loop through each combination of dof constraints and test element matrix inner product sens
         for dep_dofs in self.dep_dofs_constrained:
             with self.subTest(dep_dofs=dep_dofs):
-                element = elements.RBE2(self.num_nodes, dep_dofs, self.C1, self.C2)
+                element = elements.RBE2(self.num_nodes, dep_dofs)
                 for matrix_type in self.matrix_types:
                     with self.subTest(matrix_type=matrix_type):
                         fail = elements.TestElementMatSVSens(

--- a/tests/element_tests/shell_tests/test_rbe3.py
+++ b/tests/element_tests/shell_tests/test_rbe3.py
@@ -15,8 +15,9 @@ class ElementTest(unittest.TestCase):
 
         # Set artificial stiffness term to zero,
         # since we know it adds error to the sensitivities
-        self.C1 = 1e6
-        self.C2 = 0.0
+        C1 = 1e6
+        C2 = 0.0
+        elements.RBE3.setScalingParameters(C1, C2)
 
         # fd/cs step size
         if TACS.dtype is complex:
@@ -83,12 +84,7 @@ class ElementTest(unittest.TestCase):
                 for indep_dofs in self.indep_dofs_constrained:
                     with self.subTest(indep_dofs=indep_dofs):
                         element = elements.RBE3(
-                            self.num_nodes,
-                            dep_dofs,
-                            self.indep_weights,
-                            indep_dofs,
-                            self.C1,
-                            self.C2,
+                            self.num_nodes, dep_dofs, self.indep_weights, indep_dofs
                         )
                         fail = elements.TestElementJacobian(
                             element,
@@ -113,12 +109,7 @@ class ElementTest(unittest.TestCase):
                 for indep_dofs in self.indep_dofs_constrained:
                     with self.subTest(indep_dofs=indep_dofs):
                         element = elements.RBE3(
-                            self.num_nodes,
-                            dep_dofs,
-                            self.indep_weights,
-                            indep_dofs,
-                            self.C1,
-                            self.C2,
+                            self.num_nodes, dep_dofs, self.indep_weights, indep_dofs
                         )
                         dvs = element.getDesignVars(self.elem_index)
                         fail = elements.TestAdjResProduct(
@@ -144,12 +135,7 @@ class ElementTest(unittest.TestCase):
                 for indep_dofs in self.indep_dofs_constrained:
                     with self.subTest(indep_dofs=indep_dofs):
                         element = elements.RBE3(
-                            self.num_nodes,
-                            dep_dofs,
-                            self.indep_weights,
-                            indep_dofs,
-                            self.C1,
-                            self.C2,
+                            self.num_nodes, dep_dofs, self.indep_weights, indep_dofs
                         )
                         fail = elements.TestAdjResXptProduct(
                             element,
@@ -173,12 +159,7 @@ class ElementTest(unittest.TestCase):
                 for indep_dofs in self.indep_dofs_constrained:
                     with self.subTest(indep_dofs=indep_dofs):
                         element = elements.RBE3(
-                            self.num_nodes,
-                            dep_dofs,
-                            self.indep_weights,
-                            indep_dofs,
-                            self.C1,
-                            self.C2,
+                            self.num_nodes, dep_dofs, self.indep_weights, indep_dofs
                         )
                         dvs = element.getDesignVars(self.elem_index)
                         for matrix_type in self.matrix_types:
@@ -205,12 +186,7 @@ class ElementTest(unittest.TestCase):
                 for indep_dofs in self.indep_dofs_constrained:
                     with self.subTest(indep_dofs=indep_dofs):
                         element = elements.RBE3(
-                            self.num_nodes,
-                            dep_dofs,
-                            self.indep_weights,
-                            indep_dofs,
-                            self.C1,
-                            self.C2,
+                            self.num_nodes, dep_dofs, self.indep_weights, indep_dofs
                         )
 
                         for matrix_type in self.matrix_types:
@@ -242,8 +218,6 @@ class ElementTest(unittest.TestCase):
                                     dep_dofs,
                                     self.indep_weights,
                                     indep_dofs,
-                                    self.C1,
-                                    self.C2,
                                 )
                                 fail = elements.TestElementMatSVSens(
                                     element,

--- a/tests/integration_tests/input_files/rbe_test.bdf
+++ b/tests/integration_tests/input_files/rbe_test.bdf
@@ -1,0 +1,112 @@
+SOL 101
+CEND
+ECHO = NONE
+SUBCASE 1
+   SPC = 1
+   LOAD = 1
+   DISPLACEMENT=ALL
+   SPCFORCES=ALL
+   MPCFORCE=ALL
+BEGIN BULK
+PARAM    POST    -1
+$
+PSHELL   1       1       .2      1               1
+$
+CQUAD4   1       1       1       2       7       6
+CQUAD4   2       1       2       3       8       7
+CQUAD4   3       1       3       4       9       8
+CQUAD4   4       1       4       5       10      9
+CQUAD4   5       1       6       7       12      11
+CQUAD4   6       1       7       8       13      12
+CQUAD4   7       1       8       9       14      13
+CQUAD4   8       1       9       10      15      14
+CQUAD4   9       1       11      12      17      16
+CQUAD4   10      1       12      13      18      17
+CQUAD4   11      1       13      14      19      18
+CQUAD4   12      1       14      15      20      19
+CQUAD4   13      1       16      17      22      21
+CQUAD4   14      1       17      18      23      22
+CQUAD4   15      1       18      19      24      23
+CQUAD4   16      1       19      20      25      24
+CQUAD4   17      1       26      27      32      31
+CQUAD4   18      1       27      28      33      32
+CQUAD4   19      1       28      29      34      33
+CQUAD4   20      1       29      30      35      34
+CQUAD4   21      1       31      32      37      36
+CQUAD4   22      1       32      33      38      37
+CQUAD4   23      1       33      34      39      38
+CQUAD4   24      1       34      35      40      39
+CQUAD4   25      1       36      37      42      41
+CQUAD4   26      1       37      38      43      42
+CQUAD4   27      1       38      39      44      43
+CQUAD4   28      1       39      40      45      44
+CQUAD4   29      1       41      42      47      46
+CQUAD4   30      1       42      43      48      47
+CQUAD4   31      1       43      44      49      48
+CQUAD4   32      1       44      45      50      49
+$
+MAT1           1   7.+10              .3   2700.      0.      0.        +
++          2.7+8
+$
+RBE2     33      1000    123456  5       10      15      20      25     +      A
++      A 26      31      36      41      46
+$
+GRID     1               0.      0.      0.
+GRID     2               2.5     0.      0.
+GRID     3               5.      0.      0.
+GRID     4               7.5     0.      0.
+GRID     5               10.     0.      0.
+GRID     6               0.      2.5     0.
+GRID     7               2.5     2.5     0.
+GRID     8               5.      2.5     0.
+GRID     9               7.5     2.5     0.
+GRID     10              10.     2.5     0.
+GRID     11              0.      5.      0.
+GRID     12              2.5     5.      0.
+GRID     13              5.      5.      0.
+GRID     14              7.5     5.      0.
+GRID     15              10.     5.      0.
+GRID     16              0.      7.5     0.
+GRID     17              2.5     7.5     0.
+GRID     18              5.      7.5     0.
+GRID     19              7.5     7.5     0.
+GRID     20              10.     7.5     0.
+GRID     21              0.      10.     0.
+GRID     22              2.5     10.     0.
+GRID     23              5.      10.     0.
+GRID     24              7.5     10.     0.
+GRID     25              10.     10.     0.
+GRID     26              20.     0.      0.
+GRID     27              22.5    0.      0.
+GRID     28              25.     0.      0.
+GRID     29              27.5    0.      0.
+GRID     30              30.     0.      0.
+GRID     31              20.     2.5     0.
+GRID     32              22.5    2.5     0.
+GRID     33              25.     2.5     0.
+GRID     34              27.5    2.5     0.
+GRID     35              30.     2.5     0.
+GRID     36              20.     5.      0.
+GRID     37              22.5    5.      0.
+GRID     38              25.     5.      0.
+GRID     39              27.5    5.      0.
+GRID     40              30.     5.      0.
+GRID     41              20.     7.5     0.
+GRID     42              22.5    7.5     0.
+GRID     43              25.     7.5     0.
+GRID     44              27.5    7.5     0.
+GRID     45              30.     7.5     0.
+GRID     46              20.     10.     0.
+GRID     47              22.5    10.     0.
+GRID     48              25.     10.     0.
+GRID     49              27.5    10.     0.
+GRID     50              30.     10.     0.
+GRID     1000            15.     5.      0.
+$
+SPC1     1       123456  1       6       11      16      21      30     +      B
++      B 35      40      45      50
+$
+FORCE    1       1000    0       1.e6    1.e2    0.      1.
+MOMENT   1       1000    0       1.e6    0.      0.      1.e2
+$
+ENDDATA

--- a/tests/integration_tests/test_shell_plate_rbe2.py
+++ b/tests/integration_tests/test_shell_plate_rbe2.py
@@ -166,7 +166,8 @@ class ProblemTest(StaticTestCase.StaticTest):
         dep_dofs = np.array([1, 1, 1, 1, 1, 1], np.intc)
         # Set the artificial stiffness to be low to pass the sensitivity tests
         # This will affect the accuracy of the element behavior
-        rbe = elements.RBE2(num_rbe_nodes, dep_dofs, C1=1e2, C2=1e-1)
+        elements.RBE2.setScalingParameters(1e2, 1e-1)
+        rbe = elements.RBE2(num_rbe_nodes, dep_dofs)
         # Set the elements for each (only two) component
         element_list = [shell, rbe]
         creator.setElements(element_list)

--- a/tests/integration_tests/test_shell_plate_rbe2.py
+++ b/tests/integration_tests/test_shell_plate_rbe2.py
@@ -4,7 +4,7 @@ from tacs import TACS, elements, constitutive, functions
 from static_analysis_base_test import StaticTestCase
 
 r"""
-Create a two separate cantilevered plates connected by an RBE3 element.
+Create a two separate cantilevered plates connected by an RBE2 element.
 Apply a load at the RBE2 center node and test KSFailure, StructuralMass, 
 and Compliance functions and sensitivities
 -----------        ----------- 

--- a/tests/integration_tests/test_shell_plate_rbe2_pytacs.py
+++ b/tests/integration_tests/test_shell_plate_rbe2_pytacs.py
@@ -42,7 +42,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         if self.dtype == complex:
             self.rtol = 5e-6
             self.atol = 1e-8
-            self.dh = 1e-9
+            self.dh = 1e-10
         else:
             self.rtol = 2e-1
             self.atol = 1e-3

--- a/tests/integration_tests/test_shell_plate_rbe2_pytacs.py
+++ b/tests/integration_tests/test_shell_plate_rbe2_pytacs.py
@@ -1,0 +1,76 @@
+import os
+from tacs import pytacs, functions
+from pytacs_analysis_base_test import PyTACSTestCase
+
+r"""
+Load a  structural model featuring two separate cantilevered plates connected by an RBE2 element.
+Apply a load at the RBE2 center node and test KSFailure, StructuralMass, 
+and Compliance functions and sensitivities. This is similar to test_shell_plate_rbe2.py, 
+except it is run through the pytacs interface.
+-----------        ----------- 
+|          |\    /|          |
+|          | \  / |          |
+| Plate 1  |__\/__| Plate 2  |
+|          |  /\  |          |
+|          | /  \ |          |
+|          |/    \|          |
+------------       -----------
+"""
+base_dir = os.path.dirname(os.path.abspath(__file__))
+bdf_file = os.path.join(base_dir, "./input_files/rbe_test.bdf")
+
+# KS function weight
+ksweight = 10.0
+
+
+class ProblemTest(PyTACSTestCase.PyTACSTest):
+    N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
+
+    FUNC_REFS = {
+        "load_set_001_compliance": 424230.1227524751,
+        "load_set_001_ks_disp": 0.5735091934240975,
+        "load_set_001_ks_vmfailure": 0.6843335686556009,
+        "load_set_001_mass": 108000.0,
+    }
+
+    def setup_tacs_problems(self, comm):
+        """
+        Setup pytacs object for problems we will be testing.
+        """
+
+        # Overwrite default check values
+        if self.dtype == complex:
+            self.rtol = 5e-6
+            self.atol = 1e-8
+            self.dh = 1e-9
+        else:
+            self.rtol = 2e-1
+            self.atol = 1e-3
+            self.dh = 1e-6
+
+        # Instantiate FEA Assembler
+        struct_options = {}
+
+        fea_assembler = pytacs.pyTACS(bdf_file, comm, options=struct_options)
+
+        # Set up constitutive objects and elements
+        fea_assembler.initialize()
+
+        # Create case 1 static problem from bdf file
+        problems = fea_assembler.createTACSProbsFromBDF()
+
+        for problem in problems.values():
+            problem.addFunction("mass", functions.StructuralMass)
+            problem.addFunction("ks_vmfailure", functions.KSFailure, ksWeight=ksweight)
+            problem.addFunction("compliance", functions.Compliance)
+            problem.addFunction(
+                "ks_disp",
+                functions.KSDisplacement,
+                ksWeight=ksweight,
+                direction=[1.0, 1.0, 1.0],
+            )
+            # Set convergence tol to be tight
+            problem.setOption("L2Convergence", 1e-20)
+            problem.setOption("L2ConvergenceRel", 1e-20)
+
+        return problems.values(), fea_assembler


### PR DESCRIPTION
The RBE elements use a Lagrange Multiplier formulation to compute their stiffnesses. This approach leads to zeros being present in some diagonals of the stiffness matrix, which causes issues when the preconditioner is factored. To get around this, the elements add a small artificial term to their diagonals. This fixes the PC issue, but adds error to the Jacobian.

This PR:
- Separates out the artificial stiffness from the true Jacobian and only adding it in for the preconditioner refactor step
- Adds options to allow user to set the scaling factors used in the RBE elements through the pytacs problem classes
- Improves the default rel. convergence tolerance of static problems featuring RBE elements from ~1e-7 to ~1e-13