### PR TITLE
Adding warning for ill-conditioned static problems

### DIFF
--- a/src/bpmat/GSEP.cpp
+++ b/src/bpmat/GSEP.cpp
@@ -93,7 +93,10 @@ EPShiftInvert::~EPShiftInvert() { ksm->decref(); }
 
 TACSVec *EPShiftInvert::createVec() { return ksm->createVec(); }
 
-void EPShiftInvert::mult(TACSVec *x, TACSVec *y) { return ksm->solve(x, y); }
+void EPShiftInvert::mult(TACSVec *x, TACSVec *y) {
+  ksm->solve(x, y);
+  return;
+}
 
 // The eigenvalues are computed as mu = 1.0/( eig - sigma )
 // eig = 1.0/mu + sigma
@@ -153,7 +156,8 @@ TACSVec *EPGeneralizedShiftInvert::createVec() { return ksm->createVec(); }
 */
 void EPGeneralizedShiftInvert::mult(TACSVec *x, TACSVec *y) {
   inner->mult(x, temp);
-  return ksm->solve(temp, y);
+  ksm->solve(temp, y);
+  return;
 }
 
 /*
@@ -219,7 +223,8 @@ TACSVec *EPBucklingShiftInvert::createVec() { return ksm->createVec(); }
 // Compute y = ( A - sigma B )^{-1} *  x
 void EPBucklingShiftInvert::mult(TACSVec *x, TACSVec *y) {
   inner->mult(x, temp);
-  return ksm->solve(temp, y);
+  ksm->solve(temp, y);
+  return;
 }
 
 // Compute <x,y> = x^{T} inner y

--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -432,8 +432,11 @@ void PCG::setMonitor(KSMPrint *_monitor) {
   b:          the right-hand-side
   x:          the solution vector
   zero_guess: flag to indicate whether to start with x = 0
+
+  output:
+  solve_flag: flag for the whether the solve terminated successfully
 */
-void PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
+int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   int solve_flag = 0;
   TacsScalar rhs_norm = 0.0;
   // R, Z and P are work-vectors
@@ -493,6 +496,7 @@ void PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
       break;
     }
   }
+  return solve_flag;
 }
 
 /*
@@ -771,8 +775,11 @@ const char *GMRES::gmresName = "GMRES";
   b:          the right-hand-side
   x:          the solution vector (with possibly significant entries)
   zero_guess: flag to indicate whether to zero entries of x before solution
+
+  output:
+  solve_flag: flag for the whether the solve terminated successfully
 */
-void GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
+int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   TacsScalar rhs_norm = 0.0;
   int solve_flag = 0;
 
@@ -935,6 +942,8 @@ void GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
     monitor->print(str_ort);
     monitor->print(str_tot);
   }
+
+  return solve_flag;
 }
 
 /*
@@ -1171,8 +1180,11 @@ const char *GCROT::gcrotName = "GCROT";
   b:          the input right-hand-side
   x:          the solution vector
   zero_guess: flag to treat x as an initial guess or zero
+
+  output:
+  solve_flag: flag for the whether the solve terminated successfully
 */
-void GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
+int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   TacsScalar rhs_norm = 0.0;
   int solve_flag = 0;
   int mat_iters = 0;
@@ -1193,7 +1205,8 @@ void GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   rhs_norm = R->norm();  // The initial residual
 
   if (TacsRealPart(rhs_norm) < atol) {
-    return;
+    solve_flag = 1;
+    return solve_flag;
   }
 
   for (int count = 0; count < max_outer; count++) {
@@ -1410,6 +1423,8 @@ void GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
     u_hat = u;
     c_hat = c;
   }
+
+  return solve_flag;
 }
 
 /*
@@ -1463,8 +1478,10 @@ void KsmPreconditioner::getOperators(TACSMat **_mat, TACSPc **_pc) {
   'Solve' the problem - this is only really a solution if a direct
   solver is used. This is often the case within TACS.
 */
-void KsmPreconditioner::solve(TACSVec *b, TACSVec *x, int zero_guess) {
+int KsmPreconditioner::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   pc->applyFactor(b, x);
+  // Return successful solve flag
+  return 1;
 }
 
 /*

--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -819,6 +819,7 @@ int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
     int niters = 0;  // Keep track of the size of the Hessenberg matrix
 
     if (TacsRealPart(res[0]) < atol) {
+      solve_flag = 1;
       break;
     }
 

--- a/src/bpmat/KSM.h
+++ b/src/bpmat/KSM.h
@@ -260,7 +260,7 @@ class TACSKsm : public TACSObject {
   virtual TACSVec *createVec() = 0;
   virtual void setOperators(TACSMat *_mat, TACSPc *_pc) = 0;
   virtual void getOperators(TACSMat **_mat, TACSPc **_pc) = 0;
-  virtual void solve(TACSVec *b, TACSVec *x, int zero_guess = 1) = 0;
+  virtual int solve(TACSVec *b, TACSVec *x, int zero_guess = 1) = 0;
   virtual void setTolerances(double _rtol, double _atol) = 0;
   virtual void setMonitor(KSMPrint *_monitor) = 0;
   const char *getObjectName();
@@ -315,7 +315,7 @@ class PCG : public TACSKsm {
   ~PCG();
 
   TACSVec *createVec() { return mat->createVec(); }
-  void solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
+  int solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
   void setOperators(TACSMat *_mat, TACSPc *_pc);
   void getOperators(TACSMat **_mat, TACSPc **_pc);
   void setTolerances(double _rtol, double _atol);
@@ -380,7 +380,7 @@ class GMRES : public TACSKsm {
   ~GMRES();
 
   TACSVec *createVec() { return mat->createVec(); }
-  void solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
+  int solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
   void setOperators(TACSMat *_mat, TACSPc *_pc);
   void getOperators(TACSMat **_mat, TACSPc **_pc);
   void setTolerances(double _rtol, double _atol);
@@ -445,7 +445,7 @@ class GCROT : public TACSKsm {
   ~GCROT();
 
   TACSVec *createVec() { return mat->createVec(); }
-  void solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
+  int solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
   void setOperators(TACSMat *_mat, TACSPc *_pc);
   void getOperators(TACSMat **_mat, TACSPc **_pc);
   void setTolerances(double _rtol, double _atol);
@@ -499,7 +499,7 @@ class KsmPreconditioner : public TACSKsm {
   TACSVec *createVec();
   void setOperators(TACSMat *_mat, TACSPc *_pc);
   void getOperators(TACSMat **_mat, TACSPc **_pc);
-  void solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
+  int solve(TACSVec *b, TACSVec *x, int zero_guess = 1);
   void setTolerances(double _rtol, double _atol);
   void setMonitor(KSMPrint *_monitor);
 

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -149,7 +149,7 @@ cdef extern from "KSM.h":
         TACSVec *createVec()
         void setOperators(TACSMat *_mat, TACSPc *_pc)
         void getOperators(TACSMat **_mat, TACSPc **_pc)
-        void solve(TACSVec *b, TACSVec *x, int zero_guess)
+        int solve(TACSVec *b, TACSVec *x, int zero_guess)
         void setTolerances(double _rtol, double _atol)
         void setMonitor(KSMPrint *_monitor)
 

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -1137,8 +1137,11 @@ cdef class KSM:
         b:          the right-hand-side
         x:          the solution vector (with possibly significant entries)
         zero_guess:  indicate whether to zero entries of x before solution
+
+        output:
+        solve_flag: flag for whether the solve terminated successfully
         """
-        self.ptr.solve(b.ptr, x.ptr, zero_guess)
+        return self.ptr.solve(b.ptr, x.ptr, zero_guess)
 
     def setTolerances(self, double rtol, double atol):
         """

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -647,7 +647,14 @@ class StaticProblem(TACSProblem):
         initNormTime = time.time()
 
         # Solve Linear System for the update
-        self.KSM.solve(self.res, self.update)
+        success = self.KSM.solve(self.res, self.update)
+
+        if not success:
+            self._TACSWarning(
+                "Linear solver failed to converge. "
+                "This is likely a sign that the problem is ill-conditioned. "
+                "Check that the model is properly restrained."
+            )
 
         self.update.scale(-1.0)
 


### PR DESCRIPTION
- Adding explicit warning message if linear solver fails in `StaticProblem.solve` method
- This should help users catch issues with models that may be ill-conditioned by design (i.e. missing bcs)