### PR TITLE
Fixing pytacs docstrings using wrap method

### DIFF
--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -137,7 +137,7 @@ class TACSProblem(BaseUI):
 
     def getNodes(self):
         """
-        Return the mesh coordiantes of this problem.
+        Return the mesh coordinates of this problem.
 
         Returns
         -------

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1060,7 +1060,7 @@ class pyTACS(BaseUI):
     @postinitialize_method
     def getOrigNodes(self):
         """
-        Return the original mesh coordiantes read in from the meshLoader.
+        Return the original mesh coordinates read in from the meshLoader.
 
         Returns
         -------

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -26,6 +26,7 @@ import copy
 import numbers
 import numpy
 import time
+from functools import wraps
 
 import numpy as np
 from mpi4py import MPI
@@ -39,6 +40,7 @@ warnings.simplefilter("default")
 
 # Define decorator functions for methods that must be called before initialize
 def preinitialize_method(method):
+    @wraps(method)
     def wrapped_method(self, *args, **kwargs):
         if self.assembler is not None:
             raise self._TACSError(
@@ -53,6 +55,7 @@ def preinitialize_method(method):
 
 # Define decorator functions for methods that must be called after initialize
 def postinitialize_method(method):
+    @wraps(method)
     def wrapped_method(self, *args, **kwargs):
         if self.assembler is None:
             raise self._TACSError(


### PR DESCRIPTION
- The pyTACS decorators added to methods in #159 inadvertently messed up the dosctrings for some of the methods in the Sphinx docs
- This PR fixes the issue by using the built-in `wraps` decorator to ensure that all docstring metadata is copied correctly for the decorated methods 