### PR TITLE
Fixing issue in AssembleMatType procedure

### DIFF
--- a/examples/plate/analysis.py
+++ b/examples/plate/analysis.py
@@ -128,7 +128,7 @@ for step_i, time in enumerate(timeSteps):
 allProblems.append(transientProb)
 
 # Setup modal problem (Note: eigenvalues are in (rad/s)**2
-modalProb = FEAAssembler.createModalProblem("dynamic_modes", sigma=1e4, numEigs=10)
+modalProb = FEAAssembler.createModalProblem("dynamic_modes", sigma=7e4, numEigs=10)
 # Add modal problem to list
 allProblems.append(modalProb)
 

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4442,7 +4442,6 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
 
       // Add the contribution from any auxiliary elements,  they need to be
       // scaled first
-      memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
       while (aux_count < naux && aux[aux_count].num == i) {
         aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
                                         auxElemMat);

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4200,23 +4200,21 @@ void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda) {
       // Add the residual from any auxiliary elements, if the load factor is 1
       // they can be added straight to the elemRes, otherwise they need to be
       // scaled first
-      if (aux_count < naux) {
-        if (!scaleAux) {
-          while (aux_count < naux && aux[aux_count].num == i) {
-            aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
-                                             ddvars, elemRes);
-            aux_count++;
-          }
-        } else {
-          memset(auxElemRes, 0, maxNVar * sizeof(TacsScalar));
-          while (aux_count < naux && aux[aux_count].num == i) {
-            aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
-                                             ddvars, auxElemRes);
-            aux_count++;
-          }
-          for (int jj = 0; jj < nvars; jj++) {
-            elemRes[jj] += lambda * auxElemRes[jj];
-          }
+      if (!scaleAux) {
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
+                                           ddvars, elemRes);
+          aux_count++;
+        }
+      } else {
+        memset(auxElemRes, 0, maxNVar * sizeof(TacsScalar));
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
+                                           ddvars, auxElemRes);
+          aux_count++;
+        }
+        for (int jj = 0; jj < nvars; jj++) {
+          elemRes[jj] += lambda * auxElemRes[jj];
         }
       }
 
@@ -4336,13 +4334,11 @@ void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
 
       // Add the contribution to the residual and the Jacobian from the
       // auxiliary elements - if any, this is scaled by the loadFactor lambda
-      if (aux_count < naux) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->addJacobian(
-              i, time, alpha * lambda, beta * lambda, gamma * lambda, elemXpts,
-              vars, dvars, ddvars, elemRes, elemMat);
-          aux_count++;
-        }
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->addJacobian(i, time, alpha * lambda, beta * lambda,
+                                         gamma * lambda, elemXpts, vars, dvars,
+                                         ddvars, elemRes, elemMat);
+        aux_count++;
       }
 
       if (residual) {
@@ -4446,15 +4442,14 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
 
       // Add the contribution from any auxiliary elements,  they need to be
       // scaled first
-      if (aux_count < naux) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
-                                          auxElemMat);
-          for (int ii = 0; ii < nvars * nvars; ii++) {
-            elemMat[ii] += lambda * auxElemMat[ii];
-          }
-          aux_count++;
+      memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
+                                        auxElemMat);
+        for (int ii = 0; ii < nvars * nvars; ii++) {
+          elemMat[ii] += lambda * auxElemMat[ii];
         }
+        aux_count++;
       }
 
       // Add the values into the element
@@ -4526,23 +4521,21 @@ void TACSAssembler::assembleMatCombo(ElementMatrixType matTypes[],
       // 1 they can be added straight to the elemRes, otherwise they need to be
       // scaled first
       int nvars = elements[i]->getNumVariables();
-      if (aux_count < naux) {
-        if (!scaleAux) {
-          while (aux_count < naux && aux[aux_count].num == i) {
-            aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts,
-                                            vars, elemMat);
-            aux_count++;
-          }
-        } else {
-          memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
-          while (aux_count < naux && aux[aux_count].num == i) {
-            aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts,
-                                            vars, auxElemMat);
-            aux_count++;
-          }
-          for (int ii = 0; ii < nvars * nvars; ii++) {
-            elemMat[ii] += lambda * auxElemMat[ii];
-          }
+      if (!scaleAux) {
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts, vars,
+                                          elemMat);
+          aux_count++;
+        }
+      } else {
+        memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts, vars,
+                                          auxElemMat);
+          aux_count++;
+        }
+        for (int ii = 0; ii < nvars * nvars; ii++) {
+          elemMat[ii] += lambda * auxElemMat[ii];
         }
       }
 
@@ -5419,13 +5412,11 @@ void TACSAssembler::addJacobianVecProduct(TacsScalar scale, TacsScalar alpha,
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any, this is scaled by the loadFactor
     // lambda
-    if (aux_count < naux) {
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->addJacobian(i, time, lambda * alpha, lambda * beta,
-                                         lambda * gamma, elemXpts, vars, dvars,
-                                         ddvars, yvars, elemMat);
-        aux_count++;
-      }
+    while (aux_count < naux && aux[aux_count].num == i) {
+      aux[aux_count].elem->addJacobian(i, time, lambda * alpha, lambda * beta,
+                                       lambda * gamma, elemXpts, vars, dvars,
+                                       ddvars, yvars, elemMat);
+      aux_count++;
     }
 
     // Temporarily set the variable array as the element input array
@@ -5485,15 +5476,13 @@ void TACSAssembler::getMatrixFreeDataSize(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any
-    if (aux_count < naux) {
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-        data_size += dsize;
-        if (tsize > temp_size) {
-          temp_size = tsize;
-        }
-        aux_count++;
+    while (aux_count < naux && aux[aux_count].num == i) {
+      aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+      data_size += dsize;
+      if (tsize > temp_size) {
+        temp_size = tsize;
       }
+      aux_count++;
     }
   }
 
@@ -5560,15 +5549,13 @@ void TACSAssembler::assembleMatrixFreeData(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any
-    if (aux_count < naux) {
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-        aux[aux_count].elem->getMatVecProductData(matType, i, time, alpha, beta,
-                                                  gamma, elemXpts, vars, dvars,
-                                                  ddvars, data);
-        data += dsize;
-        aux_count++;
-      }
+    while (aux_count < naux && aux[aux_count].num == i) {
+      aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+      aux[aux_count].elem->getMatVecProductData(matType, i, time, alpha, beta,
+                                                gamma, elemXpts, vars, dvars,
+                                                ddvars, data);
+      data += dsize;
+      aux_count++;
     }
   }
 }
@@ -5631,30 +5618,28 @@ void TACSAssembler::addMatrixFreeVecProduct(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any, scaled by lambda
-    if (aux_count < naux) {
-      if (lambda == TacsScalar(1.0)) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-          aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
-                                                yvars);
-          data += dsize;
-          aux_count++;
-        }
-      } else {
-        TacsScalar aux_yvars[nvars];
-        for (int kk = 0; kk < nvars; kk++) {
-          aux_yvars[kk] = 0.0;
-        }
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-          aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
-                                                yvars);
-          data += dsize;
-          aux_count++;
-        }
-        for (int kk = 0; kk < nvars; kk++) {
-          yvars[kk] += lambda * aux_yvars[kk];
-        }
+    if (lambda == TacsScalar(1.0)) {
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+        aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
+                                              yvars);
+        data += dsize;
+        aux_count++;
+      }
+    } else {
+      TacsScalar aux_yvars[nvars];
+      for (int kk = 0; kk < nvars; kk++) {
+        aux_yvars[kk] = 0.0;
+      }
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+        aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
+                                              yvars);
+        data += dsize;
+        aux_count++;
+      }
+      for (int kk = 0; kk < nvars; kk++) {
+        yvars[kk] += lambda * aux_yvars[kk];
       }
     }
 

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4200,21 +4200,23 @@ void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda) {
       // Add the residual from any auxiliary elements, if the load factor is 1
       // they can be added straight to the elemRes, otherwise they need to be
       // scaled first
-      if (!scaleAux) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
-                                           ddvars, elemRes);
-          aux_count++;
-        }
-      } else {
-        memset(auxElemRes, 0, maxNVar * sizeof(TacsScalar));
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
-                                           ddvars, auxElemRes);
-          aux_count++;
-        }
-        for (int jj = 0; jj < nvars; jj++) {
-          elemRes[jj] += lambda * auxElemRes[jj];
+      if (aux_count < naux) {
+        if (!scaleAux) {
+          while (aux_count < naux && aux[aux_count].num == i) {
+            aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
+                                             ddvars, elemRes);
+            aux_count++;
+          }
+        } else {
+          memset(auxElemRes, 0, maxNVar * sizeof(TacsScalar));
+          while (aux_count < naux && aux[aux_count].num == i) {
+            aux[aux_count].elem->addResidual(i, time, elemXpts, vars, dvars,
+                                             ddvars, auxElemRes);
+            aux_count++;
+          }
+          for (int jj = 0; jj < nvars; jj++) {
+            elemRes[jj] += lambda * auxElemRes[jj];
+          }
         }
       }
 
@@ -4334,11 +4336,13 @@ void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
 
       // Add the contribution to the residual and the Jacobian from the
       // auxiliary elements - if any, this is scaled by the loadFactor lambda
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->addJacobian(i, time, alpha * lambda, beta * lambda,
-                                         gamma * lambda, elemXpts, vars, dvars,
-                                         ddvars, elemRes, elemMat);
-        aux_count++;
+      if (aux_count < naux) {
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->addJacobian(
+              i, time, alpha * lambda, beta * lambda, gamma * lambda, elemXpts,
+              vars, dvars, ddvars, elemRes, elemMat);
+          aux_count++;
+        }
       }
 
       if (residual) {
@@ -4442,14 +4446,15 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
 
       // Add the contribution from any auxiliary elements,  they need to be
       // scaled first
-      memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
-                                        auxElemMat);
-        aux_count++;
-      }
-      for (int ii = 0; ii < nvars * nvars; ii++) {
-        elemMat[ii] += lambda * auxElemMat[ii];
+      if (aux_count < naux) {
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
+                                          auxElemMat);
+          for (int ii = 0; ii < nvars * nvars; ii++) {
+            elemMat[ii] += lambda * auxElemMat[ii];
+          }
+          aux_count++;
+        }
       }
 
       // Add the values into the element
@@ -4521,21 +4526,23 @@ void TACSAssembler::assembleMatCombo(ElementMatrixType matTypes[],
       // 1 they can be added straight to the elemRes, otherwise they need to be
       // scaled first
       int nvars = elements[i]->getNumVariables();
-      if (!scaleAux) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts, vars,
-                                          elemMat);
-          aux_count++;
-        }
-      } else {
-        memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts, vars,
-                                          auxElemMat);
-          aux_count++;
-        }
-        for (int ii = 0; ii < nvars * nvars; ii++) {
-          elemMat[ii] += lambda * auxElemMat[ii];
+      if (aux_count < naux) {
+        if (!scaleAux) {
+          while (aux_count < naux && aux[aux_count].num == i) {
+            aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts,
+                                            vars, elemMat);
+            aux_count++;
+          }
+        } else {
+          memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
+          while (aux_count < naux && aux[aux_count].num == i) {
+            aux[aux_count].elem->getMatType(matTypes[j], i, time, elemXpts,
+                                            vars, auxElemMat);
+            aux_count++;
+          }
+          for (int ii = 0; ii < nvars * nvars; ii++) {
+            elemMat[ii] += lambda * auxElemMat[ii];
+          }
         }
       }
 
@@ -5412,11 +5419,13 @@ void TACSAssembler::addJacobianVecProduct(TacsScalar scale, TacsScalar alpha,
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any, this is scaled by the loadFactor
     // lambda
-    while (aux_count < naux && aux[aux_count].num == i) {
-      aux[aux_count].elem->addJacobian(i, time, lambda * alpha, lambda * beta,
-                                       lambda * gamma, elemXpts, vars, dvars,
-                                       ddvars, yvars, elemMat);
-      aux_count++;
+    if (aux_count < naux) {
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->addJacobian(i, time, lambda * alpha, lambda * beta,
+                                         lambda * gamma, elemXpts, vars, dvars,
+                                         ddvars, yvars, elemMat);
+        aux_count++;
+      }
     }
 
     // Temporarily set the variable array as the element input array
@@ -5476,13 +5485,15 @@ void TACSAssembler::getMatrixFreeDataSize(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any
-    while (aux_count < naux && aux[aux_count].num == i) {
-      aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-      data_size += dsize;
-      if (tsize > temp_size) {
-        temp_size = tsize;
+    if (aux_count < naux) {
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+        data_size += dsize;
+        if (tsize > temp_size) {
+          temp_size = tsize;
+        }
+        aux_count++;
       }
-      aux_count++;
     }
   }
 
@@ -5549,13 +5560,15 @@ void TACSAssembler::assembleMatrixFreeData(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any
-    while (aux_count < naux && aux[aux_count].num == i) {
-      aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-      aux[aux_count].elem->getMatVecProductData(matType, i, time, alpha, beta,
-                                                gamma, elemXpts, vars, dvars,
-                                                ddvars, data);
-      data += dsize;
-      aux_count++;
+    if (aux_count < naux) {
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+        aux[aux_count].elem->getMatVecProductData(matType, i, time, alpha, beta,
+                                                  gamma, elemXpts, vars, dvars,
+                                                  ddvars, data);
+        data += dsize;
+        aux_count++;
+      }
     }
   }
 }
@@ -5618,28 +5631,30 @@ void TACSAssembler::addMatrixFreeVecProduct(ElementMatrixType matType,
 
     // Add the contribution to the residual and the Jacobian
     // from the auxiliary elements - if any, scaled by lambda
-    if (lambda == TacsScalar(1.0)) {
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-        aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
-                                              yvars);
-        data += dsize;
-        aux_count++;
-      }
-    } else {
-      TacsScalar aux_yvars[nvars];
-      for (int kk = 0; kk < nvars; kk++) {
-        aux_yvars[kk] = 0.0;
-      }
-      while (aux_count < naux && aux[aux_count].num == i) {
-        aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
-        aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
-                                              yvars);
-        data += dsize;
-        aux_count++;
-      }
-      for (int kk = 0; kk < nvars; kk++) {
-        yvars[kk] += lambda * aux_yvars[kk];
+    if (aux_count < naux) {
+      if (lambda == TacsScalar(1.0)) {
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+          aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
+                                                yvars);
+          data += dsize;
+          aux_count++;
+        }
+      } else {
+        TacsScalar aux_yvars[nvars];
+        for (int kk = 0; kk < nvars; kk++) {
+          aux_yvars[kk] = 0.0;
+        }
+        while (aux_count < naux && aux[aux_count].num == i) {
+          aux[aux_count].elem->getMatVecDataSizes(matType, i, &dsize, &tsize);
+          aux[aux_count].elem->addMatVecProduct(matType, i, data, temp, xvars,
+                                                yvars);
+          data += dsize;
+          aux_count++;
+        }
+        for (int kk = 0; kk < nvars; kk++) {
+          yvars[kk] += lambda * aux_yvars[kk];
+        }
       }
     }
 

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4426,11 +4426,7 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
     // To avoid allocating memory inside the element loop, make the aux element
     // contribution mat big enough for the largest element
     int maxNVar = this->maxElementSize;
-    TacsScalar *auxElemMat = NULL;
-    bool scaleAux = lambda != TacsScalar(1.0) && naux > 0;
-    if (scaleAux) {
-      auxElemMat = new TacsScalar[maxNVar * maxNVar];
-    }
+    TacsScalar *auxElemMat = new TacsScalar[maxNVar * maxNVar];
 
     for (int i = 0; i < numElements; i++) {
       // Retrieve the element variables and node locations
@@ -4444,33 +4440,22 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
       // Get the element matrix
       elements[i]->getMatType(matType, i, time, elemXpts, vars, elemMat);
 
-      // Add the contribution from any auxiliary elements, if the load factor is
-      // 1 they can be added straight to the elemRes, otherwise they need to be
+      // Add the contribution from any auxiliary elements,  they need to be
       // scaled first
-      if (!scaleAux) {
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
-                                          elemMat);
-          aux_count++;
-        }
-      } else {
-        memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
-        while (aux_count < naux && aux[aux_count].num == i) {
-          aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
-                                          auxElemMat);
-          aux_count++;
-        }
-        for (int ii = 0; ii < nvars * nvars; ii++) {
-          elemMat[ii] += lambda * auxElemMat[ii];
-        }
+      memset(auxElemMat, 0, maxNVar * maxNVar * sizeof(TacsScalar));
+      while (aux_count < naux && aux[aux_count].num == i) {
+        aux[aux_count].elem->getMatType(matType, i, time, elemXpts, vars,
+                                        auxElemMat);
+        aux_count++;
+      }
+      for (int ii = 0; ii < nvars * nvars; ii++) {
+        elemMat[ii] += lambda * auxElemMat[ii];
       }
 
       // Add the values into the element
       addMatValues(A, i, elemMat, elementIData, elemWeights, matOr);
     }
-    if (scaleAux) {
-      delete[] auxElemMat;
-    }
+    delete[] auxElemMat;
   }
 
   A->beginAssembly();

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -168,10 +168,8 @@ class ModalProblem(TACSProblem):
 
         # Assemble and factor the stiffness/Jacobian matrix. Factor the
         # Jacobian and solve the linear system for the displacements
-        alpha = 1.0
-        beta = 0.0
-        gamma = 0.0
-        self.assembler.assembleJacobian(alpha, beta, gamma, None, self.K)
+        self.assembler.assembleMatType(tacs.TACS.STIFFNESS_MATRIX, self.K)
+        self.assembler.assembleMatType(tacs.TACS.MASS_MATRIX, self.M)
 
         subspace = self.getOption("subSpaceSize")
         restarts = self.getOption("nRestarts")

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -370,6 +370,8 @@ class ModalProblem(TACSProblem):
 
         self.assembler.setDesignVars(self.x)
         self.assembler.setNodes(self.Xpts)
+        # Make previous auxiliary loads are removed
+        self.assembler.setAuxElements(None)
         # Set artificial stiffness factors in rbe class
         c1 = self.getOption("RBEStiffnessScaleFactor")
         c2 = self.getOption("RBEArtificialStiffness")

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -370,7 +370,7 @@ class ModalProblem(TACSProblem):
 
         self.assembler.setDesignVars(self.x)
         self.assembler.setNodes(self.Xpts)
-        # Make previous auxiliary loads are removed
+        # Make sure previous auxiliary loads are removed
         self.assembler.setAuxElements(None)
         # Set artificial stiffness factors in rbe class
         c1 = self.getOption("RBEStiffnessScaleFactor")

--- a/tests/integration_tests/test_shell_plate_quad.py
+++ b/tests/integration_tests/test_shell_plate_quad.py
@@ -189,7 +189,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
             )
 
         # Add modal problem
-        mp = fea_assembler.createModalProblem("modal", 1e3, 10)
+        mp = fea_assembler.createModalProblem("modal", 7e4, 10)
         mp.setOption("printLevel", 2)
         tacs_probs.append(mp)
 

--- a/tests/integration_tests/test_shell_plate_quad.py
+++ b/tests/integration_tests/test_shell_plate_quad.py
@@ -1,6 +1,6 @@
 import numpy as np
 import os
-from tacs import pytacs, elements, constitutive, functions, problems
+from tacs import pytacs, elements, constitutive, functions
 from pytacs_analysis_base_test import PyTACSTestCase
 
 """
@@ -8,7 +8,8 @@ The nominal case is a 1m x 1m flat plate under three load cases:
 a 10 kN point force at center, a 100kPa pressure applied to the surface, and a 100G gravity load. The
 perimeter of the plate is fixed in all 6 degrees of freedom. The plate comprises
 100 CQUAD4 elements and test KSFailure, StructuralMass, CenterOfMass, MomentOfInertia,
-and Compliance functions and sensitivities
+and Compliance functions and sensitivities. Finally, a modal analysis is performed 
+and the eigenvalues tested.
 """
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
@@ -22,42 +23,46 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
     FUNC_REFS = {
-        "point_load_compliance": 683.8571611640772,
-        "point_load_ks_vmfailure": 0.5757488025913641,
-        "point_load_mass": 12.5,
-        "point_load_cgx": 0.5,
-        "point_load_cgy": 0.5,
-        "point_load_cgz": 0.0,
-        "point_load_Ixx": 1.0416927083333238,
-        "point_load_Ixy": 0.0,
+        "point_load_Ixx": 1.041692708333326,
+        "point_load_Ixy": 4.884981308350689e-15,
         "point_load_Ixz": 0.0,
-        "point_load_Iyy": 1.0416927083333243,
+        "point_load_Iyy": 1.0416927083333283,
         "point_load_Iyz": 0.0,
-        "point_load_Izz": 2.08333333333333,
-        "pressure_compliance": 4679.345460326432,
-        "pressure_ks_vmfailure": 1.2938623156872926,
-        "pressure_mass": 12.5,
-        "pressure_cgx": 0.5,
-        "pressure_cgy": 0.5,
-        "pressure_cgz": 0.0,
-        "pressure_Ixx": 1.0416927083333238,
-        "pressure_Ixy": 0.0,
+        "point_load_Izz": 2.0833333333333233,
+        "point_load_cgx": 0.5000000000000002,
+        "point_load_cgy": 0.5000000000000006,
+        "point_load_cgz": 0.0,
+        "point_load_compliance": 683.857161165581,
+        "point_load_ks_vmfailure": 0.5757488025917175,
+        "point_load_mass": 12.5,
+        "pressure_Ixx": 1.041692708333326,
+        "pressure_Ixy": 4.884981308350689e-15,
         "pressure_Ixz": 0.0,
-        "pressure_Iyy": 1.0416927083333243,
+        "pressure_Iyy": 1.0416927083333283,
         "pressure_Iyz": 0.0,
-        "pressure_Izz": 2.08333333333333,
-        "gravity_compliance": 70.36280588344383,
-        "gravity_ks_vmfailure": 0.11707320009742483,
-        "gravity_mass": 12.5,
-        "gravity_cgx": 0.5,
-        "gravity_cgy": 0.5,
-        "gravity_cgz": 0.0,
-        "gravity_Ixx": 1.0416927083333238,
-        "gravity_Ixy": 0.0,
+        "pressure_Izz": 2.0833333333333233,
+        "pressure_cgx": 0.5000000000000002,
+        "pressure_cgy": 0.5000000000000006,
+        "pressure_cgz": 0.0,
+        "pressure_compliance": 4679.345460326935,
+        "pressure_ks_vmfailure": 1.293862315687351,
+        "pressure_mass": 12.5,
+        "gravity_Ixx": 1.041692708333326,
+        "gravity_Ixy": 4.884981308350689e-15,
         "gravity_Ixz": 0.0,
-        "gravity_Iyy": 1.0416927083333243,
+        "gravity_Iyy": 1.0416927083333283,
         "gravity_Iyz": 0.0,
-        "gravity_Izz": 2.08333333333333,
+        "gravity_Izz": 2.0833333333333233,
+        "gravity_cgx": 0.5000000000000002,
+        "gravity_cgy": 0.5000000000000006,
+        "gravity_cgz": 0.0,
+        "gravity_compliance": 70.36280588359826,
+        "gravity_ks_vmfailure": 0.1170732000975571,
+        "gravity_mass": 12.5,
+        "modal_eigsm.0": 87437.50645902398,
+        "modal_eigsm.1": 396969.8881660927,
+        "modal_eigsm.2": 396969.8881662339,
+        "modal_eigsm.3": 866727.6714828992,
     }
 
     def setup_tacs_problems(self, comm):
@@ -182,5 +187,10 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
                 direction2=[0.0, 0.0, 1.0],
                 aboutCM=True,
             )
+
+        # Add modal problem
+        mp = fea_assembler.createModalProblem("modal", 1e3, 10)
+        mp.setOption("printLevel", 2)
+        tacs_probs.append(mp)
 
         return tacs_probs, fea_assembler


### PR DESCRIPTION
- Our nightly benchmark tests caught a change in the modal analysis results of one of our pytacs [examples](https://github.com/smdogroup/tacs/blob/master/examples/plate/analysis.py) (benchmarks can also be run locally using `$testflo -b .`)
- I narrowed the problem down to this [line](https://github.com/smdogroup/tacs/blob/master/src/TACSAssembler.cpp#L4452) of code in the `assembleMatType` procedure which was causing TACSFrequencyAnalysis to behave differently
- The problem is that `getMatType` isn't an additive procedure (like `addJacobian`) so everytime the auxiliary element contribution is computed, it overwrites the element contribution
- The fix to this was to always split out the auxelem matrix contribution and then scale (rather than conditionally doing so)
- I also added a new modalProblem integration test case to catch this in the future