### PR TITLE
Bump min required mpi4py to 3.1.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py==3.1.0']
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py==3.1.1']

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="tacs",
-    version="3.1.0",
+    version="3.1.1",
     description="Parallel finite-element analysis package",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
 optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
-    "mphys": ["mphys>=0.4.0", "openmdao"],
+    "mphys": ["mphys>=0.4.0", "openmdao<3.25"],
 }
 
 # Add an optional dependency that concatenates all others

--- a/setup.py
+++ b/setup.py
@@ -122,7 +122,7 @@ setup(
     long_description_content_type="text/markdown",
     author="Graeme J. Kennedy",
     author_email="graeme.kennedy@ae.gatech.edu",
-    install_requires=["numpy", "mpi4py>=3.1.0", "scipy>=1.2.1", "pynastran>=1.3.3"],
+    install_requires=["numpy", "mpi4py>=3.1.1", "scipy>=1.2.1", "pynastran>=1.3.3"],
     extras_require=optional_dependencies,
     packages=find_packages(include=["tacs*"]),
     ext_modules=cythonize(exts, include_path=inc_dirs),

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="tacs",
-    version="3.1.1",
+    version="3.2.0",
     description="Parallel finite-element analysis package",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -116,7 +116,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="tacs",
-    version="3.2.0",
+    version="3.1.0",
     description="Parallel finite-element analysis package",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
mpi4py 3.1.0 has a typo in it's python dependencies definition that causes errors during pip install (see [here](https://github.com/mpi4py/mpi4py/releases/tag/3.1.1) and [here](https://github.com/mpi4py/mpi4py/commit/e77486bea7a7520d09cea48cd03a98d583a85f60)). Due to a new [major release](https://pypi.org/project/setuptools/#history) of setuptools (best guess), this just started causing build errors on our docker images (see [here](https://github.com/mdolab/docker/actions/runs/4040746729/jobs/6946677857#step:10:9815))

This PR therefore bumps the minimum required version of mpi4py to 3.1.1 where the error is fixed.

Also includes the OpenMDAO version guard from #174 

Bumping TACS version to 3.2.0