### PR TITLE
Adding upperbound for openmdao version (3.25)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
 optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
-    "mphys": ["mphys>=0.4.0", "openmdao"],
+    "mphys": ["mphys>=0.4.0", "openmdao<3.25"],
 }
 
 # Add an optional dependency that concatenates all others


### PR DESCRIPTION
- Setting OpenMDAO upperbound version requirement to last compatible version (3.25)
- Will update version requirement to `openmdao >= 3.25` when PR #163 is merged