### PR TITLE
Add methods for retreiving number of iterations and residual norm from KSM linear solvers

### DIFF
--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -456,6 +456,7 @@ int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
 
     if (count == 0) {
       rhs_norm = R->norm();
+      resNorm = rhs_norm;
     }
 
     if (monitor && count == 0) {
@@ -480,20 +481,19 @@ int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
         P->axpby(1.0, beta, Z);                    // P' = Z' + beta*P
         iterCount++;
 
-        TacsScalar norm = R->norm();
+        resNorm = R->norm();
 
         if (monitor) {
-          monitor->printResidual(i + 1, norm);
+          monitor->printResidual(i + 1, resNorm);
         }
 
-        if (TacsRealPart(norm) < atol ||
-            TacsRealPart(norm) < rtol * TacsRealPart(rhs_norm)) {
+        if (TacsRealPart(resNorm) < atol ||
+            TacsRealPart(resNorm) < rtol * TacsRealPart(rhs_norm)) {
           solve_flag = 1;
           break;
         }
       }
     }
-    resNorm = norm
 
     if (solve_flag) {
       break;
@@ -931,7 +931,6 @@ int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
       pc->applyFactor(work, W[0]);
       x->axpy(1.0, W[0]);
     }
-
 
     iterCount += niters;
     resNorm = res[niters];

--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -438,6 +438,7 @@ void PCG::setMonitor(KSMPrint *_monitor) {
 */
 int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   int solve_flag = 0;
+  iterCount = 0;
   TacsScalar rhs_norm = 0.0;
   // R, Z and P are work-vectors
   // R == the residual
@@ -477,6 +478,7 @@ int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
         pc->applyFactor(R, Z);                     // Z' = M^{-1} R
         TacsScalar beta = R->dot(Z) / temp;        // beta = (R',Z')/(R,Z)
         P->axpby(1.0, beta, Z);                    // P' = Z' + beta*P
+        iterCount++;
 
         TacsScalar norm = R->norm();
 
@@ -491,6 +493,7 @@ int PCG::solve(TACSVec *b, TACSVec *x, int zero_guess) {
         }
       }
     }
+    resNorm = norm
 
     if (solve_flag) {
       break;
@@ -782,6 +785,7 @@ const char *GMRES::gmresName = "GMRES";
 int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   TacsScalar rhs_norm = 0.0;
   int solve_flag = 0;
+  iterCount = 0;
 
   double t_pc = 0.0, t_ortho = 0.0;
   double t_total = 0.0;
@@ -927,6 +931,10 @@ int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
       pc->applyFactor(work, W[0]);
       x->axpy(1.0, W[0]);
     }
+
+
+    iterCount += niters;
+    resNorm = res[niters];
 
     if (solve_flag) {
       break;
@@ -1189,6 +1197,7 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   TacsScalar rhs_norm = 0.0;
   int solve_flag = 0;
   int mat_iters = 0;
+  iterCount = 0;
 
   // Compute the residual
   if (zero_guess) {
@@ -1207,6 +1216,7 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
 
   if (TacsRealPart(rhs_norm) < atol) {
     solve_flag = 1;
+    resNorm = rhs_norm;
     return solve_flag;
   }
 
@@ -1395,6 +1405,8 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
     // mat->mult( x, R );      // R = A*x
     // R->axpy( -1.0, b );     // R = A*x - b
     // R->scale( -1.0 );
+    iterCount += niters;
+    resNorm = R->norm();
 
     if (solve_flag) {
       break;

--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -888,13 +888,14 @@ int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
       res[i + 1] = -h1 * Qsin[i];
 
       niters++;
-      resNorm = fabs(TacsRealPart(res[i + 1]));
+      resNorm = fabs(res[i + 1]);
 
       if (monitor) {
         monitor->printResidual(i + 1, resNorm);
       }
 
-      if (resNorm < atol || resNorm < rtol * TacsRealPart(rhs_norm)) {
+      if (TacsRealPart(resNorm) < atol ||
+          TacsRealPart(resNorm) < rtol * TacsRealPart(rhs_norm)) {
         // Set the solve flag
         solve_flag = 1;
 
@@ -1212,10 +1213,10 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   }
 
   rhs_norm = R->norm();  // The initial residual
+  resNorm = rhs_norm;
 
   if (TacsRealPart(rhs_norm) < atol) {
     solve_flag = 1;
-    resNorm = rhs_norm;
     return solve_flag;
   }
 
@@ -1229,7 +1230,7 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
     W[0]->scale(1.0 / res[0]);  // W[0] = b/|| b ||
 
     if (monitor) {
-      monitor->printResidual(mat_iters, fabs(TacsRealPart(res[0])));
+      monitor->printResidual(mat_iters, resNorm);
     }
 
     // The inner F/GMRES loop
@@ -1296,12 +1297,13 @@ int GCROT::solve(TACSVec *b, TACSVec *x, int zero_guess) {
 
       niters++;
 
-      resNorm = fabs(TacsRealPart(res[i + 1]));
+      resNorm = fabs(res[i + 1]);
 
       if (monitor) {
         monitor->printResidual(mat_iters, resNorm);
       }
-      if (resNorm < atol || resNorm < rtol * TacsRealPart(rhs_norm)) {
+      if (TacsRealPart(resNorm) < atol ||
+          TacsRealPart(resNorm) < rtol * TacsRealPart(rhs_norm)) {
         // Set the solve flag
         solve_flag = 1;
 

--- a/src/bpmat/KSM.h
+++ b/src/bpmat/KSM.h
@@ -268,15 +268,16 @@ class TACSKsm : public TACSObject {
   virtual int solve(TACSVec *b, TACSVec *x, int zero_guess = 1) = 0;
   virtual void setTolerances(double _rtol, double _atol) = 0;
   virtual void setMonitor(KSMPrint *_monitor) = 0;
-  inline int getIterCount() {return iterCount;}
-  inline TacsScalar getResidualNorm() {return resNorm;}
+  inline int getIterCount() { return iterCount; }
+  inline TacsScalar getResidualNorm() { return resNorm; }
   const char *getObjectName();
 
  private:
   static const char *ksmName;
-protected:
-  int iterCount; ///< Number of iterations taken during the last solve
-  TacsScalar resNorm; ///< The residual norm at the end of the last solve
+
+ protected:
+  int iterCount;       ///< Number of iterations taken during the last solve
+  TacsScalar resNorm;  ///< The residual norm at the end of the last solve
 };
 
 /*

--- a/src/bpmat/KSM.h
+++ b/src/bpmat/KSM.h
@@ -268,8 +268,8 @@ class TACSKsm : public TACSObject {
   virtual int solve(TACSVec *b, TACSVec *x, int zero_guess = 1) = 0;
   virtual void setTolerances(double _rtol, double _atol) = 0;
   virtual void setMonitor(KSMPrint *_monitor) = 0;
-  inline int getIterCount() { return iterCount; }
-  inline TacsScalar getResidualNorm() { return resNorm; }
+  virtual int getIterCount() { return iterCount; }
+  virtual TacsScalar getResidualNorm() { return resNorm; }
   const char *getObjectName();
 
  private:

--- a/src/bpmat/KSM.h
+++ b/src/bpmat/KSM.h
@@ -252,9 +252,14 @@ class KSMPrint : public TACSObject {
   tolerances for the method
 
   setMonitor(): Set the monitor - possibly NULL - that will be used
+
+  getIterCount(): Return the number of iterations taken during the last solve
+
+  getResidualNorm(): Return the residual norm from the end of the last solve
  */
 class TACSKsm : public TACSObject {
  public:
+  TACSKsm() : iterCount(0), resNorm(0.0) {}
   virtual ~TACSKsm() {}
 
   virtual TACSVec *createVec() = 0;
@@ -263,10 +268,15 @@ class TACSKsm : public TACSObject {
   virtual int solve(TACSVec *b, TACSVec *x, int zero_guess = 1) = 0;
   virtual void setTolerances(double _rtol, double _atol) = 0;
   virtual void setMonitor(KSMPrint *_monitor) = 0;
+  inline int getIterCount() {return iterCount;}
+  inline TacsScalar getResidualNorm() {return resNorm;}
   const char *getObjectName();
 
  private:
   static const char *ksmName;
+protected:
+  int iterCount; ///< Number of iterations taken during the last solve
+  TacsScalar resNorm; ///< The residual norm at the end of the last solve
 };
 
 /*

--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -155,6 +155,8 @@ cdef extern from "KSM.h":
         int solve(TACSVec *b, TACSVec *x, int zero_guess)
         void setTolerances(double _rtol, double _atol)
         void setMonitor(KSMPrint *_monitor)
+        int getIterCount()
+        TacsScalar getResidualNorm()
 
     cdef cppclass GMRES(TACSKsm):
         GMRES(TACSMat *_mat, TACSPc *_pc, int _m,

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -1141,6 +1141,14 @@ cdef class KSM:
         self.ptr.incref()
         return
 
+    def getIterCount(self):
+        """Get the number of iterations performed in the last solve"""
+        return self.ptr.getIterCount()
+
+    def getResidualNorm(self):
+        """Get the residual norm of the last solve"""
+        return self.ptr.getResidualNorm()
+
     def __dealloc__(self):
         if self.ptr:
             self.ptr.decref()

--- a/tests/integration_tests/static_analysis_base_test.py
+++ b/tests/integration_tests/static_analysis_base_test.py
@@ -7,20 +7,20 @@ from tacs import TACS
 
 """
 This is a base class for static problem unit test cases.
-This base class will test function evaluations and total 
-and partial sensitivities for the user-specified problem 
+This base class will test function evaluations and total
+and partial sensitivities for the user-specified problem
 that inherits from it.
-When the user creates a new test based on this class three 
-methods are required to be defined in the child class. 
+When the user creates a new test based on this class three
+methods are required to be defined in the child class.
 
     1. setup_assembler
     2. setup_tacs_vecs
     3. setup_funcs
-    
-See the virtual method implementations for each method 
+
+See the virtual method implementations for each method
 below for more details.
 
-NOTE: The child class must NOT implement its own setUp method 
+NOTE: The child class must NOT implement its own setUp method
 for the unittest class. This is handled in the base class.
 """
 
@@ -89,10 +89,11 @@ class StaticTestCase:
             # Create GMRES solver object
             subspace = 100
             restarts = 2
-            atol = 1e-30
-            rtol = 1e-12
+            self.linSolveIterLimit = subspace * restarts
+            self.linSolveAtol = 1e-30
+            self.linSolveRrtol = 1e-12
             self.gmres = TACS.KSM(self.mat, self.pc, subspace, restarts)
-            self.gmres.setTolerances(rtol, atol)
+            self.gmres.setTolerances(self.linSolveRrtol, self.linSolveAtol)
 
             # Create the function list
             self.func_list, self.func_ref = self.setup_funcs(self.assembler)
@@ -148,6 +149,18 @@ class StaticTestCase:
 
             # solve
             func_vals = self.run_solve()
+
+            # Test that linear solver residual is sufficiently small
+            linSolveRes = np.abs(np.real(self.gmres.getResidualNorm()))
+            converged = (
+                linSolveRes < self.linSolveAtol
+                or linSolveRes < self.linSolveRrtol * np.real(self.res0.norm())
+            )
+            self.assertTrue(converged, "Linear solver did not converge")
+
+            # Test that linear solver took between 1 and subspce * restarts iterations
+            numIters = self.gmres.getIterCount()
+            self.assertTrue(numIters > 0 and numIters <= self.linSolveIterLimit)
 
             # Test functions values against historical values
             np.testing.assert_allclose(

--- a/tests/integration_tests/static_analysis_base_test.py
+++ b/tests/integration_tests/static_analysis_base_test.py
@@ -91,9 +91,9 @@ class StaticTestCase:
             restarts = 2
             self.linSolveIterLimit = subspace * restarts
             self.linSolveAtol = 1e-30
-            self.linSolveRrtol = 1e-12
+            self.linSolveRtol = 1e-12
             self.gmres = TACS.KSM(self.mat, self.pc, subspace, restarts)
-            self.gmres.setTolerances(self.linSolveRrtol, self.linSolveAtol)
+            self.gmres.setTolerances(self.linSolveRtol, self.linSolveAtol)
 
             # Create the function list
             self.func_list, self.func_ref = self.setup_funcs(self.assembler)
@@ -154,7 +154,7 @@ class StaticTestCase:
             linSolveRes = np.abs(np.real(self.gmres.getResidualNorm()))
             converged = (
                 linSolveRes < self.linSolveAtol
-                or linSolveRes < self.linSolveRrtol * np.real(self.res0.norm())
+                or linSolveRes < self.linSolveRtol * np.real(self.res0.norm())
             )
             self.assertTrue(converged, "Linear solver did not converge")
 

--- a/tests/integration_tests/static_analysis_base_test.py
+++ b/tests/integration_tests/static_analysis_base_test.py
@@ -151,7 +151,7 @@ class StaticTestCase:
             func_vals = self.run_solve()
 
             # Test that linear solver residual is sufficiently small
-            linSolveRes = np.abs(np.real(self.gmres.getResidualNorm()))
+            linSolveRes = np.real(self.gmres.getResidualNorm())
             converged = (
                 linSolveRes < self.linSolveAtol
                 or linSolveRes < self.linSolveRtol * np.real(self.res0.norm())


### PR DESCRIPTION
In my nonlinear solver, I wanted to be able to check the final residual and the number of iterations from each linear solve (e.g to decide whether the preconditioner needs to be updated), this PR adds this functionality for all solvers that inherit from `TACSKsm` 

PR Summary:
- Adds protected `iterCount` and `resNorm` attributes to the abstract `TACSKsm` class, `iterCount` is the total number of iterations taken for the last linear solve and `resNorm` is the residual norm from the end of the last linear solve.
- Adds default constructor to `TACSKsm` that initialises `iterCount` and `resNorm` to 0
- Adds getter methods for `iterCount` and `resNorm` to `TACSKsm` and their python interfaces
- Adds code to update  `iterCount` and `resNorm` to the end of the `solve` methods of the `PCG`, `GMRES` and `GCROT` classes that inherit from `TACSKsm` 
- Adds basic convergence tests that rely on `iterCount` and `resNorm` to `StaticTestCase.test_solve`

Closes #4 