### PR TITLE
Add `__init__` method to `BaseUI` for setting up pyTACS options/comm

### DIFF
--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -19,7 +19,9 @@ class TACSProblem(BaseUI):
     Base class for TACS problem types. Contains methods common to all TACS problems.
     """
 
-    def __init__(self, assembler, comm, outputViewer=None, meshLoader=None):
+    def __init__(
+        self, assembler, comm=None, options=None, outputViewer=None, meshLoader=None
+    ):
         # TACS assembler object
         self.assembler = assembler
         # TACS F5 output writer
@@ -29,8 +31,6 @@ class TACSProblem(BaseUI):
         # pyNastran BDF object
         if self.meshLoader:
             self.bdfInfo = self.meshLoader.getBDFInfo()
-        # MPI communicator object
-        self.comm = comm
 
         # Create Design variable vector
         self.x = self.assembler.createDesignVec()
@@ -43,8 +43,8 @@ class TACSProblem(BaseUI):
         # List of functions
         self.functionList = OrderedDict()
 
-        # Empty options dict, should be filled out by child class
-        self.options = {}
+        # Setup comm and options
+        super().__init__(options=options, comm=comm)
 
         return
 

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -44,7 +44,7 @@ class TACSProblem(BaseUI):
         self.functionList = OrderedDict()
 
         # Setup comm and options
-        super().__init__(options=options, comm=comm)
+        BaseUI.__init__(self, options=options, comm=comm)
 
         return
 

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -86,7 +86,7 @@ class ModalProblem(TACSProblem):
         comm,
         outputViewer=None,
         meshLoader=None,
-        options={},
+        options=None,
     ):
         """
         NOTE: This class should not be initialized directly by the user.

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -122,6 +122,9 @@ class ModalProblem(TACSProblem):
         # Problem name
         self.name = name
 
+        # Default setup for common problem class objects, sets up comm and options
+        TACSProblem.__init__(self, assembler, comm, options, outputViewer, meshLoader)
+
         # Set time eigenvalue parameters
         self.sigma = sigma
         self.numEigs = numEigs
@@ -129,9 +132,6 @@ class ModalProblem(TACSProblem):
         # String name used in evalFunctions
         self.valName = "eigsm"
         self._initializeFunctionList()
-
-        # Default setup for common problem class objects, sets up comm and options
-        super().__init__(assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/problems/modal.py
+++ b/tacs/problems/modal.py
@@ -122,9 +122,6 @@ class ModalProblem(TACSProblem):
         # Problem name
         self.name = name
 
-        # Default setup for common problem class objects
-        TACSProblem.__init__(self, assembler, comm, outputViewer, meshLoader)
-
         # Set time eigenvalue parameters
         self.sigma = sigma
         self.numEigs = numEigs
@@ -133,17 +130,8 @@ class ModalProblem(TACSProblem):
         self.valName = "eigsm"
         self._initializeFunctionList()
 
-        # Process the default options which are added to self.options
-        # under the 'defaults' key. Make sure the key are lower case
-        def_keys = self.defaultOptions.keys()
-        self.options["defaults"] = {}
-        for key in def_keys:
-            self.options["defaults"][key.lower()] = self.defaultOptions[key]
-            self.options[key.lower()] = self.defaultOptions[key]
-
-        # Set user-defined options
-        for key in options:
-            TACSProblem.setOption(self, key, options[key])
+        # Default setup for common problem class objects, sets up comm and options
+        super().__init__(assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -109,7 +109,7 @@ class StaticProblem(TACSProblem):
         comm,
         outputViewer=None,
         meshLoader=None,
-        options={},
+        options=None,
     ):
         """
         NOTE: This class should not be initialized directly by the user.
@@ -140,20 +140,8 @@ class StaticProblem(TACSProblem):
         # Problem name
         self.name = name
 
-        # Default setup for common problem class objects
-        TACSProblem.__init__(self, assembler, comm, outputViewer, meshLoader)
-
-        # Process the default options which are added to self.options
-        # under the 'defaults' key. Make sure the key are lower case
-        def_keys = self.defaultOptions.keys()
-        self.options["defaults"] = {}
-        for key in def_keys:
-            self.options["defaults"][key.lower()] = self.defaultOptions[key]
-            self.options[key.lower()] = self.defaultOptions[key]
-
-        # Set user-defined options
-        for key in options:
-            TACSProblem.setOption(self, key, options[key])
+        # Default setup for common problem class objects, sets up comm and options
+        super().__init__(assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -140,6 +140,9 @@ class StaticProblem(TACSProblem):
         # Problem name
         self.name = name
 
+        # Set linear solver to None, until we set it up later
+        self.KSM = None
+
         # Default setup for common problem class objects, sets up comm and options
         TACSProblem.__init__(self, assembler, comm, options, outputViewer, meshLoader)
 
@@ -282,23 +285,24 @@ class StaticProblem(TACSProblem):
         # Default setOption for common problem class objects
         TACSProblem.setOption(self, name, value)
 
-        # Update tolerances
-        if "l2convergence" in name.lower():
-            self.KSM.setTolerances(
-                self.getOption("L2ConvergenceRel"),
-                self.getOption("L2Convergence"),
-            )
-        # No need to reset solver for output options
-        elif name.lower() in [
-            "writesolution",
-            "printtiming",
-            "numbersolutions",
-            "outputdir",
-        ]:
-            pass
-        # Reset solver for all other option changes
-        else:
-            self._createVariables()
+        if self.KSM is not None:
+            # Update tolerances
+            if "l2convergence" in name.lower():
+                self.KSM.setTolerances(
+                    self.getOption("L2ConvergenceRel"),
+                    self.getOption("L2Convergence"),
+                )
+            # No need to reset solver for output options
+            elif name.lower() in [
+                "writesolution",
+                "printtiming",
+                "numbersolutions",
+                "outputdir",
+            ]:
+                pass
+            # Reset solver for all other option changes
+            else:
+                self._createVariables()
 
     @property
     def loadScale(self):

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -141,7 +141,7 @@ class StaticProblem(TACSProblem):
         self.name = name
 
         # Default setup for common problem class objects, sets up comm and options
-        super().__init__(assembler, comm, options, outputViewer, meshLoader)
+        TACSProblem.__init__(self, assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -91,7 +91,7 @@ class TransientProblem(TACSProblem):
         comm,
         outputViewer=None,
         meshLoader=None,
-        options={},
+        options=None,
     ):
         """
         NOTE: This class should not be initialized directly by the user.
@@ -130,26 +130,14 @@ class TransientProblem(TACSProblem):
         # Problem name
         self.name = name
 
-        # Default setup for common problem class objects
-        TACSProblem.__init__(self, assembler, comm, outputViewer, meshLoader)
-
         # Set time interval parameters
         self.tInit = tInit
         self.tFinal = tFinal
         self.numSteps = numSteps
         self.numStages = None
 
-        # Process the default options which are added to self.options
-        # under the 'defaults' key. Make sure the key are lower case
-        def_keys = self.defaultOptions.keys()
-        self.options["defaults"] = {}
-        for key in def_keys:
-            self.options["defaults"][key.lower()] = self.defaultOptions[key]
-            self.options[key.lower()] = self.defaultOptions[key]
-
-        # Set user-defined options
-        for key in options:
-            TACSProblem.setOption(self, key, options[key])
+        # Default setup for common problem class objects, sets up comm and options
+        super().__init__(assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -136,6 +136,9 @@ class TransientProblem(TACSProblem):
         self.numSteps = numSteps
         self.numStages = None
 
+        # Set integrator to None, until we set it up later
+        self.integrator = None
+
         # Default setup for common problem class objects, sets up comm and options
         TACSProblem.__init__(self, assembler, comm, options, outputViewer, meshLoader)
 
@@ -244,30 +247,31 @@ class TransientProblem(TACSProblem):
         TACSProblem.setOption(self, name, value)
 
         # Update tolerances
-        if "l2convergence" in name.lower():
-            # Set solver tolerances
-            atol = self.getOption("L2Convergence")
-            self.integrator.setAbsTol(atol)
-            rtol = self.getOption("L2ConvergenceRel")
-            self.integrator.setRelTol(rtol)
-        elif name.lower() == "printlevel":
-            printLevel = self.getOption("printLevel")
-            self.integrator.setPrintLevel(printLevel)
-        elif name.lower() == "jacassemblyfreq":
-            # Jacobian assembly frequency
-            jacFreq = self.getOption("jacAssemblyFreq")
-            self.integrator.setJacAssemblyFreq(jacFreq)
-        # No need to reset solver for output options
-        elif name.lower() in [
-            "writesolution",
-            "printtiming",
-            "numbersolutions",
-            "outputdir",
-        ]:
-            pass
-        # Reset solver for all other option changes
-        else:
-            self._createVariables()
+        if self.integrator is not None:
+            if "l2convergence" in name.lower():
+                # Set solver tolerances
+                atol = self.getOption("L2Convergence")
+                self.integrator.setAbsTol(atol)
+                rtol = self.getOption("L2ConvergenceRel")
+                self.integrator.setRelTol(rtol)
+            elif name.lower() == "printlevel":
+                printLevel = self.getOption("printLevel")
+                self.integrator.setPrintLevel(printLevel)
+            elif name.lower() == "jacassemblyfreq":
+                # Jacobian assembly frequency
+                jacFreq = self.getOption("jacAssemblyFreq")
+                self.integrator.setJacAssemblyFreq(jacFreq)
+            # No need to reset solver for output options
+            elif name.lower() in [
+                "writesolution",
+                "printtiming",
+                "numbersolutions",
+                "outputdir",
+            ]:
+                pass
+            # Reset solver for all other option changes
+            else:
+                self._createVariables()
 
     def getNumTimeSteps(self):
         """

--- a/tacs/problems/transient.py
+++ b/tacs/problems/transient.py
@@ -137,7 +137,7 @@ class TransientProblem(TACSProblem):
         self.numStages = None
 
         # Default setup for common problem class objects, sets up comm and options
-        super().__init__(assembler, comm, options, outputViewer, meshLoader)
+        TACSProblem.__init__(self, assembler, comm, options, outputViewer, meshLoader)
 
         # Create problem-specific variables
         self._createVariables()

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -23,8 +23,8 @@ from .utilities import BaseUI
 
 class pyMeshLoader(BaseUI):
     def __init__(self, comm, printDebug=False):
-        # MPI communicator
-        self.comm = comm
+        # Set MPI communicator
+        BaseUI.__init__(self, comm=comm)
         # Debug printing flag
         self.printDebug = printDebug
         self.bdfInfo = None

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -152,7 +152,7 @@ class pyTACS(BaseUI):
         ],
     }
 
-    def __init__(self, fileName, comm=None, dvNum=0, scaleList=None, options={}):
+    def __init__(self, fileName, comm=None, dvNum=0, scaleList=None, options=None):
         """
 
         Parameters
@@ -180,26 +180,8 @@ class pyTACS(BaseUI):
 
         startTime = time.time()
 
-        # Set the communicator and rank -- defaults to MPI_COMM_WORLD
-        if comm is None:
-            comm = MPI.COMM_WORLD
-        self.comm = comm
-        self.rank = comm.rank
-
-        # Process the default options which are added to self.options
-        # under the 'defaults' key. Make sure the key are lower case
-        self.options = {}
-        def_keys = self.defaultOptions.keys()
-        self.options["defaults"] = {}
-        for key in def_keys:
-            self.options["defaults"][key.lower()] = self.defaultOptions[key]
-            self.options[key.lower()] = self.defaultOptions[key]
-
-        # Process the user-supplied options
-        userOptions = options
-        optKeys = userOptions.keys()
-        for key in optKeys:
-            self.setOption(key, userOptions[key])
+        # Setup comm and options
+        BaseUI.__init__(self, options=options, comm=comm)
 
         importTime = time.time()
 

--- a/tacs/utilities.py
+++ b/tacs/utilities.py
@@ -1,3 +1,4 @@
+from mpi4py import MPI
 import tacs.TACS
 
 
@@ -7,8 +8,41 @@ class BaseUI:
     Contains common methods useful for many classes.
     """
 
+    defaultOptions = {}
+
     # Set common data type for all pyTACS classes to inherit (real or complex)
     dtype = tacs.TACS.dtype
+
+    def __init__(self, options=None, comm=None) -> None:
+        """Setup the communicator and options for a pyTACS object
+
+        Parameters
+        ----------
+        options : dict, optional
+            Object-specific option parameters (case-insensitive), by default None
+        comm : _type_, optional
+            The comm object on which to create the pyTACS object., by default MPI.COMM_WORLD
+        """
+        # Set the communicator and rank
+        if comm is None:
+            comm = MPI.COMM_WORLD
+        self.comm = comm
+        self.rank = comm.rank
+
+        # Process the default options which are added to self.options
+        # under the 'defaults' key. Make sure the key are lower case
+        self.options = {}
+        def_keys = self.defaultOptions.keys()
+        self.options["defaults"] = {}
+        for key in def_keys:
+            self.options["defaults"][key.lower()] = self.defaultOptions[key]
+            self.options[key.lower()] = self.defaultOptions[key]
+
+        # Process the user-supplied options
+        userOptions = options if options is not None else {}
+        optKeys = userOptions.keys()
+        for key in optKeys:
+            self.setOption(key, userOptions[key])
 
     def setOption(self, name, value):
         """

--- a/tacs/utilities.py
+++ b/tacs/utilities.py
@@ -20,7 +20,7 @@ class BaseUI:
         ----------
         options : dict, optional
             Object-specific option parameters (case-insensitive), by default None
-        comm : _type_, optional
+        comm : mpi4py.MPI.Intracomm, optional
             The comm object on which to create the pyTACS object., by default MPI.COMM_WORLD
         """
         # Set the communicator and rank

--- a/tests/integration_tests/test_rigid_body_mass.py
+++ b/tests/integration_tests/test_rigid_body_mass.py
@@ -60,7 +60,9 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         fea_assembler.initialize()
 
         # Create case 1 static problem
-        problem = fea_assembler.createStaticProblem("rigid_body")
+        problem = fea_assembler.createStaticProblem(
+            "rigid_body", options={"printTiming": True}
+        )
 
         problem.addFunction("mass", functions.StructuralMass)
         problem.addFunction("cgx", functions.CenterOfMass, direction=[1.0, 0.0, 0.0])

--- a/tests/integration_tests/test_thermal_initial_conditions.py
+++ b/tests/integration_tests/test_thermal_initial_conditions.py
@@ -78,7 +78,11 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
 
         # Create transient problem, loads are already applied through BCs
         tp = fea_assembler.createTransientProblem(
-            name="transient", tInit=0.0, tFinal=5.0, numSteps=100
+            name="transient",
+            tInit=0.0,
+            tFinal=5.0,
+            numSteps=100,
+            options={"printLevel": 2},
         )
         # Set the initial conditions
         tp.setInitConditions(vars=150.0)


### PR DESCRIPTION
Previously, all pyTACS classes had the same boilerplate code in their `__init__` methods for setting up their MPI communicators and options dictionaries. This PR moves that code into the `__init__` method of the `BaseUI` class which is inherited by all pyTACS classes, reducing repeated code.