### PR TITLE
Adding warnings for invalid beam/shell ref axes

### DIFF
--- a/src/elements/shell/TACSBeamElement.h
+++ b/src/elements/shell/TACSBeamElement.h
@@ -53,6 +53,14 @@ class TACSBeamRefAxisTransform : public TACSBeamTransform {
     A2D::Vec3Dot dott1(axis, t1, dot);
     A2D::Vec3Axpy axpy(-1.0, dot, t1, axis, t2_dir);
 
+    // Check if ref axis is parallel to beam
+    if (abs(TacsRealPart(dot.value)) > 1.0 - SMALL_NUM) {
+      fprintf(stderr,
+              "TACSBeamRefAxisTransform: Error, user-provided reference axis "
+              "is parallel to beam axis. "
+              "Element behavior may be ill-conditioned.\n");
+    }
+
     // Compute the t2 direction
     A2D::Vec3 t2;
     A2D::Vec3Normalize normalizet2(t2_dir, t2);
@@ -61,7 +69,7 @@ class TACSBeamRefAxisTransform : public TACSBeamTransform {
     A2D::Vec3 t3;
     A2D::Vec3CrossProduct cross(t1, t2, t3);
 
-    // Assemble the referece frame
+    // Assemble the reference frame
     A2D::Mat3x3 T;
     A2D::Mat3x3FromThreeVec3 assembleT(t1, t2, t3, T);
 
@@ -111,6 +119,8 @@ class TACSBeamRefAxisTransform : public TACSBeamTransform {
 
  private:
   A2D::Vec3 axis;
+  /* Tolerance for colinearity test in between beam axis and ref axis */
+  const double SMALL_NUM = 1e-8;
 };
 
 /*

--- a/src/elements/shell/TACSShellElementTransform.h
+++ b/src/elements/shell/TACSShellElementTransform.h
@@ -121,6 +121,14 @@ class TACSShellRefAxisTransform : public TACSShellTransform {
     // Compute the dot product with
     TacsScalar an = vec3Dot(axis, n);
 
+    // Check if ref axis is parallel with normal
+    if (abs(TacsRealPart(an)) > 1.0 - SMALL_NUM) {
+      fprintf(stderr,
+              "TACSShellRefAxisTransform: Error, user-provided reference axis "
+              "is perpendicular to shell. "
+              "Element behavior may be ill-conditioned.\n");
+    }
+
     // Take the component of the reference axis perpendicular
     // to the surface
     TacsScalar t1[3];
@@ -200,6 +208,8 @@ class TACSShellRefAxisTransform : public TACSShellTransform {
 
  private:
   TacsScalar axis[3];
+  /* Tolerance for colinearity test in between shell normal and ref axis */
+  const double SMALL_NUM = 1e-8;
 };
 
 #endif  // TACS_SHELL_ELEMENT_TRANSFORM_H


### PR DESCRIPTION
Adding warning messages for invalid ref axes in Beam/Shell classes.
This adds a check for the ShellRefAxisTransform that makes sure the ref axis isn't perpendicular to the element
and a check for the BeamRefAxisTransform that makes sure the ref axis isn't parallel to the beam axis.