### PR TITLE
Separate problem names/workdir for Caps unittests

### DIFF
--- a/tests/integration_tests/test_caps_shape_derivatives.py
+++ b/tests/integration_tests/test_caps_shape_derivatives.py
@@ -31,7 +31,9 @@ class TestCaps2TacsShape(unittest.TestCase):
 
         # build the tacs model with constraints, loads, properties, analysis functions, mesh, etc.
         comm = MPI.COMM_WORLD
-        tacs_model = caps2tacs.TacsModel.build(csm_file=csm_path, comm=comm)
+        tacs_model = caps2tacs.TacsModel.build(
+            csm_file=csm_path, comm=comm, problem_name="capsStruct1"
+        )
         tacs_model.egads_aim.set_mesh(  # need a refined-enough mesh for the derivative test to pass
             edge_pt_min=15,
             edge_pt_max=20,

--- a/tests/integration_tests/test_caps_thick_derivatives.py
+++ b/tests/integration_tests/test_caps_thick_derivatives.py
@@ -28,7 +28,9 @@ class TestCaps2TacsSizing(unittest.TestCase):
 
         # build the tacs model with constraints, loads, properties, analysis functions, mesh, etc.
         comm = MPI.COMM_WORLD
-        tacs_model = caps2tacs.TacsModel.build(csm_file=csm_path, comm=comm)
+        tacs_model = caps2tacs.TacsModel.build(
+            csm_file=csm_path, comm=comm, problem_name="capsStruct2"
+        )
         tacs_model.egads_aim.set_mesh(  # need a refined-enough mesh for the derivative test to pass
             edge_pt_min=15,
             edge_pt_max=20,


### PR DESCRIPTION
* Previously both unit tests were assigned the same auto-workdir name with ESP/CAPS called "capsStruct".
* There was a testflo error in which one processor tried to start a caps unittest while the other was running and encountered the capsLock file, crashing the test.
* Solution is to have each CAPS unittest run on separate automatic work directories with names "capsStruct1", "capsStruct2".