### PR TITLE
Updating crm_opt example to work with current API

### DIFF
--- a/examples/crm/crm_opt.py
+++ b/examples/crm/crm_opt.py
@@ -2,86 +2,64 @@
 # mass of the CRM model subject to a global stress aggregate constraint
 # enforcing that the maximum stress at any quadrature point is less than
 # a specified upper bound.
-from __future__ import print_function
 
 # Import necessary libraries
 import numpy as np
 from mpi4py import MPI
-from tacs import TACS, elements, constitutive, functions
 from paropt import ParOpt
 
+from tacs import pyTACS, elements, constitutive, functions
 
-class uCRM_VonMisesMassMin(ParOpt.pyParOptProblem):
+
+class uCRM_VonMisesMassMin(ParOpt.Problem):
     """
     Mass minimization with a von Mises stress constraint
     """
 
     def __init__(self, comm, bdf_name):
         self.comm = comm
-        struct_mesh = TACS.MeshLoader(self.comm)
-        struct_mesh.scanBDFFile(bdf_name)
 
         # Set constitutive properties
         rho = 2500.0  # density, kg/m^3
         E = 70e9  # elastic modulus, Pa
         nu = 0.3  # poisson's ratio
-        kcorr = 5.0 / 6.0  # shear correction factor
         ys = 350e6  # yield stress, Pa
         min_thickness = 0.002
         max_thickness = 0.20
         thickness = 0.02
 
-        # Loop over components, creating stiffness and element object for each
-        num_components = struct_mesh.getNumComponents()
-        for i in range(num_components):
-            descriptor = struct_mesh.getElementDescript(i)
-
-            # Set the design variable index
-            design_variable_index = i
-            stiff = constitutive.isoFSDT(
-                rho,
-                E,
-                nu,
-                kcorr,
-                ys,
-                thickness,
-                design_variable_index,
-                min_thickness,
-                max_thickness,
+        # Callback function used to setup TACS element objects and DVs
+        def elemCallBack(
+            dvNum, compID, compDescript, elemDescripts, globalDVs, **kwargs
+        ):
+            # Setup (isotropic) property and constitutive objects
+            prop = constitutive.MaterialProperties(rho=rho, E=E, nu=nu, ys=ys)
+            # Set one thickness dv for every component
+            con = constitutive.IsoShellConstitutive(
+                prop, t=thickness, tNum=dvNum, tlb=min_thickness, tub=max_thickness
             )
-            element = None
 
-            # Create the element object
-            if descriptor in ["CQUAD", "CQUADR", "CQUAD4"]:
-                element = elements.MITCShell(2, stiff, component_num=i)
-            struct_mesh.setElement(i, element)
+            # This is an all-quad mesh, return a quad shell
+            transform = None
+            elem = elements.Quad4Shell(transform, con)
+            return elem
 
-        # Create tacs assembler object from mesh loader
-        self.assembler = struct_mesh.createTACS(6)
+        # Create pyTACS assembler object
+        self.fea_assembler = pyTACS(bdf_name, comm=comm)
+        # Setup elements
+        self.fea_assembler.initialize(elemCallBack)
 
-        # Create the KS Function
-        ksWeight = 50.0
-        self.funcs = [
-            functions.StructuralMass(self.assembler),
-            functions.KSFailure(self.assembler, ksWeight=ksWeight),
-        ]
-
-        # Create the forces
-        self.forces = self.assembler.createVec()
-        force_array = self.forces.getArray()
-        force_array[2::6] += 100.0  # uniform load in z direction
-        self.assembler.applyBCs(self.forces)
-
-        # Set up the solver
-        self.ans = self.assembler.createVec()
-        self.res = self.assembler.createVec()
-        self.adjoint = self.assembler.createVec()
-        self.dfdu = self.assembler.createVec()
-        self.mat = self.assembler.createFEMat()
-        self.pc = TACS.Pc(self.mat)
-        subspace = 100
-        restarts = 2
-        self.gmres = TACS.KSM(self.mat, self.pc, subspace, restarts)
+        # Create a static problem with a uniform z load applied to all nodes
+        self.static_problem = self.fea_assembler.createStaticProblem("uniform_z_load")
+        F = self.fea_assembler.createVec()
+        F[2::6] += 100.0
+        self.static_problem.addLoadToRHS(F)
+        # Add failure function (con)
+        self.static_problem.addFunction(
+            "ks_failure", functions.KSFailure, ksWeight=50.0
+        )
+        # add mass (obj)
+        self.static_problem.addFunction("mass", functions.StructuralMass)
 
         # Scale the mass objective so that it is O(10)
         self.mass_scale = 1e-3
@@ -91,7 +69,7 @@ class uCRM_VonMisesMassMin(ParOpt.pyParOptProblem):
         self.thickness_scale = 1000.0
 
         # The number of thickness variables in the problem
-        self.nvars = num_components
+        self.nvars = self.fea_assembler.getNumDesignVars()
 
         # The number of constraints (1 global stress constraint that
         # will use the KS function)
@@ -104,29 +82,18 @@ class uCRM_VonMisesMassMin(ParOpt.pyParOptProblem):
         # Set the inequality options for this problem in ParOpt:
         # The dense constraints are inequalities c(x) >= 0 and
         # use both the upper/lower bounds
-        self.setInequalityOptions(dense_ineq=True, use_lower=True, use_upper=True)
+        self.setInequalityOptions(sparse_ineq=False, use_lower=True, use_upper=True)
 
-        # For visualization
-        flag = (
-            TACS.ToFH5.NODES
-            | TACS.ToFH5.DISPLACEMENTS
-            | TACS.ToFH5.STRAINS
-            | TACS.ToFH5.EXTRAS
-        )
-        self.f5 = TACS.ToFH5(self.assembler, TACS.PY_SHELL, flag)
         self.iter_count = 0
 
         return
 
     def getVarsAndBounds(self, x, lb, ub):
         """Set the values of the bounds"""
-        xvals = np.zeros(self.nvars, TACS.dtype)
-        self.assembler.getDesignVars(xvals)
+        xvals = self.static_problem.getDesignVars()
         x[:] = self.thickness_scale * xvals
 
-        xlb = np.zeros(self.nvars, TACS.dtype)
-        xub = np.zeros(self.nvars, TACS.dtype)
-        self.assembler.getDesignVarRange(xlb, xub)
+        xlb, xub = self.static_problem.getDesignVarRange()
         lb[:] = self.thickness_scale * xlb
         ub[:] = self.thickness_scale * xub
 
@@ -137,65 +104,58 @@ class uCRM_VonMisesMassMin(ParOpt.pyParOptProblem):
         # Evaluate the objective and constraints
         fail = 0
         con = np.zeros(1)
+        func_dict = {}
 
         # Set the new design variable values
-        self.assembler.setDesignVars(x[:] / self.thickness_scale)
+        self.static_problem.setDesignVars(x[:] / self.thickness_scale)
 
-        # Assemble the Jacobian and factor the matrix
-        alpha = 1.0
-        beta = 0.0
-        gamma = 0.0
-        self.assembler.zeroVariables()
-        self.assembler.assembleJacobian(alpha, beta, gamma, self.res, self.mat)
-        self.pc.factor()
-
-        # Solve the linear system and set the varaibles into TACS
-        self.gmres.solve(self.forces, self.ans)
-        self.assembler.setVariables(self.ans)
+        # Solve
+        self.static_problem.solve()
 
         # Evaluate the function
-        fvals = self.assembler.evalFunctions(self.funcs)
+        self.static_problem.evalFunctions(func_dict)
+
+        if self.comm.rank == 0:
+            print(func_dict)
 
         # Set the mass as the objective
-        fobj = self.mass_scale * fvals[0]
+        fobj = self.mass_scale * func_dict["uniform_z_load_mass"]
 
         # Set the KS function (the approximate maximum ratio of the
         # von Mises stress to the design stress) so that
         # it is less than or equal to 1.0
-        con[0] = 1.0 - fvals[1]  # ~= 1.0 - max (sigma/design) >= 0
+        con[0] = (
+            1.0 - func_dict["uniform_z_load_ks_failure"]
+        )  # ~= 1.0 - max (sigma/design) >= 0
 
         return fail, fobj, con
 
     def evalObjConGradient(self, x, g, A):
         """Evaluate the objective and constraint gradient"""
         fail = 0
+        sens_dict = {}
 
-        # Evaluate the derivative of the mass and place it in the
+        # Set the new design variable values
+        self.static_problem.setDesignVars(x[:] / self.thickness_scale)
+
+        # Evaluate the function sensitivities
+        self.static_problem.evalFunctionsSens(sens_dict)
+
         # objective gradient
-        gx = np.zeros(self.nvars, TACS.dtype)
-        self.assembler.evalDVSens(self.funcs[0], gx)
-        g[:] = self.mass_scale * gx / self.thickness_scale
-
-        # Compute the total derivative w.r.t. material design variables
-        dfdx = np.zeros(self.nvars, TACS.dtype)
-        product = np.zeros(self.nvars, TACS.dtype)
-
-        # Compute the derivative of the function w.r.t. the state
-        # variables
-        self.assembler.evalDVSens(self.funcs[1], dfdx)
-        self.assembler.evalSVSens(self.funcs[1], self.dfdu)
-        self.gmres.solve(self.dfdu, self.adjoint)
-
-        # Compute the product of the adjoint with the derivative of the
-        # residuals
-        self.assembler.evalAdjointResProduct(self.adjoint, product)
+        g[:] = (
+            self.mass_scale
+            * sens_dict["uniform_z_load_mass"]["struct"]
+            / self.thickness_scale
+        )
 
         # Set the constraint gradient
-        A[0][:] = -(dfdx - product) / self.thickness_scale
+        A[0][:] = (
+            -sens_dict["uniform_z_load_ks_failure"]["struct"] / self.thickness_scale
+        )
 
         # Write out the solution file every 10 iterations
         if self.iter_count % 10 == 0:
-            self.f5.writeToFile("ucrm_iter%d.f5" % (self.iter_count))
+            self.static_problem.writeSolution()
         self.iter_count += 1
 
         return fail
@@ -208,15 +168,29 @@ bdf_name = "CRM_box_2nd.bdf"
 crm_opt = uCRM_VonMisesMassMin(tacs_comm, bdf_name)
 
 # Set up the optimization problem
-max_lbfgs = 5
-opt = ParOpt.pyParOpt(crm_opt, max_lbfgs, ParOpt.BFGS)
-opt.setOutputFile("crm_opt.out")
+options = {
+    "algorithm": "tr",
+    "tr_init_size": 0.05,
+    "tr_min_size": 1e-6,
+    "tr_max_size": 10.0,
+    "tr_eta": 0.25,
+    "tr_infeas_tol": 1e-6,
+    "tr_l1_tol": 1e-3,
+    "tr_linfty_tol": 0.0,
+    "tr_adaptive_gamma_update": True,
+    "tr_max_iterations": 1000,
+    "max_major_iters": 100,
+    "penalty_gamma": 1e3,
+    "qn_subspace_size": 10,
+    "qn_type": "bfgs",
+    "abs_res_tol": 1e-8,
+    "starting_point_strategy": "affine_step",
+    "barrier_strategy": "mehrotra_predictor_corrector",
+    "use_line_search": False,
+}
+opt = ParOpt.Optimizer(crm_opt, options)
 
-# Set optimization parameters
-opt.checkGradients(1e-6)
-
-# Set optimization parameters
-opt.setArmijoParam(1e-5)
+# Run the optimization
 opt.optimize()
 
 # Get the optimized point

--- a/examples/crm/crm_opt.py
+++ b/examples/crm/crm_opt.py
@@ -160,6 +160,10 @@ class uCRM_VonMisesMassMin(ParOpt.Problem):
 
         return fail
 
+    def writeSolutionBDF(self, file_name):
+        # Write loads and optimized panel properties to BDF
+        self.fea_assembler.writeBDF(file_name, self.static_problem)
+
 
 # Load structural mesh from BDF file
 tacs_comm = MPI.COMM_WORLD
@@ -195,3 +199,6 @@ opt.optimize()
 
 # Get the optimized point
 x, z, zw, zl, zu = opt.getOptimizedPoint()
+
+# Write final design to BDF
+crm_opt.writeSolutionBDF("opt_sol.bdf")

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -3271,7 +3271,7 @@ void TACSAssembler::setDesignVars(TACSBVec *dvs) {
   Retrieve the design variable range.
 
   This call is collective on all TACS processes. The ranges provided
-  by indivdual objects may not be consistent (if someone provided
+  by individual objects may not be consistent (if someone provided
   incorrect data they could be.)
 
   @param lb the lower bound on the design variables

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -1731,7 +1731,7 @@ cdef class Assembler:
         Retrieve the design variable range.
 
         This call is collective on all TACS processes. The ranges
-        provided by indivdual objects may not be consistent (if
+        provided by individual objects may not be consistent (if
         someone provided incorrect data they could be.) Make a
         best guess; take the minimum upper bound and the maximum
         lower bound.

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -69,7 +69,7 @@ class TACSProblem(BaseUI):
 
         Returns
         ----------
-        x : array
+        x : numpy.ndarray
             The current design variable vector set in tacs.
 
         """
@@ -103,6 +103,23 @@ class TACSProblem(BaseUI):
 
         # Set the variables in tacs
         self.assembler.setDesignVars(self.x)
+
+    def getDesignVarRange(self):
+        """
+        get the lower/upper bounds for the design variables.
+
+        Returns
+        ----------
+        xlb : numpy.ndarray
+            The design variable lower bound.
+        xub : numpy.ndarray
+            The design variable upper bound.
+
+        """
+        xlb = self.assembler.createDesignVec()
+        xub = self.assembler.createDesignVec()
+        self.assembler.getDesignVarRange(xlb, xub)
+        return xlb.getArray(), xub.getArray()
 
     def _arrayToDesignVec(self, dvArray):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -220,6 +220,9 @@ class pyTACS(BaseUI):
         self.Xpts0 = None
         # List of initial designvars
         self.x0 = None
+        # Design var upper/lower-bounds
+        self.xub = None
+        self.xlb = None
 
         # Variables per node for model
         self.varsPerNode = None
@@ -775,6 +778,11 @@ class pyTACS(BaseUI):
         self.x0 = self.assembler.createDesignVec()
         self.assembler.getDesignVars(self.x0)
 
+        # Store design variable upper/lower-bounds
+        self.xub = self.assembler.createDesignVec()
+        self.xlb = self.assembler.createDesignVec()
+        self.assembler.getDesignVarRange(self.xlb, self.xub)
+
     def _elemCallBackFromBDF(self):
         """
         Automatically setup elemCallBack using information contained in BDF file.
@@ -1143,6 +1151,21 @@ class pyTACS(BaseUI):
 
         """
         return self.x0.getArray().copy()
+
+    @postinitialize_method
+    def getDesignVarRange(self):
+        """
+        get the lower/upper bounds for the design variables.
+
+        Returns
+        ----------
+        xlb : numpy.ndarray
+            The design variable lower bound.
+        xub : numpy.ndarray
+            The design variable upper bound.
+
+        """
+        return self.xlb.getArray().copy(), self.xub.getArray().copy()
 
     @postinitialize_method
     def createDesignVec(self, asBVec=False):


### PR DESCRIPTION
- updating crm_opt.py example to work with current tacs/paropt API
- adding `getDesignVarRange` method to pyTACS