### PR TITLE
Fixing issue with `writeBDF` in parallel

### DIFF
--- a/tacs/TACS.pxd
+++ b/tacs/TACS.pxd
@@ -382,6 +382,7 @@ cdef extern from "TACSElement.h":
         int getDesignVarsPerNode()
         int getDesignVarNums(int, int, int*)
         int getDesignVars(int, int, TacsScalar*)
+        int setDesignVars(int, int, const TacsScalar*)
         int getDesignVarRange(int, int, TacsScalar*, TacsScalar*)
         TACSElementBasis* getElementBasis()
         TACSElementModel* getElementModel()

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -438,6 +438,27 @@ cdef class Element:
         self.ptr.getDesignVars(elemIndex, dvLen, <TacsScalar*>dvs.data)
         return dvs
 
+    def setDesignVars(self, int elemIndex, np.ndarray[TacsScalar, ndim=1] dvs):
+        """
+        setDesignVars(self, int elemIndex, np.ndarray[TacsScalar, ndim=1] dvs)
+
+        Set the design variable values associated with this element
+
+        Args:
+            elemIndex (integer) The element index
+            dvs (np.ndarray) An array of the design variable values
+        """
+        cdef int dvsPerNode = 0
+        cdef int dvLen = 0
+
+        if self.ptr is NULL:
+            return None
+
+        dvsPerNode = self.ptr.getDesignVarsPerNode()
+        dvLen = self.ptr.getDesignVarNums(elemIndex, 0, NULL)
+        assert len(dvs) == dvLen * dvsPerNode
+        self.ptr.setDesignVars(elemIndex, dvLen, <TacsScalar*>dvs.data)
+
     def getDesignVarRange(self, int elemIndex):
         """
         getDesignVarRange(self, int elemIndex)

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1576,8 +1576,8 @@ class pyTACS(BaseUI):
         dv_bvec = self.createDesignVec(asBVec=True)
         dv_bvec.getArray()[:] = problems[0].getDesignVars()
         # Transfer all non-local dvs
-        dv_bvec.beginSetValues()
-        dv_bvec.endSetValues()
+        dv_bvec.beginDistributeValues()
+        dv_bvec.endDistributeValues()
 
         # Get local node info for each processor
         multNodes = self.getLocalMultiplierNodeIDs()

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1576,7 +1576,8 @@ class pyTACS(BaseUI):
         dv_bvec = self.createDesignVec(asBVec=True)
         dv_bvec.getArray()[:] = problems[0].getDesignVars()
         # Transfer all non-local dvs
-        dv_bvec.distributeValues()
+        dv_bvec.beginSetValues()
+        dv_bvec.endSetValues()
 
         # Get local node info for each processor
         multNodes = self.getLocalMultiplierNodeIDs()


### PR DESCRIPTION
- Not all constitutive dvs are updated on root proc by TACSAssembler when `writeBDF` is called parallel
- This is because TACSAssembler's `setDesignVars` method only updates element objects owned by each processor
- To fix this we directly set variable values to element class in `writeBDF` procedure