### PR TITLE
Fixing issue with mpi4py build requirement on Python 3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,8 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy', 'mpi4py==3.1.1']
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy',
+            # Build against an old version (3.1.1) of mpi4py for forward compatibility
+            "mpi4py==3.1.1; python_version<'3.11'",
+            # Python 3.11 requires 3.1.4+
+            "mpi4py==3.1.4; python_version>='3.11'"]


### PR DESCRIPTION
Apparently, Python 3.11 isn't compatible with older versions (<3.1.4) of mpi4py, see [release notes](https://github.com/mpi4py/mpi4py/releases/tag/3.1.4). To fix this we can add a conditional mpi4py version requirement for Python versions >= 3.11