### PR TITLE
Add methods to mphys interface for getting DV bounds and scaling factors

### DIFF
--- a/tacs/mphys/mphys_tacs.py
+++ b/tacs/mphys/mphys_tacs.py
@@ -1125,6 +1125,57 @@ class TacsBuilder(Builder):
         else:
             return self.fea_assembler.getOrigDesignVars()
 
+    def get_dv_bounds(self):
+        """Get arrays containing the lower and upper bounds for the design variables,
+        in the form needed by OpenMDAO's `add_design_variable` method.
+
+        Returns
+        -------
+        list of ndarray
+            lower and upper bounds for the design variables
+        """
+        if MPI is not None and self.comm.size > 1:
+            # Get bounds owned by this processor
+            local_dv_bounds = self.fea_assembler.getDesignVarRange()
+            local_dv_bounds = list(local_dv_bounds)
+            local_dv_bounds[0] = local_dv_bounds[0].astype(float)
+            local_dv_bounds[1] = local_dv_bounds[1].astype(float)
+
+            # Size of design variable on this processor
+            local_ndvs = self.fea_assembler.getNumDesignVars()
+            # Size of design variable vector on each processor
+            dv_sizes = self.comm.allgather(local_ndvs)
+            # Offsets for global design variable vector
+            offsets = np.zeros(self.comm.size, dtype=int)
+            offsets[1:] = np.cumsum(dv_sizes)[:-1]
+            # Gather the portions of the design variable array distributed across each processor
+            tot_ndvs = sum(dv_sizes)
+            global_dv_bounds = []
+            for ii in [0, 1]:
+                global_dv_bounds.append(
+                    np.zeros(tot_ndvs, dtype=local_dv_bounds[ii].dtype)
+                )
+                self.comm.Allgatherv(
+                    local_dv_bounds[ii],
+                    [global_dv_bounds[ii], dv_sizes, offsets, MPI.DOUBLE],
+                )
+            # return the global dv array
+            return global_dv_bounds
+        else:
+            return self.fea_assembler.getDesignVarRange()
+
+    def get_dv_scalers(self):
+        """Get an array containing the scaling factors for the design
+        variables, in the form needed by OpenMDAO's `add_design_variable`
+        method.
+
+        Returns
+        -------
+        array
+            Scaling values
+        """
+        return np.array(self.fea_assembler.scaleList)
+
     def get_ndv(self):
         """
         Get total number of structural design variables across all procs

--- a/tests/integration_tests/test_mphys_struct_plate.py
+++ b/tests/integration_tests/test_mphys_struct_plate.py
@@ -11,8 +11,8 @@ from tacs import elements, constitutive, functions
 
 """
 This is a simple 1m by 2m plate made up of four quad shell elements.
-The plate is structurally loaded under a 100G gravity load and a unit force, 
-"f_struct", is applied on on every node. The mass and KSFailure of the plate 
+The plate is structurally loaded under a 100G gravity load and a unit force,
+"f_struct", is applied on on every node. The mass and KSFailure of the plate
 are evaluated as outputs and have their partial and total sensitivities checked.
 """
 
@@ -58,7 +58,7 @@ class ProblemTest(OpenMDAOTestCase.OpenMDAOTest):
             E = 73.1e9  # elastic modulus, Pa
             nu = 0.33  # poisson's ratio
             ys = 324.0e6  # yield stress, Pa
-            thickness = 0.012
+            thickness = 0.01
             min_thickness = 0.002
             max_thickness = 0.05
 
@@ -125,10 +125,15 @@ class ProblemTest(OpenMDAOTestCase.OpenMDAOTest):
                     write_solution=False,
                 )
                 tacs_builder.initialize(self.comm)
-                ndv_struct = tacs_builder.get_ndv()
 
                 dvs = self.add_subsystem("dvs", om.IndepVarComp(), promotes=["*"])
-                dvs.add_output("dv_struct", np.array(ndv_struct * [0.01]))
+                structDVs = tacs_builder.get_initial_dvs()
+                dvs.add_output("dv_struct", structDVs)
+                lb, ub = tacs_builder.get_dv_bounds()
+                structDVScaling = tacs_builder.get_dv_scalers()
+                self.add_design_var(
+                    "dv_struct", lower=lb, upper=ub, scaler=structDVScaling
+                )
 
                 f_size = tacs_builder.get_ndof() * tacs_builder.get_number_of_nodes()
                 forces = self.add_subsystem("forces", om.IndepVarComp(), promotes=["*"])


### PR DESCRIPTION
Adds methods to the `TACSBuilder` class to retrieve the DV bounds and scaling factors that have been defined in the `element_callback`. This makes it easy to define the DV bounds and scales when using TACS through MPhys, e.g

```python
  dvs = self.add_subsystem("dvs", om.IndepVarComp(), promotes=["*"])
  structDVs = tacs_builder.get_initial_dvs()
  dvs.add_output("dv_struct", structDVs)
  lb, ub = tacs_builder.get_dv_bounds()
  structDVScaling = tacs_builder.get_dv_scalers()
  self.add_design_var(
      "dv_struct", lower=lb, upper=ub, scaler=structDVScaling
  )
```