### PR TITLE
Require cython<3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29', 'oldest-supported-numpy',
+requires = ['setuptools>=45.0', 'wheel', 'cython>=0.29,<3.0', 'oldest-supported-numpy',
             # Build against an old version (3.1.1) of mpi4py for forward compatibility
             "mpi4py==3.1.1; python_version<'3.11'",
             # Python 3.11 requires 3.1.4+


### PR DESCRIPTION
[Cython 3.0](https://cython.readthedocs.io/en/latest/src/changes.html#unified-release-notes) just came out and seems to break the TACS build (see [here](https://github.com/smdogroup/tacs/actions/runs/5581344219/jobs/10199381683))

We should definitely work on fixing these issues, but for now, this PR updates the build requirements to require a cython version <3.0 so that the build works.