### PR TITLE
pinning against metis 5.1.0

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -85,7 +85,7 @@ jobs:
           conda install gxx_linux-64=9.3.0 -q -y;
           conda install -c anaconda openblas -q -y;
           conda install -c conda-forge lapack -q -y;
-          conda install -c conda-forge metis -q -y;
+          conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ This will generate a .plt or .vtk file respectively.
 
 # Setting up and installing TACS from source #
 
-In addition to a working implementation of MPI, BLAS and LAPACK, TACS requires Metis 5.1 for mesh partitioning. The latest version of Metis can be obtained [here](http://glaros.dtc.umn.edu/gkhome/metis/metis/download). TACS can optionally use the approximate minimum degree ordering routines from AMD/UFConfig. These were distributed separately, but can now be obtained from SuiteSparse package. If you use AMD, be sure to define the TACS_HAS_AMD_LIBRARY flag within the Makefile.in configuration file.
+In addition to a working implementation of MPI, BLAS and LAPACK, TACS requires Metis 5.1.0 for mesh partitioning. The 5.1.0 version of Metis can be obtained [here](https://src.fedoraproject.org/lookaside/pkgs/metis/metis-5.1.0.tar.gz/5465e67079419a69e0116de24fce58fe/). TACS can optionally use the approximate minimum degree ordering routines from AMD/UFConfig. These were distributed separately, but can now be obtained from SuiteSparse package. If you use AMD, be sure to define the TACS_HAS_AMD_LIBRARY flag within the Makefile.in configuration file.
 
 To convert TACS FH5 output files to tecplot-compatible files, you must install [TecIO](https://tecplot.azureedge.net/products/tecio/2021r2/tecio.tgz). This can be placed in the tacs/extern directory. There is also a FH5 to VTK converter as well that produces (large) ASCII files.
 

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -54,7 +54,7 @@ requirements:
     - mpich-mpicxx  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - metis >=5.1
+    - metis ==5.1.0
     - tecio
     - mpi4py
     - cython >=0.29,<3.0
@@ -72,7 +72,7 @@ requirements:
     - mpich-mpicxx  # [mpi == "mpich"]
     - libopenblas
     - lapack
-    - metis >=5.1
+    - metis ==5.1.0
     - mpi4py
     - pynastran
     - numba

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -42,7 +42,7 @@ The following packages are required to use TACS:
 * MPI
 * BLAS
 * LAPACK
-* Metis 5.1
+* Metis 5.1.0
 
 To use the python interface to TACS you will also require:
 
@@ -123,7 +123,7 @@ These instructions direct you to install METIS and other dependencies in the dir
 This location for the dependencies is not required, and indeed may not be best.
 If you already have these libraries installed, simply adjust the variables in ``tacs/Makefile.in`` accordingly.
 
-Go to the directory ``tacs/extern``. Download ``metis-5.1.0`` from `<http://glaros.dtc.umn.edu/gkhome/metis/metis/download>`_ and place the file ``metis-5.1.0.tar.gz`` there.
+Go to the directory ``tacs/extern``. Download ``metis-5.1.0`` from `<https://src.fedoraproject.org/lookaside/pkgs/metis/metis-5.1.0.tar.gz/5465e67079419a69e0116de24fce58fe/>`_ and place the file ``metis-5.1.0.tar.gz`` there.
 Note that METIS needs CMake to build and install.
 
 Optionally, you can also place ``SuiteSparse-5.13.0.tar.gz`` (available from `<https://github.com/DrTimothyAldenDavis/SuiteSparse/releases>`_) in the same directory if you want to use the approximate minimum degree ordering routines from SuiteSparse.


### PR DESCRIPTION
The recently released metis 5.1.1 package on conda forge seems to be causing segfault issues in TACS environments setup through conda (see [here](https://github.com/timryanb/mphys/actions/runs/5622597192/job/15235542766)). 

Pinning CI/conda recipe against older 5.1.0 package to prevent this in future

Also updating broken Metis download link in ReadMe/docs. Closes issue #235 