### PR TITLE
Fix local node ID conversion in `getLocalNodeIDsForComps`

### DIFF
--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -552,11 +552,7 @@ class pyMeshLoader(BaseUI):
             componentIDs, nastranOrdering=False
         )
 
-        # convert global nodeIDs to local numbering on this processor if requested
-        rank = self.comm.rank
-        ownerRange = self.assembler.getOwnerRange()
-        allNodesOnProc = list(range(ownerRange[rank], ownerRange[rank + 1]))
-        nodes = [i for i, v in enumerate(allNodesOnProc) if v in globalNodeIDs]
+        nodes = self.getLocalNodeIDsFromGlobal(globalNodeIDs, nastranOrdering=False)
 
         return nodes
 


### PR DESCRIPTION
The conversion from global to local nodeIDs in `getLocalNodeIDsForComps` doesn't currently account for the node reordering that TACS does after the mesh is loaded. @timryanb came up with this fix so that it does.

## ToDo before merging

- [ ] Add a test for this