### PR TITLE
Minor fix for when getLocalNodeIDsForComps is called in parallel

### DIFF
--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -552,9 +552,12 @@ class pyMeshLoader(BaseUI):
             componentIDs, nastranOrdering=False
         )
 
-        nodes = self.getLocalNodeIDsFromGlobal(globalNodeIDs, nastranOrdering=False)
+        # get the corresponding local IDs on each proc
+        localNodeIDs = self.getLocalNodeIDsFromGlobal(globalNodeIDs, nastranOrdering=False)
+        # If the returned index is > 0 then it is owned by this proc, otherwise remove it
+        localNodeIDs = [localID for localID in localNodeIDs if localID >= 0]
 
-        return nodes
+        return localNodeIDs
 
     def getGlobalElementIDsForComps(self, componentIDs, nastranOrdering=False):
         """


### PR DESCRIPTION
- Adding a necessary ownership check before returning nodes in `getLocalNodeIDsForComps` if run in parallel