### PR TITLE
Caps Thermal Properties and Structural Mesh Morphing

### DIFF
--- a/tacs/caps2tacs/materials.py
+++ b/tacs/caps2tacs/materials.py
@@ -16,6 +16,8 @@ class Material:
         shear_allow: float = None,
         yield_allow: float = None,
         thermExpCoeff: float = None,
+        kappa:float=None,
+        specific_heat:float=None,
     ):
         """
         Material base class to wrap ESP/CAPS material inputs to TACS AIM
@@ -36,6 +38,8 @@ class Material:
         self._shear_allow = shear_allow
         self._yield_allow = yield_allow
         self._thermExpCoeff = thermExpCoeff
+        self._kappa = kappa
+        self._specific_heat = specific_heat
 
     @property
     def name(self) -> str:
@@ -60,6 +64,8 @@ class Material:
         m_dict["compressionAllow"] = self._compression_allow
         m_dict["shearAllow"] = self._shear_allow
         m_dict["yieldAllow"] = self._yield_allow
+        m_dict["kappa"] = self._kappa
+        m_dict["specificHeat"] = self._specific_heat
 
         # return all items that are not None
         return {k: v for k, v in m_dict.items() if v is not None}
@@ -92,6 +98,8 @@ class Isotropic(Material):
         shear_allow: float = None,
         yield_allow: float = None,
         thermExpCoeff: float = None,
+        kappa:float=None,
+        specific_heat:float=None,
     ):
         """
         wrapper class for ESP/CAPS isotropic materials
@@ -107,6 +115,8 @@ class Isotropic(Material):
             shear_allow=shear_allow,
             yield_allow=yield_allow,
             thermExpCoeff=thermExpCoeff,
+            kappa=kappa,
+            specific_heat=specific_heat,
         )
 
     @classmethod
@@ -136,6 +146,8 @@ class Isotropic(Material):
             compression_allow=20.0e7,
             yield_allow=20.0e7,
             thermExpCoeff=23.1e-6,
+            specific_heat=903,
+            kappa=237,
         )
 
     @classmethod
@@ -149,9 +161,11 @@ class Isotropic(Material):
             compression_allow=1.7e9,
             yield_allow=0.9e9,
             thermExpCoeff=11.5e-6,
+            kappa=45,
+            specific_heat=420,
         )
 
 
 class Orthotropic(Material):
-    # TBD
+    # TBD, ESP/CAPS doesn't accept all of E1, E2, E3, alpha_i, kappa_i, c_p, etc.
     pass

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -19,7 +19,7 @@ class TacsAim:
     only supports shell properties at the moment
     """
 
-    def __init__(self, caps_problem, comm=None, project_name="tacs"):
+    def __init__(self, caps_problem, comm=None, project_name="tacs", mesh_morph:bool=False):
         self.comm = comm
 
         # geometry and design parameters to change the design of the CSM file during an optimization
@@ -41,6 +41,7 @@ class TacsAim:
         # build flags
         self._setup = False
         self._first_setup = True
+        self._mesh_morph = mesh_morph
 
         # broadcast TacsAimMetadata from root proc to other processors
         self._analysis_dir = None
@@ -172,6 +173,14 @@ class TacsAim:
     @root_broadcast
     def get_output_parameter(self, out_name: str):
         return self.geometry.outpmtr[out_name].value
+    
+    @property
+    def mesh_morph(self) -> bool:
+        return self._mesh_morph
+    
+    @mesh_morph.setter
+    def mesh_morph(self, new_bool:bool):
+        self._mesh_morph = new_bool
 
     @property
     def project_name(self):

--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -52,6 +52,7 @@ class TacsModel:
         mesh="egads",
         tacs_project="tacs",
         problem_name: str = "capsStruct",
+        mesh_morph:bool=False,
     ):
         """
         make a pyCAPS problem with the tacsAIM and egadsAIM on serial / root proc
@@ -70,7 +71,7 @@ class TacsModel:
             caps_problem = pyCAPS.Problem(
                 problemName=problem_name, capsFile=csm_file, outLevel=1
             )
-        tacs_aim = TacsAim(caps_problem, comm, project_name=tacs_project)
+        tacs_aim = TacsAim(caps_problem, comm, project_name=tacs_project, mesh_morph=mesh_morph)
         mesh_aim = None
         if mesh == "egads":
             mesh_aim = EgadsAim(caps_problem, comm)


### PR DESCRIPTION
* Added thermal properties into caps2tacs
* Added code into ESP/CAPS side to accept the thermal properties from caps2tacs into the tacsAIM
* Added code to F2F to accept the thermal properties into the F2F callback
* note TACS doesn't accept the thermal properties still although maybe I could add the features to accept thermal properties from caps2tacs into the pyTACS callback too (Tim?)
* Added triggers for new structural mesh morphing in ESP/CAPS (@ Marshall Galbraith)