### PR TITLE
Adding method to set finite difference step size used in element classes

### DIFF
--- a/src/elements/TACSElement.cpp
+++ b/src/elements/TACSElement.cpp
@@ -28,9 +28,23 @@
 int TACSElement::fdOrder = 2;
 
 /*
+  Default finite difference step length
+*/
+#ifdef TACS_USE_COMPLEX
+double TACSElement::dh = 1e-30;
+#else
+double TACSElement::dh = 1e-7;
+#endif  // TACS_USE_COMPLEX
+
+/*
   Allow users to set default finite difference order for real analysis
 */
 void TACSElement::setFiniteDifferenceOrder(int order) { fdOrder = order; }
+
+/*
+  Allow users to set default finite difference order for real analysis
+*/
+void TACSElement::setFiniteDifferenceStepSize(double _dh) { dh = _dh; }
 
 /*
   Finds the finite-difference based Jacobian of the element. This is
@@ -44,13 +58,6 @@ void TACSElement::addJacobian(int elemIndex, double time, TacsScalar alpha,
                               const TacsScalar dvars[],
                               const TacsScalar ddvars[], TacsScalar res[],
                               TacsScalar J[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   // Get the number of variables
   int nvars = getNumVariables();
 
@@ -201,13 +208,6 @@ void TACSElement::addAdjResProduct(
     int elemIndex, double time, TacsScalar scale, const TacsScalar psi[],
     const TacsScalar Xpts[], const TacsScalar vars[], const TacsScalar dvars[],
     const TacsScalar ddvars[], int dvLen, TacsScalar dfdx[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   TacsScalar *x = new TacsScalar[dvLen];
   getDesignVars(elemIndex, dvLen, x);
 
@@ -271,13 +271,6 @@ void TACSElement::addAdjResXptProduct(
     int elemIndex, double time, TacsScalar scale, const TacsScalar psi[],
     const TacsScalar Xpts[], const TacsScalar vars[], const TacsScalar dvars[],
     const TacsScalar ddvars[], TacsScalar fXptSens[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   int nnodes = getNumNodes();
   TacsScalar *X = new TacsScalar[3 * nnodes];
   memcpy(X, Xpts, 3 * nnodes * sizeof(TacsScalar));
@@ -356,13 +349,6 @@ void TACSElement::addMatDVSensInnerProduct(
     ElementMatrixType matType, int elemIndex, double time, TacsScalar scale,
     const TacsScalar psi[], const TacsScalar phi[], const TacsScalar Xpts[],
     const TacsScalar vars[], int dvLen, TacsScalar dfdx[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   TacsScalar *x = new TacsScalar[dvLen];
   getDesignVars(elemIndex, dvLen, x);
 
@@ -435,13 +421,6 @@ void TACSElement::addMatXptSensInnerProduct(
     ElementMatrixType matType, int elemIndex, double time, TacsScalar scale,
     const TacsScalar psi[], const TacsScalar phi[], const TacsScalar Xpts[],
     const TacsScalar vars[], TacsScalar dfdX[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   int nnodes = getNumNodes();
   TacsScalar *X = new TacsScalar[3 * nnodes];
   memcpy(X, Xpts, 3 * nnodes * sizeof(TacsScalar));
@@ -510,13 +489,6 @@ void TACSElement::getMatSVSensInnerProduct(
     ElementMatrixType matType, int elemIndex, double time,
     const TacsScalar psi[], const TacsScalar phi[], const TacsScalar Xpts[],
     const TacsScalar vars[], TacsScalar dfdu[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   int nvars = getNumVariables();
   memset(dfdu, 0, nvars * sizeof(TacsScalar));
   TacsScalar *mat = new TacsScalar[nvars * nvars];
@@ -585,13 +557,6 @@ void TACSElement::addPointQuantityDVSens(
     double pt[], const TacsScalar Xpts[], const TacsScalar vars[],
     const TacsScalar dvars[], const TacsScalar ddvars[],
     const TacsScalar dfdq[], int dvLen, TacsScalar dfdx[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   TacsScalar *x = new TacsScalar[dvLen];
   getDesignVars(elemIndex, dvLen, x);
 
@@ -662,13 +627,6 @@ void TACSElement::addPointQuantitySVSens(
     TacsScalar beta, TacsScalar gamma, int n, double pt[],
     const TacsScalar Xpts[], const TacsScalar vars[], const TacsScalar dvars[],
     const TacsScalar ddvars[], const TacsScalar dfdq[], TacsScalar dfdu[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   TacsScalar detXd = 0.0;
   int nvals = evalPointQuantity(elemIndex, quantityType, time, n, pt, Xpts,
                                 vars, dvars, ddvars, &detXd, NULL);
@@ -748,13 +706,6 @@ void TACSElement::addPointQuantityXptSens(
     double pt[], const TacsScalar Xpts[], const TacsScalar vars[],
     const TacsScalar dvars[], const TacsScalar ddvars[],
     const TacsScalar dfddetXd, const TacsScalar dfdq[], TacsScalar dfdXpts[]) {
-  // The step length
-#ifdef TACS_USE_COMPLEX
-  const double dh = 1e-30;
-#else
-  const double dh = 1e-7;
-#endif  // TACS_USE_COMPLEX
-
   TacsScalar detXd = 0.0;
   int nvals = evalPointQuantity(elemIndex, quantityType, time, n, pt, Xpts,
                                 vars, dvars, ddvars, &detXd, NULL);

--- a/src/elements/TACSElement.h
+++ b/src/elements/TACSElement.h
@@ -70,6 +70,13 @@ class TACSElement : public TACSObject {
   */
   static void setFiniteDifferenceOrder(int order);
 
+  /*
+    Allow users to set default finite difference step size
+
+    @param dh The requested finite difference step size
+  */
+  static void setFiniteDifferenceStepSize(double _dh);
+
   /**
     Get the number of degrees of freedom per node for this element
 
@@ -743,10 +750,14 @@ class TACSElement : public TACSObject {
                              const TacsScalar ddvars[], int ld_data,
                              TacsScalar *data) {}
 
- private:
-  int componentNum;
+ protected:
   // Defines order of finite differencing method
   static int fdOrder;
+  // Defines step size of finite differencing method
+  static double dh;
+
+ private:
+  int componentNum;
 };
 
 #endif  // TACS_ELEMENT_H

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -666,7 +666,10 @@ void TACSShellElement<quadrature, basis, director, model>::getMatType(
   // Create dummy residual vector
   TacsScalar res[vars_per_node * num_nodes];
   memset(res, 0, vars_per_node * num_nodes * sizeof(TacsScalar));
-  dh = 1e-4;
+  // We have to override the complex step size sice, complex step can't be used
+  // here since the user may need to complex step over this function to get
+  // derivatives
+  dh = fmin(TACSElement::dh, 1e-7);
   // Set alpha or gamma based on if this is a stiffness or mass matrix
   if (matType == TACS_STIFFNESS_MATRIX) {
     alpha = 1.0;

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -669,7 +669,7 @@ void TACSShellElement<quadrature, basis, director, model>::getMatType(
   // We have to override the complex step size sice, complex step can't be used
   // here since the user may need to complex step over this function to get
   // derivatives
-  dh = fmin(TACSElement::dh, 1e-7);
+  dh = fmax(TACSElement::dh, 1e-7);
   // Set alpha or gamma based on if this is a stiffness or mass matrix
   if (matType == TACS_STIFFNESS_MATRIX) {
     alpha = 1.0;

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -296,6 +296,11 @@ cdef class Element:
         TACSElement.setFiniteDifferenceOrder(order)
         return
 
+    @classmethod
+    def setFiniteDifferenceStepSize(cls, double dh):
+        TACSElement.setFiniteDifferenceStepSize(dh)
+        return
+
     def getNumNodes(self):
         if self.ptr != NULL:
             return self.ptr.getNumNodes()

--- a/tacs/cpp_headers/TACS.pxd
+++ b/tacs/cpp_headers/TACS.pxd
@@ -262,6 +262,8 @@ cdef extern from "TACSElement.h":
         int getComponentNum()
         @staticmethod
         void setFiniteDifferenceOrder(int)
+        @staticmethod
+        void setFiniteDifferenceStepSize(double)
         int getVarsPerNode()
         int getNumNodes()
         int getNumVariables()


### PR DESCRIPTION
- Adding method to set the finite difference step size for TACSElements
- The finite difference step size used to estimate the geometric stiffness in TACShellElement is now tied to the TACSElement fd step size
- The step size all elements in a model can be modified by calling this class method at the begining of a script
```
from tacs.TACS import Element
Element.setFiniteDifferenceStepSize(1e-6)
```
- The change in step size in the geometric stiffness routine has caused a few of our more sensitive buckling sensitivity tests to fail
- Still have to figure out a way to work around this
- Closes #246 