### PR TITLE
Adding warning to `MaterialProperties` for invalid keyword args

### DIFF
--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -235,7 +235,7 @@ cdef class MaterialProperties:
               warnings.warn(
                 f"Invalid keyword argument '{input_key}' detected in MaterialProperties. \n"
                 "Keyword argument will be ignored. Acceptable arguments are: \n"
-                f"{ALL_KEYS}",
+                + ", ".join(ALL_KEYS),
                 RuntimeWarning
             )
 

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -13,6 +13,7 @@
 #distutils: language=c++
 
 import warnings
+import difflib
 
 # For the use of MPI
 from mpi4py.libmpi cimport *
@@ -231,13 +232,9 @@ cdef class MaterialProperties:
 
         # Check for any invalid/misspelled inputs
         for input_key in kwargs:
-          if input_key not in ALL_KEYS:
-              warnings.warn(
-                f"Invalid keyword argument '{input_key}' detected in MaterialProperties. \n"
-                "Keyword argument will be ignored. Acceptable arguments are: \n"
-                + ", ".join(ALL_KEYS),
-                RuntimeWarning
-            )
+            if input_key not in ALL_KEYS:
+                guess = difflib.get_close_matches(name, ALL_KEYS, n=1, cutoff=0.0)[0]
+                raise ValueError(f"{name} is not a valid material property. Perhaps you meant {guess}?\nAcceptable arguments are: \n" + ", ".join(ALL_KEYS),)
 
         # Check if any input provided in kwargs was orthotropic
         if any(input_key in ORTHOTROPIC_KEYS for input_key in kwargs):

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -234,7 +234,9 @@ cdef class MaterialProperties:
         for input_key in kwargs:
             if input_key not in ALL_KEYS:
                 guess = difflib.get_close_matches(input_key, ALL_KEYS, n=1, cutoff=0.0)[0]
-                raise ValueError(f"{input_key} is not a valid material property. Perhaps you meant {guess}?\nAcceptable arguments are: \n" + ", ".join(ALL_KEYS),)
+                raise ValueError(f"{input_key} is not a valid material property. Perhaps you meant {guess}?\n "
+                                 "Acceptable arguments are: \n" +
+                                 ", ".join(ALL_KEYS),)
 
         # Check if any input provided in kwargs was orthotropic
         if any(input_key in ORTHOTROPIC_KEYS for input_key in kwargs):

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -234,7 +234,7 @@ cdef class MaterialProperties:
         for input_key in kwargs:
             if input_key not in ALL_KEYS:
                 guess = difflib.get_close_matches(input_key, ALL_KEYS, n=1, cutoff=0.0)[0]
-                raise ValueError(f"{input_key} is not a valid material property. Perhaps you meant {guess}?\n "
+                raise ValueError(f"{input_key} is not a valid material property. Perhaps you meant {guess}? \n"
                                  "Acceptable arguments are: \n" +
                                  ", ".join(ALL_KEYS),)
 

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -12,6 +12,8 @@
 
 #distutils: language=c++
 
+import warnings
+
 # For the use of MPI
 from mpi4py.libmpi cimport *
 cimport mpi4py.MPI as MPI
@@ -216,9 +218,29 @@ cdef class MaterialProperties:
         cdef TacsScalar kappa3 = 230.0
 
         ISOTROPIC_KEYS = ["rho", "E", "nu", "G", "ys", "alpha", "specific_heat", "kappa"]
+        ORTHOTROPIC_KEYS = ["E1", "E2", "E3",
+                            "nu12", "nu13", "nu23",
+                            "G12", "G13", "G23",
+                            "T1", "T2", "T3",
+                            "C1", "C2", "C3",
+                            "S12", "S13", "S23",
+                            "Xt", "Yt", "Xc", "Yc", "S",
+                            "alpha1", "alpha2", "alpha3",
+                            "kappa1", "kappa2", "kappa3"]
+        ALL_KEYS = ISOTROPIC_KEYS + ORTHOTROPIC_KEYS
+
+        # Check for any invalid/misspelled inputs
+        for input_key in kwargs:
+          if input_key not in ALL_KEYS:
+              warnings.warn(
+                f"Invalid keyword argument '{input_key}' detected in MaterialProperties. \n"
+                "Keyword argument will be ignored. Acceptable arguments are: \n"
+                f"{ALL_KEYS}",
+                RuntimeWarning
+            )
 
         # Check if any input provided in kwargs was orthotropic
-        if any(input_key not in ISOTROPIC_KEYS for input_key in kwargs):
+        if any(input_key in ORTHOTROPIC_KEYS for input_key in kwargs):
             is_orthotropic = True
         else:
             is_orthotropic = False

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -233,8 +233,8 @@ cdef class MaterialProperties:
         # Check for any invalid/misspelled inputs
         for input_key in kwargs:
             if input_key not in ALL_KEYS:
-                guess = difflib.get_close_matches(name, ALL_KEYS, n=1, cutoff=0.0)[0]
-                raise ValueError(f"{name} is not a valid material property. Perhaps you meant {guess}?\nAcceptable arguments are: \n" + ", ".join(ALL_KEYS),)
+                guess = difflib.get_close_matches(input_key, ALL_KEYS, n=1, cutoff=0.0)[0]
+                raise ValueError(f"{input_key} is not a valid material property. Perhaps you meant {guess}?\nAcceptable arguments are: \n" + ", ".join(ALL_KEYS),)
 
         # Check if any input provided in kwargs was orthotropic
         if any(input_key in ORTHOTROPIC_KEYS for input_key in kwargs):


### PR DESCRIPTION
- Since PR #252 , invalid input args being passed to MaterialProperties change the default material type to orthotropic
- This can have unexpected behavior for users who accidentally misspell valid isotropic parameters 
- To make the issue clearer the following changes have been made:
    1. Passing an invalid/misspelled argument raises an explicit warning
    2. Invalid arguments are ignored when deciding if the properties are orthtropic/isotropic
