### PR TITLE
Adding 2.0 version upperbound for numpy in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -124,7 +124,7 @@ setup(
     author="Graeme J. Kennedy",
     author_email="graeme.kennedy@ae.gatech.edu",
     install_requires=[
-        "numpy",
+        "numpy<2.0.0",
         "mpi4py>=3.1.1",
         "scipy>=1.2.1",
         "pynastran>=1.3.3",


### PR DESCRIPTION
Numpy 2.0 is expected to be released around December 2023 (numpy/numpy#24300). 
This will be a breaking update, so we have to make sure that our dependencies have a version upper bound to guard against this.