### PR TITLE
Bug fix for c++ compiler version and <typeinfo>

### DIFF
--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -18,8 +18,8 @@ MAKE = make -j 8
 AR_FLAGS = rcs
 
 # Flags for debugging and regular compilation versions
-EXTRA_DEBUG_CC_FLAGS = -fPIC -g -std=c++11
-EXTRA_CC_FLAGS = -fPIC -O3 -std=c++11
+EXTRA_DEBUG_CC_FLAGS = -fPIC -g
+EXTRA_CC_FLAGS = -fPIC -O3
 
 # Use this if you have problems with mpich
 # TACS_DEF = -DMPICH_IGNORE_CXX_SEEK

--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -18,8 +18,8 @@ MAKE = make -j 8
 AR_FLAGS = rcs
 
 # Flags for debugging and regular compilation versions
-EXTRA_DEBUG_CC_FLAGS = -fPIC -g
-EXTRA_CC_FLAGS = -fPIC -O3
+EXTRA_DEBUG_CC_FLAGS = -fPIC -g -std=c++11
+EXTRA_CC_FLAGS = -fPIC -O3 -std=c++11
 
 # Use this if you have problems with mpich
 # TACS_DEF = -DMPICH_IGNORE_CXX_SEEK

--- a/TACS_Common.mk
+++ b/TACS_Common.mk
@@ -26,7 +26,7 @@ TACS_LD_FLAGS = ${EXTRA_LD_FLAGS} ${TACS_LD_CMD} ${TACS_EXTERN_LIBS}
 # This is the one rule that is used to compile all the
 # source code in TACS
 %.o: %.cpp
-	${CXX} ${TACS_CC_FLAGS} -c $< -o $*.o
+	${CXX} ${TACS_CC_FLAGS} -std=c++14 -c $< -o $*.o
 	@echo
 	@echo "        --- Compiled $*.cpp successfully ---"
 	@echo

--- a/setup.py
+++ b/setup.py
@@ -84,6 +84,7 @@ for mod in ["TACS", "elements", "constitutive", "functions"]:
             libraries=libs,
             library_dirs=lib_dirs,
             runtime_library_dirs=runtime_lib_dirs,
+            extra_compile_args=["-std=c++11"],
         )
     )
 

--- a/setup.py
+++ b/setup.py
@@ -84,7 +84,7 @@ for mod in ["TACS", "elements", "constitutive", "functions"]:
             libraries=libs,
             library_dirs=lib_dirs,
             runtime_library_dirs=runtime_lib_dirs,
-            extra_compile_args=["-std=c++11"],
+            extra_compile_args=["-std=c++14"],
         )
     )
 

--- a/src/elements/shell/TACSShellElement.h
+++ b/src/elements/shell/TACSShellElement.h
@@ -1,6 +1,8 @@
 #ifndef TACS_SHELL_ELEMENT_H
 #define TACS_SHELL_ELEMENT_H
 
+#include <typeinfo>
+
 #include "TACSDirector.h"
 #include "TACSElement.h"
 #include "TACSElementAlgebra.h"


### PR DESCRIPTION
- Add standard version for c++ in `Makefile.in.info` and `setup.py`.
- Add `<typeinfo>` header to `TACSShellElement.h`