### PR TITLE
caps2tacs - Parallel Instances of tacsAIMs for huge speed up of post_analysis() for shape optimization

### DIFF
--- a/docs/source/caps2tacs/main.rst
+++ b/docs/source/caps2tacs/main.rst
@@ -9,7 +9,7 @@ won't work until after the full install so you can ignore that if you source it 
 
    export ESP_ROOT=~/packages/ESP123/EngSketchPad
    export PYTHONPATH=${PYTHONPATH}:$ESP_ROOT/pyESP
-   source $ESP_ROOT/ESPenv.shell
+   source $ESP_ROOT/ESPenv.sh
    alias csm='$ESP_ROOT/bin/serveCSM'
 
 The installation on a Linux machine proceeds as follows. Note if the ESP/OpenCASCADE version changes
@@ -39,13 +39,13 @@ Important things to include in your CSM file are included below (for reference s
 * Configuration parameters such as ``cfgpmtr nribs 10`` which are integer variables usually fixed during optimization.
 * Design parameters such as ``despmtr span 10`` which are real number variables that can be tied to a TACS shape variable.
 * ``capsGroup`` attributes define regions of the geometry with the same property cars, denoted ``capsGroup $rib1``, etc. 
-We often use pattern statements to define these, and sometimes a user-defined primitive ``udprim editAttr``.
-* ``capsConstraint`` attributes define regions of the geometry intended to have the same structural constraints, e.g. ``capsConstraint fix``.
-These constraints include Temperature and elastic constraints as of right now.
-* ``capsLoad`` attributes define regions of the geometry with the same fixed loads. This is useful in simple structural analyses. 
-Note that aerodynamic loads cannot be setup this way (see the funtofem github for how to do this).
-* ``capsAIM`` attribute - this specifies for a body the analysis tools or AIMs using this CSM file. Note that we often add the 
-``tacsAIM, egadsTessAIM`` here for structural analyses. 
+    We often use pattern statements to define these, and sometimes a user-defined primitive ``udprim editAttr``.
+* ``capsConstraint`` attributes define regions of the geometry intended to have the same structural constraints, e.g. ``capsConstraint fix``. 
+    These constraints include Temperature and elastic constraints as of right now.
+* ``capsLoad`` attributes define regions of the geometry with the same fixed loads. 
+    This is useful in simple structural analyses. Note that aerodynamic loads cannot be setup this way (see the funtofem github for how to do this).
+* ``capsAIM`` attribute - this specifies for a body the analysis tools or AIMs using this CSM file. 
+    Note that we often add the ``tacsAIM, egadsTessAIM`` here for structural analyses. 
 * Occasionally ``capsMesh`` attribute - which can be used to set alternative auto-mesh settings on different sections of the geometry.
 
 The main ``TacsModel`` object supervises the process of TACS analysis and geometry updates for optimization.
@@ -73,18 +73,17 @@ hyperparameters by running a small analysis / using egadsAIM view routine until 
 There are certain objects that must be setup and registered to the tacs model before running a TACS analysis.
 If these are not correctly specified, then the tacs model will throw an error in the setup check phase.
 
-* Material properties - you must setup one or more material objects for use in the element property definitions.
-Available material types include Isotropic and Orthotropic (Anisotropic can be added directly through the underlying tacsAIM).
-Several common materials are saved as class methods such as aluminum, steel, titanium, carbon fiber.
+* Material properties - you must setup one or more material objects for use in the element property definitions. 
+   Available material types include Isotropic and Orthotropic (Anisotropic can be added directly through the underlying tacsAIM). Several common materials are saved as class methods such as aluminum, steel, titanium, carbon fiber.
 * Element Properties - currently caps2tacs only supports shell elements for use in aerodynamic structures. 
-Element properties can be setup directly through a `ShellProperty` object or indirectly through the `ThicknessVariable` object.
-The names of shell properties or the thickness variables must be tied to a `capsGroup` setup in the CSM file.
+   Element properties can be setup directly through a `ShellProperty` object or indirectly through the `ThicknessVariable` object. 
+   The names of shell properties or the thickness variables must be tied to a `capsGroup` setup in the CSM file.
 * Constraints - elastic and thermal constraints are available in caps2tacs. Common instances are the ``PinConstraint`` and ``TemperatureConstraint``.
-The name/capsConstraint input to these constraint objects must match the ``capsConstraint`` attributes in the CSM file.
+   The name/capsConstraint input to these constraint objects must match the ``capsConstraint`` attributes in the CSM file.
 * Loads - for static problems ``GridForce`` and ``Pressure`` load objects are available whose names must match the ``capsLoad`` attributes.
-Note that for aerodynamic structures only coupling with a CFD software such as through the ``FUNtoFEM repo (see below`` can setup aerodynamic loads.
+   Note that for aerodynamic structures only coupling with a CFD software such as through the ``FUNtoFEM repo (see below`` can setup aerodynamic loads.
 * Output Functionals for optimization - functionals such as ``ksfailure``, ``mass``, ``temperature``, ``compliance``
-are available for use in structural optimizations.
+   are available for use in structural optimizations.
 
 Once all of the above structural analysis setup objects are provided, the TacsModel is ready for analysis. You can
 then run the setup method which completes the setup phase. Then, the routines ``pre_analysis()`` generates a mesh, 
@@ -106,7 +105,7 @@ on a coarse mesh of a symmetric NACA 0012 wing structure.
 2. An unsteady analysis with a vertical distributed load varying sinusoidally in time.
 3. A sizing optimization which finds the optimal panel thicknesses to hold fixed aero loads.
 4. A sizing and shape optimization which optimizes the panel thicknesses and location of ribs
-and spars inside the wing to hold fixed aero loads.
+    and spars inside the wing to hold fixed aero loads.
 5. A steady analysis, using the AFLR AIM for meshing, with a vertical distributed load.
 
 The sizing optimization shown below resulted in about a 40\% drop in weight from the equal thickness design. Notice 

--- a/examples/caps_wing/1_steady_analysis.py
+++ b/examples/caps_wing/1_steady_analysis.py
@@ -2,6 +2,11 @@
 Sean Engelstad, Febuary 2023
 GT SMDO Lab, Dr. Graeme Kennedy
 Caps to TACS example
+
+Update : November 2023
+You can now run this with active_procs=[0,1] and conda-mpirun -n 2 python 1_steady_analysis.py
+to test out running 2 tacs aims in parallel.
+Or just run python 1_steady_analysis.py instead.
 """
 
 from tacs import caps2tacs
@@ -12,7 +17,10 @@ from mpi4py import MPI
 # 1: build the tacs aim, egads aim wrapper classes
 
 comm = MPI.COMM_WORLD
-tacs_model = caps2tacs.TacsModel.build(csm_file="simple_naca_wing.csm", comm=comm)
+
+print(f"proc on rank {comm.rank}")
+
+tacs_model = caps2tacs.TacsModel.build(csm_file="simple_naca_wing.csm", comm=comm, active_procs=[0])
 tacs_model.mesh_aim.set_mesh(
     edge_pt_min=15,
     edge_pt_max=20,
@@ -52,16 +60,21 @@ caps2tacs.AnalysisFunction.mass().register_to(tacs_model)
 # alternative is to call tacs_aim.setup_aim().pre_analysis() with tacs_aim = tacs_model.tacs_aim
 tacs_model.setup(include_aim=True)
 
+comm.Barrier()
+
 # ----------------------------------------------------------------------------------
 # 2. Run the TACS steady elastic structural analysis, forward + adjoint
 
 # choose method 1 or 2 to demonstrate the analysis : 1 - fewer lines, 2 - more lines
-method = 2
+method = 1
 
 # show both ways of performing the structural analysis in more or less detail
 if method == 1:  # less detail version
+    print(f"tacs - preanalysis rank {comm.rank}", flush=True)
     tacs_model.pre_analysis()
+    print(f"tacs - run analysis rank {comm.rank}", flush=True)
     tacs_model.run_analysis()
+    print(f"tacs - post analysis rank {comm.rank}", flush=True)
     tacs_model.post_analysis()
 
     print("Tacs model static analysis outputs...\n")
@@ -85,7 +98,7 @@ elif method == 2:  # longer way that directly uses pyTACS & static problem routi
         SPs[caseID].evalFunctions(tacs_funcs, evalFuncs=function_names)
         SPs[caseID].evalFunctionsSens(tacs_sens, evalFuncs=function_names)
         SPs[caseID].writeSolution(
-            baseName="tacs_output", outputDir=tacs_model.analysis_dir
+            baseName="tacs_output", outputDir=tacs_model.analysis_dir(proc=0)
         )
 
     # print the output analysis functions and sensitivities

--- a/examples/caps_wing/1_steady_analysis.py
+++ b/examples/caps_wing/1_steady_analysis.py
@@ -46,6 +46,9 @@ caps2tacs.ThicknessVariable(
     caps_group="OML", value=0.03, material=aluminum
 ).register_to(tacs_model)
 
+# SHAPE VAR FOR DEBUGGING, CAN REMOVE THIS
+caps2tacs.ShapeVariable("rib_a1", value=1.0).register_to(tacs_model)
+
 # add constraints and loads
 caps2tacs.PinConstraint("root").register_to(tacs_model)
 caps2tacs.GridForce("OML", direction=[0, 0, 1.0], magnitude=100).register_to(tacs_model)

--- a/examples/caps_wing/6_animate_shape_vars.py
+++ b/examples/caps_wing/6_animate_shape_vars.py
@@ -9,11 +9,12 @@ You'll need to use f5tovtk to convert to *.vtk files and open up each group of s
 using the .. shortcut which opens up a group of files at once. For each of these groups of vtk files,
 click file -> save animation and save all the png files in a subfolder. Then, either use the GifWriter in the
 caps2tacs module or copy the GifWriter script into that directory and use it to make a gif. Repeat for each shape variable.
+
+NOTE : this is meant to be done on one processor, but could be parallelized better in the future.
 """
 
 from tacs import caps2tacs
 from mpi4py import MPI
-import openmdao.api as om
 
 # --------------------------------------------------------------#
 # Setup CAPS Problem

--- a/examples/caps_wing/7_multiproc_post_analysis.py
+++ b/examples/caps_wing/7_multiproc_post_analysis.py
@@ -117,5 +117,6 @@ for func in tacs_model.analysis_functions:
 
 # print out timing results (compare serial to parallel instances of tacsAIM)
 mins_elapsed = (time.time() - start_time) / 60.0
+naims = len(tacs_model.active_procs)
 if comm.rank == 0:
-    print(f"Elapsed time with {size} procs is {mins_elapsed} mins using 4 shape vars.")
+    print(f"Elapsed time with {naims} procs is {mins_elapsed} mins using 4 shape vars.")

--- a/examples/caps_wing/archive/_parallel_test.py
+++ b/examples/caps_wing/archive/_parallel_test.py
@@ -1,0 +1,9 @@
+from mpi4py import MPI
+
+# make sure your system has procs 1 - N using mpirun command (not all rank zero)
+# ended up uninstalling pip mpi4py, conda uninstalling mpi4py and then installing mpi4py through conda-forge channel
+# this comes with its own mpirun binary located in your conda-env/bin folder (then I alias that mpirun as conda-mpirun)
+# so that my OS mpirun doesn't get messed up. -Sean Engelstad
+# command is then conda-mpirun -n 4 python _parallel_test.py (using conda-mpirun alias)
+comm = MPI.COMM_WORLD
+print(f"rank = {comm.rank}")

--- a/examples/caps_wing/results/gif_writer.py
+++ b/examples/caps_wing/results/gif_writer.py
@@ -1,0 +1,28 @@
+import imageio, os
+
+
+class GifWriter:
+    """
+    module to write gifs from a set of pngs
+    """
+
+    def __init__(self, frames_per_second: int = 4):
+        self._fps = frames_per_second
+
+    def __call__(self, gif_filename: str, path: str):
+        """
+        call on current path to create gif of given filename
+        """
+        gif_filepath = os.path.join(path, gif_filename)
+        with imageio.get_writer(gif_filepath, mode="I", fps=self._fps) as writer:
+            path_dir = os.listdir(path)
+            path_dir = sorted(path_dir)
+            for image_file in path_dir:
+                print(image_file)
+                if ".png" in image_file:
+                    image = imageio.imread(image_file)
+                    writer.append_data(image)
+
+
+my_writer = GifWriter(frames_per_second=4)
+my_writer("sizing1.gif", os.getcwd())

--- a/examples/caps_wing/results/sizing_and_shape2/images/gif_writer.py
+++ b/examples/caps_wing/results/sizing_and_shape2/images/gif_writer.py
@@ -1,0 +1,28 @@
+import imageio, os
+
+
+class GifWriter:
+    """
+    module to write gifs from a set of pngs
+    """
+
+    def __init__(self, frames_per_second: int = 4):
+        self._fps = frames_per_second
+
+    def __call__(self, gif_filename: str, path: str):
+        """
+        call on current path to create gif of given filename
+        """
+        gif_filepath = os.path.join(path, gif_filename)
+        with imageio.get_writer(gif_filepath, mode="I", fps=self._fps) as writer:
+            path_dir = os.listdir(path)
+            path_dir = sorted(path_dir)
+            for image_file in path_dir:
+                print(image_file)
+                if ".png" in image_file:
+                    image = imageio.imread(image_file)
+                    writer.append_data(image)
+
+
+my_writer = GifWriter(frames_per_second=20)
+my_writer("size_and_shape2.gif", os.getcwd())

--- a/setup.py
+++ b/setup.py
@@ -104,6 +104,7 @@ optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
     "mphys": ["mphys>=1.1.0", "openmdao>=3.25.0"],
+    "caps2tacs": ["imageio>=2.16.1"],
 }
 
 # Add an optional dependency that concatenates all others

--- a/tacs/caps2tacs/aflr_aim.py
+++ b/tacs/caps2tacs/aflr_aim.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["AflrAim"]
 
 

--- a/tacs/caps2tacs/analysis_function.py
+++ b/tacs/caps2tacs/analysis_function.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["AnalysisFunction", "Derivative"]
 
 from tacs.functions import (

--- a/tacs/caps2tacs/constraints.py
+++ b/tacs/caps2tacs/constraints.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["Constraint", "PinConstraint", "TemperatureConstraint"]
 
 

--- a/tacs/caps2tacs/gif_writer.py
+++ b/tacs/caps2tacs/gif_writer.py
@@ -7,15 +7,16 @@ class GifWriter:
     module to write gifs from a set of pngs
     """
 
-    def __init__(self, frames_per_second: int = 4):
-        self._fps = frames_per_second
+    def __init__(self, duration: int = 20):
+        # duration of each frame
+        self._duration = duration
 
     def __call__(self, gif_filename: str, path: str):
         """
         call on current path to create gif of given filename
         """
         gif_filepath = os.path.join(path, gif_filename)
-        with imageio.get_writer(gif_filepath, mode="I", fps=self._fps) as writer:
+        with imageio.get_writer(gif_filepath, mode="I", duration=self._duration) as writer:
             path_dir = os.listdir(path)
             path_dir = sorted(path_dir)
             for image_file in path_dir:

--- a/tacs/caps2tacs/gif_writer.py
+++ b/tacs/caps2tacs/gif_writer.py
@@ -16,7 +16,9 @@ class GifWriter:
         call on current path to create gif of given filename
         """
         gif_filepath = os.path.join(path, gif_filename)
-        with imageio.get_writer(gif_filepath, mode="I", duration=self._duration) as writer:
+        with imageio.get_writer(
+            gif_filepath, mode="I", duration=self._duration
+        ) as writer:
             path_dir = os.listdir(path)
             path_dir = sorted(path_dir)
             for image_file in path_dir:

--- a/tacs/caps2tacs/gif_writer.py
+++ b/tacs/caps2tacs/gif_writer.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["GifWriter"]
 import imageio, os
 

--- a/tacs/caps2tacs/loads.py
+++ b/tacs/caps2tacs/loads.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["Load", "Pressure", "GridForce"]
 
 from typing import TYPE_CHECKING, List

--- a/tacs/caps2tacs/materials.py
+++ b/tacs/caps2tacs/materials.py
@@ -176,6 +176,7 @@ class Isotropic(Material):
             rho=2.7e3,
             T1=20.0e7,
             C1=20.0e7,
+            S1=270e6,
             alpha=23.1e-6,
             cp=903,
             kappa=237,
@@ -190,9 +191,42 @@ class Isotropic(Material):
             rho=4.51e3,
             T1=2.4e7,
             C1=2.4e7,
+            S1=0.6 * 2.4e7,  # estimated shear strength
             alpha=8.41e-6,
             cp=522.3,
             kappa=11.4,
+        )
+
+    @classmethod
+    def titanium_alloy(cls):
+        # Ti 6AL-4V (grade 5)
+        return cls(
+            name="titanium-alloy",
+            E=114e9,
+            nu=0.361,
+            rho=4.43e3,
+            T1=880e6,
+            C1=970e6,
+            S1=0.6 * 880e6,  # estimated shear strength
+            alpha=9.2e-6,
+            cp=526.3,
+            kappa=6.7,
+        )
+
+    @classmethod
+    def aluminum_alloy(cls):
+        # Aluminum alloy Al-MS89
+        return cls(
+            name="aluminum-alloy",
+            E=90e9,
+            rho=2.92e3,
+            nu=0.3,
+            T1=420e6,
+            C1=420e6,
+            S1=0.6 * 420e6,  # estimated
+            alpha=19.0e-6,
+            kappa=115.0,
+            cp=903,  # guessed the cp (not provided in data sheet)
         )
 
     @classmethod
@@ -204,6 +238,7 @@ class Isotropic(Material):
             rho=7.8e3,
             T1=1.0e9,
             C1=1.7e9,
+            S1=0.6 * 420e6,  # estimated
             alpha=11.5e-6,
             kappa=45,
             cp=420,

--- a/tacs/caps2tacs/materials.py
+++ b/tacs/caps2tacs/materials.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["Material", "Isotropic", "Orthotropic"]
 
 from typing import TYPE_CHECKING

--- a/tacs/caps2tacs/proc_decorator.py
+++ b/tacs/caps2tacs/proc_decorator.py
@@ -1,6 +1,22 @@
-__all__ = ["root_proc"]
+__all__ = ["root_proc", "parallel", "root_broadcast"]
 
 from functools import wraps
+
+
+# do something on all active procs
+def parallel(method):
+    @wraps(method)
+    def wrapped_method(self, *args, **kwargs):
+        if self.comm.rank in self.active_procs:
+            return method(self, *args, **kwargs)
+        else:
+
+            def empty_function(self):
+                return
+
+            return empty_function
+
+    return wrapped_method
 
 
 # Define a root proc decorator so that certain ESP/CAPS method like pre and post analysis
@@ -8,7 +24,7 @@ from functools import wraps
 def root_proc(method):
     @wraps(method)
     def wrapped_method(self, *args, **kwargs):
-        if self.comm is None or self.comm.rank == 0:
+        if self.comm.rank == self.active_procs[0]:
             return method(self, *args, **kwargs)
         else:
 
@@ -28,9 +44,10 @@ def root_broadcast(method):
             return method(self, *args, **kwargs)
         else:
             output = None
-            if self.comm.rank == 0:
+            root = self.active_procs[0]
+            if self.comm.rank == root:
                 output = method(self, *args, **kwargs)
-            output = self.comm.bcast(output, root=0)
+            output = self.comm.bcast(output, root=root)
             return output
 
     return wrapped_method

--- a/tacs/caps2tacs/proc_decorator.py
+++ b/tacs/caps2tacs/proc_decorator.py
@@ -12,7 +12,7 @@ def parallel(method):
         else:
 
             def empty_function(self):
-                return
+                return self  # for potential method cascading
 
             return empty_function
 

--- a/tacs/caps2tacs/property.py
+++ b/tacs/caps2tacs/property.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["Property", "ShellProperty"]
 
 from .materials import Material

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -128,6 +128,7 @@ class TacsAim:
         self,
         large_format: bool = True,
         static: bool = True,
+        barrier:bool=True,
     ):
         # make sure there is at least one material, property, constraint, etc.
         assert len(self._materials) > 0
@@ -214,7 +215,8 @@ class TacsAim:
         self._setup = True
 
         # have other procs wait til this is done
-        self.comm.Barrier()
+        if barrier:
+            self.comm.Barrier()
         return self  # return object for method cascading
 
     @parallel
@@ -285,6 +287,14 @@ class TacsAim:
         # broadcast this analysis directory to other processors
         analysisDir = self.comm.bcast(analysisDir, root=proc)
         return analysisDir
+
+    @property
+    def root_proc_ind(self) -> int:
+        return self.active_procs[0]
+
+    @property
+    def root_proc(self) -> bool:
+        return self.comm.rank == self.root_proc_ind
 
     @property
     def root_analysis_dir(self) -> str:

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -151,7 +151,9 @@ class TacsAim:
                 }
             if len(self.variables) > 0:
                 self.aim.input.Design_Variable = {
-                    dv.name: dv.DV_dictionary for dv in self._design_variables if dv._active
+                    dv.name: dv.DV_dictionary
+                    for dv in self._design_variables
+                    if dv._active
                 }
 
             if self._dict_options is not None:

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -101,14 +101,14 @@ class TacsAim:
         for ishape, this_shape_var in enumerate(self.shape_variables):
             iproc = ishape % n_procs
             rank = self.active_procs[iproc]
-            if isinstance(this_shape_var, str):
-                if shape_var.name == this_shape_var:
+            if isinstance(shape_var, str):
+                if shape_var == this_shape_var.name:
                     return rank
-            elif isinstance(this_shape_var, ShapeVariable):
-                if shape_var == this_shape_var:
+            elif isinstance(shape_var, ShapeVariable):
+                if shape_var.name == this_shape_var.name:
                     return rank
-        # failed to find one, should trigger error elsewhere
-        return None
+        # if not found in for loop trigger error
+        raise AssertionError(f"failed to find shape var {shape_var} on rank {self.comm.rank}")
 
     @property
     def local_shape_vars(self) -> list:

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -183,6 +183,7 @@ class TacsAim:
                 self.aim.input["Mesh"].link(self._mesh_aim.aim.output["Surface_Mesh"])
 
                 # add the design variables to the DesignVariable and DesignVariableRelation properties
+                DV_dict = {}
                 if len(self.thickness_variables) > 0:
                     self.aim.input.Design_Variable_Relation = {
                         dv.name: dv.DVR_dictionary
@@ -191,19 +192,18 @@ class TacsAim:
                     }
 
                     # register all thickness variables to each proc
-                    self.aim.input.Design_Variable = {
-                        dv.name: dv.DV_dictionary
-                        for dv in self._design_variables
-                        if dv._active and isinstance(dv, ThicknessVariable)
-                    }
+                    for dv in self._design_variables:
+                        if dv._active and isinstance(dv, ThicknessVariable):
+                            DV_dict[dv.name] = dv.DV_dictionary
 
                 # distribute the shape variables that are active on each proc
                 if len(local_shape_vars) > 0:
-                    DV_dict = self.aim.input.Design_Variable
                     for dv in local_shape_vars:
                         if dv._active:
                             DV_dict[dv.name] = dv.DV_dictionary
-                    self.aim.input.Design_Variable = DV_dict
+
+                # update the DV dict
+                self.aim.input.Design_Variable = DV_dict
 
         if self._dict_options is not None:
             self._set_dict_options()
@@ -296,7 +296,7 @@ class TacsAim:
 
     def dat_file_path(self, proc: int = 0) -> str:
         return os.path.join(self.analysis_dir(proc), self.dat_file)
-    
+
     @property
     def root_dat_file(self):
         return self.dat_file_path(self.root_proc_ind)

--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -96,6 +96,8 @@ class TacsAim:
     def get_proc_with_shape_var(self, shape_var: ShapeVariable or str):
         """get the proc index that has a certain shape variable"""
         n_procs = len(self.active_procs)
+        assert n_procs > 0
+        assert len(self.shape_variables) > 0
         for ishape, this_shape_var in enumerate(self.shape_variables):
             iproc = ishape % n_procs
             rank = self.active_procs[iproc]

--- a/tacs/caps2tacs/tacs_component.py
+++ b/tacs/caps2tacs/tacs_component.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["TacsStaticComponent"]
 
 import os, numpy as np, matplotlib.pyplot as plt
@@ -58,7 +61,11 @@ class TacsStaticComponent(om.ExplicitComponent):
             # design history file
             if tacs_model.root_proc:
                 self._design_hdl = open(
-                    os.path.join(tacs_model.analysis_dir, "design_hist.txt"), "w"
+                    os.path.join(
+                        tacs_model.analysis_dir(tacs_model.root_proc_ind),
+                        "design_hist.txt",
+                    ),
+                    "w",
                 )
 
     def setup_partials(self):
@@ -145,7 +152,8 @@ class TacsStaticComponent(om.ExplicitComponent):
 
         if tacs_model.root_proc:
             self._plot_history(
-                directory=tacs_model.analysis_dir, filename="opt_history.png"
+                directory=tacs_model.analysis_dir(tacs_model.root_proc_ind),
+                filename="opt_history.png",
             )
 
     def _function_report(self):

--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -78,6 +78,8 @@ class TacsModel:
         assert 0 in active_procs
         caps_problem = None
         assert mesh in cls.MESH_AIMS
+        assert max(active_procs)+1 <= comm.Get_size()
+
         for iproc in active_procs:
             if comm.rank == iproc:
                 caps_problem = pyCAPS.Problem(

--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -17,7 +17,9 @@ from tacs.pytacs import pyTACS
 # optional funtofem dependency for shape variable animations
 # will still work without funtofem
 import importlib
+
 f2f_loader = importlib.util.find_spec("funtofem")
+
 
 class TacsModel:
     MESH_AIMS = ["egads", "aflr"]
@@ -277,7 +279,7 @@ class TacsModel:
                     )
         return self.SPs
 
-    def _convert_shape_vars_dict(self, shape_vars_dict:dict):
+    def _convert_shape_vars_dict(self, shape_vars_dict: dict):
         """convert the shape variable dict keys from str or funtofem variables to Tacs Shape Variables if necessary"""
         # convert shape variable dict to caps2tacs ShapeVariable keys if necessary
         shape_vars_dict2 = {}
@@ -290,8 +292,8 @@ class TacsModel:
                 for var in self.tacs_aim.shape_variables:
                     if var.name == key:
                         shape_vars_dict2[var] = shape_vars_dict[key]
-                        break # go to next key
-        elif f2f_loader is not None: # optional funtofem dependency
+                        break  # go to next key
+        elif f2f_loader is not None:  # optional funtofem dependency
             # import has to go here to prevent circular import
             from funtofem import Variable
 
@@ -300,16 +302,19 @@ class TacsModel:
                 for f2f_var in shape_vars_dict:
                     for tacs_var in self.tacs_aim.shape_variables:
                         if f2f_var.name == tacs_var.name:
-                            
                             # copy the value list to the new dictionary
                             shape_vars_dict2[tacs_var] = shape_vars_dict[f2f_var]
-                            break # go to next variable
+                            break  # go to next variable
 
             else:
-                raise AssertionError(f"The datatype {type(first_key)} is not allowed in caps2tacs shape variable dictionaries.")
+                raise AssertionError(
+                    f"The datatype {type(first_key)} is not allowed in caps2tacs shape variable dictionaries."
+                )
         else:
-            raise AssertionError(f"The datatype {type(first_key)} is not allowed in caps2tacs shape variable dictionaries.")
-    
+            raise AssertionError(
+                f"The datatype {type(first_key)} is not allowed in caps2tacs shape variable dictionaries."
+            )
+
         return shape_vars_dict2
 
     def animate_shape_vars(self, shape_vars_dict: dict):
@@ -372,7 +377,8 @@ class TacsModel:
                         number=i,
                     )
                     self.SPs[caseID].writeSensFile(
-                        evalFuncs=None, tacsAim=self.tacs_aim,
+                        evalFuncs=None,
+                        tacsAim=self.tacs_aim,
                     )
 
                 del self.SPs

--- a/tacs/caps2tacs/variables.py
+++ b/tacs/caps2tacs/variables.py
@@ -9,7 +9,7 @@ class ShapeVariable:
     shape variables in ESP/CAPS are design parameters that affect the structural geometry
     """
 
-    def __init__(self, name: str, value=None, active:bool=True):
+    def __init__(self, name: str, value=None, active: bool = True):
         """
         ESP/CAPS shape variable controls a design parameter in the CSM file
             name: corresponds to the design parameter in the CSM file
@@ -53,7 +53,7 @@ class ThicknessVariable:
         upper_bound: float = None,
         max_delta: float = None,
         material: Material = None,
-        active:bool=True,
+        active: bool = True,
     ):
         """
         ESP/CAPS Thickness variable sets the thickness over a portion of the geometry in the CSM file

--- a/tacs/caps2tacs/variables.py
+++ b/tacs/caps2tacs/variables.py
@@ -1,3 +1,6 @@
+"""
+Written by Sean Engelstad, GT SMDO Lab, 2022-2023
+"""
 __all__ = ["ShapeVariable", "ThicknessVariable"]
 
 from .materials import Material

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -883,7 +883,7 @@ class TACSProblem(TACSSystem):
                     auxElems, elemID, trac, faceIndex, nastranOrdering=True
                 )
 
-    def writeSensFile(self, evalFuncs, tacsAim, proc:int=0, root=0):
+    def writeSensFile(self, evalFuncs, tacsAim, proc: int = 0, root=0):
         """
         write an ESP/CAPS .sens file from the tacs aim
         Optional tacs_aim arg for TacsAim wrapper class object in root/tacs/caps2tacs/
@@ -906,16 +906,33 @@ class TACSProblem(TACSSystem):
 
         # obtain the functions and sensitivities from TACS assembler
         tacs_funcs = {}
-        tacs_sens = {}
-        if not(is_dummy_file):
+        if not (is_dummy_file):
+            local_tacs_sens = {}
             self.evalFunctions(tacs_funcs, evalFuncs=evalFuncs)
-            self.evalFunctionsSens(tacs_sens, evalFuncs=evalFuncs)
+            self.evalFunctionsSens(local_tacs_sens, evalFuncs=evalFuncs)
+
+            # get nastran=>local tacs id map for this processor
+            # this local_tacs_ids is len(num_nodes) globally with -1 for nodes
+            # not on this processor and the local tacs_ids for nodes owned by this processor
+            num_nodes = self.meshLoader.bdfInfo.nnodes
+            bdfNodes = range(num_nodes)
+            local_tacs_ids = self.meshLoader.getLocalNodeIDsFromGlobal(
+                bdfNodes, nastranOrdering=False
+            )
+
+            # only need to combine xpts sens across processors, the struct sens is only root proc (usually rank 0)
+            local_xpt_sens = {}
+            for tacs_key in local_tacs_sens:
+                local_xpt_sens[tacs_key] = local_tacs_sens[tacs_key]["Xpts"]
+
+            # gather the tacs ids and tacs xpts sens globally
+            mpi_tacs_ids = self.comm.gather(local_tacs_ids, root=root)
+            mpi_xpt_sens = self.comm.gather(local_xpt_sens, root=root)
 
         num_funcs = len(evalFuncs)
         assert tacsAim is not None
         num_struct_dvs = len(tacsAim.thickness_variables)
         num_nodes = self.meshLoader.bdfInfo.nnodes
-        node_ids = self.meshLoader.allLocalNodeIDs
 
         # uses other proc and broadcast so needed before root-proc check
         sens_file_path = tacsAim.sens_file_path(proc)
@@ -934,26 +951,32 @@ class TACSProblem(TACSSystem):
                             if func_name in tacs_key:
                                 break
 
-                        if not(is_dummy_file):
-                            # get the tacs coordinate derivatives
-                            xpts_sens = tacs_sens[tacs_key]["Xpts"]
-
+                        if not (is_dummy_file):
                             # write the func name, value and nnodes
                             hdl.write(f"{func_name}\n")
                             hdl.write(f"{tacs_funcs[tacs_key].real}\n")
                             hdl.write(f"{num_nodes}\n")
 
                             # write the coordinate derivatives for the given function
-                            for bdf_ind in range(num_nodes):
-                                tacs_ind = node_ids[bdf_ind]
-                                nastran_node = bdf_ind + 1
+                            for nastran_id_m1 in range(num_nodes):
+                                dfdxyz = None
+                                # find the xpt-sens among those of each processor in the mpi_tacs_sens list
+                                for ilocal, local_tacs_ids in enumerate(mpi_tacs_ids):
+                                    if local_tacs_ids[nastran_id_m1] != -1:
+                                        local_tacs_id = local_tacs_ids[nastran_id_m1]
+                                        dfdxyz = mpi_xpt_sens[ilocal][tacs_key][
+                                            3 * local_tacs_id : 3 * local_tacs_id + 3
+                                        ]
+                                        break
+
+                                nastran_id = nastran_id_m1 + 1
                                 hdl.write(
-                                    f"{nastran_node} {xpts_sens[3*tacs_ind].real} {xpts_sens[3*tacs_ind+1].real} {xpts_sens[3*tacs_ind+2].real}\n"
+                                    f"{nastran_id} {dfdxyz[0].real} {dfdxyz[1].real} {dfdxyz[2].real}\n"
                                 )
 
                             # write any struct derivatives if there are struct derivatives
                             if num_struct_dvs > 0:
-                                struct_sens = tacs_sens[tacs_key]["struct"]
+                                struct_sens = local_tacs_sens[tacs_key]["struct"]
                                 for idx, thick_var in enumerate(
                                     tacsAim.thickness_variables
                                 ):
@@ -962,7 +985,7 @@ class TACSProblem(TACSSystem):
                                     hdl.write("1\n")
                                     hdl.write(f"{struct_sens[idx].real}\n")
 
-                        else: # is a dummy sens file for animating the structure shape
+                        else:  # is a dummy sens file for animating the structure shape
                             # write the func name, value and nnodes
                             hdl.write(f"{func_name}\n")
                             hdl.write(f"{0.0}\n")
@@ -975,7 +998,9 @@ class TACSProblem(TACSSystem):
 
                             # write any struct derivatives if there are struct derivatives
                             if num_struct_dvs > 0:
-                                for idx, thick_var in enumerate(tacsAim.thickness_variables):
+                                for idx, thick_var in enumerate(
+                                    tacsAim.thickness_variables
+                                ):
                                     # assumes these are sorted in tacs aim wrapper
                                     hdl.write(f"{thick_var.name}\n")
                                     hdl.write("1\n")

--- a/tacs/problems/base.py
+++ b/tacs/problems/base.py
@@ -883,7 +883,7 @@ class TACSProblem(TACSSystem):
                     auxElems, elemID, trac, faceIndex, nastranOrdering=True
                 )
 
-    def writeSensFile(self, evalFuncs, tacsAim):
+    def writeSensFile(self, evalFuncs, tacsAim, proc:int=0):
         """
         write an ESP/CAPS .sens file from the tacs aim
         Optional tacs_aim arg for TacsAim wrapper class object in root/tacs/caps2tacs/
@@ -894,7 +894,8 @@ class TACSProblem(TACSSystem):
             names of TACS functions to be evaluated
         tacsAim : tacs.caps2tacs.TacsAIM
             class which handles the sensitivity file writing for ESP/CAPS shape derivatives
-
+        proc: int
+            which processor (in case of parallel tacsAIM instances) to write the sens file to
         """
 
         is_dummy_file = evalFuncs is None
@@ -914,10 +915,10 @@ class TACSProblem(TACSSystem):
         num_nodes = self.meshLoader.bdfInfo.nnodes
         node_ids = self.meshLoader.allLocalNodeIDs
 
-        if self.comm.rank == 0:
+        if self.comm.rank == proc:
             # open the sens file nastran_CAPS.sens and write coordinate derivatives
             # and any other struct derivatives to it
-            with open(tacsAim.sens_file_path, "w") as hdl:
+            with open(tacsAim.sens_file_path(proc), "w") as hdl:
                 for func_name in evalFuncs:
                     hdl.write(f"{num_funcs} {num_struct_dvs}\n")
 

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -1210,17 +1210,19 @@ class pyMeshLoader(BaseUI):
         """
 
         self._nastranToLocalNodeIDMap()
-        local_maps = self.comm.gather(self._local_map, root=0)
-        full_map_list = []
-        for local_map in local_maps:
-            full_map_list += local_map
         all_struct_ids = None
+        local_maps = self.comm.gather(self._local_map, root=0)
         if self.comm.rank == 0:
-            all_struct_ids = np.zeros((self.bdfInfo.nnodes), dtype=int)
-            for map in full_map_list:
-                for key in map:
-                    all_struct_ids[int(key)] = map[int(key)]
-            all_struct_ids = list(all_struct_ids)
+            full_map_list = []
+            for local_map in local_maps:
+                full_map_list += local_map
+            all_struct_ids = None
+            if self.comm.rank == 0:
+                all_struct_ids = np.zeros((self.bdfInfo.nnodes), dtype=int)
+                for map in full_map_list:
+                    for key in map:
+                        all_struct_ids[int(key)] = map[int(key)]
+                all_struct_ids = list(all_struct_ids)
         # broadcast to other procs
         all_struct_ids = self.comm.bcast(all_struct_ids, root=0)
         return all_struct_ids

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -1217,16 +1217,11 @@ class pyMeshLoader(BaseUI):
         all_struct_ids = None
         local_maps = self.comm.gather(self._local_map, root=0)
         if self.comm.rank == 0:
-            full_map_list = []
+            all_struct_ids = np.zeros((self.bdfInfo.nnodes), dtype=int)
             for local_map in local_maps:
-                full_map_list += local_map
-            all_struct_ids = None
-            if self.comm.rank == 0:
-                all_struct_ids = np.zeros((self.bdfInfo.nnodes), dtype=int)
-                for map in full_map_list:
-                    for key in map:
-                        all_struct_ids[int(key)] = map[int(key)]
-                all_struct_ids = list(all_struct_ids)
+                for key in local_map:
+                    all_struct_ids[int(key)] = map[int(key)]
+            all_struct_ids = list(all_struct_ids)
         # broadcast to other procs
         all_struct_ids = self.comm.bcast(all_struct_ids, root=0)
         return all_struct_ids

--- a/tacs/pymeshloader.py
+++ b/tacs/pymeshloader.py
@@ -48,13 +48,17 @@ class pyMeshLoader(BaseUI):
             # Read in bdf file as pynastran object
             # By default we avoid cross-referencing unless we actually need it,
             # since its expensive for large models
-            self.bdfInfo = pn.read_bdf(bdf, validate=False, xref=False, debug=debugPrint)
+            self.bdfInfo = pn.read_bdf(
+                bdf, validate=False, xref=False, debug=debugPrint
+            )
         # Create a copy of the BDF object
         elif isinstance(bdf, pn.BDF):
             self.bdfInfo = deepcopy(bdf)
         else:
-            raise self._TACSError("BDF input must be provided as a file name 'str' or pyNastran 'BDF' object. "
-                                  f"Provided input was of type '{type(bdf).__name__}'.")
+            raise self._TACSError(
+                "BDF input must be provided as a file name 'str' or pyNastran 'BDF' object. "
+                f"Provided input was of type '{type(bdf).__name__}'."
+            )
 
         # Set flag letting us know model is not xrefed yet
         self.bdfInfo.is_xrefed = False

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -856,10 +856,10 @@ class pyTACS(BaseUI):
         # Check if (res2-res0) - 2 * (res1 - res0) is zero (or very close to it)
         resNorm = np.real(res1.norm())
         res2.axpy(-2.0, res1)
-        if resNorm == 0.0: # degenerate case
-            return False
+        if resNorm == 0.0 or (np.real(res2.norm()) / resNorm) <= self.getOption("linearityTol")
+            return False # not nonlinear case
         else:
-            return (np.real(res2.norm()) / resNorm) > self.getOption("linearityTol")
+            return True # nonlinear case
 
     def _elemCallBackFromBDF(self):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -856,7 +856,10 @@ class pyTACS(BaseUI):
         # Check if (res2-res0) - 2 * (res1 - res0) is zero (or very close to it)
         resNorm = np.real(res1.norm())
         res2.axpy(-2.0, res1)
-        return (np.real(res2.norm()) / resNorm) > self.getOption("linearityTol")
+        if resNorm == 0.0: # degenerate case
+            return False
+        else:
+            return (np.real(res2.norm()) / resNorm) > self.getOption("linearityTol")
 
     def _elemCallBackFromBDF(self):
         """

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -856,7 +856,7 @@ class pyTACS(BaseUI):
         # Check if (res2-res0) - 2 * (res1 - res0) is zero (or very close to it)
         resNorm = np.real(res1.norm())
         res2.axpy(-2.0, res1)
-        if resNorm == 0.0 or (np.real(res2.norm()) / resNorm) <= self.getOption("linearityTol")
+        if resNorm == 0.0 or (np.real(res2.norm()) / resNorm) <= self.getOption("linearityTol"):
             return False # not nonlinear case
         else:
             return True # nonlinear case

--- a/tests/integration_tests/test_caps_shape_derivatives.py
+++ b/tests/integration_tests/test_caps_shape_derivatives.py
@@ -61,8 +61,8 @@ class TestCaps2TacsShape(unittest.TestCase):
         ).register_to(tacs_model)
 
         # include shape variables
-        caps2tacs.ShapeVariable("rib_a1").register_to(tacs_model)
-        # caps2tacs.ShapeVariable("rib_a2").register_to(tacs_model)
+        caps2tacs.ShapeVariable("rib_a1", value=1.0).register_to(tacs_model)
+        caps2tacs.ShapeVariable("rib_a2", value=0.0).register_to(tacs_model)
 
         # add constraints and loads
         caps2tacs.PinConstraint("root").register_to(tacs_model)
@@ -101,7 +101,7 @@ class TestCaps2TacsShape(unittest.TestCase):
         ) in (
             tacs_model.shape_variables
         ):  # perturb the variables to affect update design
-            shape_var.value += dxds[var.name] * h
+            shape_var.value += dxds[shape_var.name] * h
         tacs_model.update_design()
         tacs_model.pre_analysis()
         tacs_model.run_analysis()


### PR DESCRIPTION
*  active_procs list in the `TacsModel.build` arg is used to create parallel instances of tacs_aim and egads_aim objects from pyCAPS or ESP/CAPS packages.
* When shape variables change, the geometry of each parallel tacsAIM is updated - especially the root tacsAIM (active_procs[0]) which is responsible for the bdf/dat file aka structure mesh.
* The primary reason for creating parallel instances of tacsAIM objects is that the `tacs_aim.post_analysis()` call scales with the # of shape variables and is really slowing down the shape optimization of an aerodynamic vehicle geometry in FUNtoFEM. Namely, the tacsAIM.post_analysis takes 26 minutes for the application case in FUNtoFEM with 8 shape variables and a 40 min CFD analysis. We can achieve a theoretical 8x speedup on this example by computing each shape derivative calculation on a parallel instance of a tacsAIM.
* A new example `7_multiproc_post_analysis.py` was written to demonstrate the speedup of using parallel tacsAIMs on a simple wing geometry. There were 4 shape variables and the theoretical 4x speedup by using 4 parallel tacsAIMs was achieved!
* Much of the underlying structure of the `tacsAIM` class was redone to accomodate parallel instances of the tacsAIM objects. Therefore, all of the ESP/CAPS unittests were ran again and verified. 
* The structure of the `writeSensFile` had to be rewritten since it was never tested before on MPI calls and it was discovered that the `tacs_sens` - Xpts derivatives are distributed across each of the processors and need to be aggregated among them. 
* The `test_caps_shape_derivatives.py` unittest would previously not pass if multiple shape variables were used even though they worked individually (which doesn't make sense). A bug was corrected in which a previous temp variable was accidentally reused. The unittest now works for multiple shape variables and analysis functions.