### PR TITLE
Mphys tweaks

### DIFF
--- a/tacs/mphys/builder.py
+++ b/tacs/mphys/builder.py
@@ -26,6 +26,7 @@ class TacsBuilder(Builder):
         coupled=True,
         write_solution=True,
         separate_mass_dvs=False,
+        res_ref=None,
     ):
         """
         Create the Builder responsible for creating MPhys Scenario's based on TACS Analyses.
@@ -109,6 +110,9 @@ class TacsBuilder(Builder):
         separate_mass_dvs : bool, optional
             Flag to determine if TACS' mass dvs should be lumped into the struct_dv input vector (False) or
             split into separate OpenMDAO inputs based on their assigned names (True). Defaults to False.
+        res_ref : float, optional
+            Reference residual norm to be used by OpenMDAO's residual scaling. Can be useful for ensuring residuals
+            from different coupled disciplines are of a similar order of magnitude. Defaults to None.
 
         Examples
         --------
@@ -229,6 +233,7 @@ class TacsBuilder(Builder):
         self.coupled = coupled
         self.write_solution = write_solution
         self.separate_mass_dvs = separate_mass_dvs
+        self.res_ref = res_ref
 
     def initialize(self, comm):
         """
@@ -275,6 +280,7 @@ class TacsBuilder(Builder):
             coupled=self.coupled,
             scenario_name=scenario_name,
             problem_setup=self.problem_setup,
+            res_ref=self.res_ref,
         )
 
     def get_mesh_coordinate_subsystem(self, scenario_name=None):

--- a/tacs/mphys/coupling.py
+++ b/tacs/mphys/coupling.py
@@ -19,12 +19,14 @@ class TacsCouplingGroup(om.Group):
         self.options.declare("coupled", default=False)
         self.options.declare("scenario_name", default=None)
         self.options.declare("problem_setup", default=None)
+        self.options.declare("res_ref", default=None)
 
     def setup(self):
         self.fea_assembler = self.options["fea_assembler"]
         self.check_partials = self.options["check_partials"]
         self.coupled = self.options["coupled"]
         self.conduction = self.options["conduction"]
+        self.res_ref = self.options["res_ref"]
 
         # Promote state variables/rhs with physics-specific tag that MPhys expects
         promotes_inputs = [
@@ -82,6 +84,7 @@ class TacsCouplingGroup(om.Group):
                 check_partials=self.check_partials,
                 coupled=self.coupled,
                 conduction=self.conduction,
+                res_ref=self.res_ref,
             ),
             promotes_inputs=promotes_inputs,
         )

--- a/tacs/mphys/functions.py
+++ b/tacs/mphys/functions.py
@@ -101,7 +101,7 @@ class TacsFunctions(om.ExplicitComponent):
             outputs[func_name] = funcs[key]
 
         if self.write_solution:
-            self.write_solution()
+            self.writeSolution()
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         if mode == "fwd":

--- a/tacs/mphys/functions.py
+++ b/tacs/mphys/functions.py
@@ -84,6 +84,11 @@ class TacsFunctions(om.ExplicitComponent):
         self.sp.setNodes(inputs["x_struct0"])
         self.sp.setVariables(inputs[self.states_name])
 
+    def writeSolution(self):
+        # write the solution files.
+        self.sp.writeSolution(number=self.solution_counter)
+        self.solution_counter += 1
+
     def compute(self, inputs, outputs):
         self._update_internal(inputs)
 
@@ -96,9 +101,7 @@ class TacsFunctions(om.ExplicitComponent):
             outputs[func_name] = funcs[key]
 
         if self.write_solution:
-            # write the solution files.
-            self.sp.writeSolution(number=self.solution_counter)
-            self.solution_counter += 1
+            self.write_solution()
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         if mode == "fwd":

--- a/tacs/mphys/postcoupling.py
+++ b/tacs/mphys/postcoupling.py
@@ -130,3 +130,6 @@ class TacsPostcouplingGroup(om.Group):
                 con_group.add_subsystem(
                     constraint.name, con_comp, promotes_inputs=promotes_inputs
                 )
+
+    def writeSolution(self):
+        self.eval_funcs.writeSolution()

--- a/tacs/mphys/solver.py
+++ b/tacs/mphys/solver.py
@@ -17,6 +17,7 @@ class TacsSolver(om.ImplicitComponent):
         self.options.declare("conduction", default=False)
         self.options.declare("check_partials")
         self.options.declare("coupled", default=False)
+        self.options.declare("res_ref", default=None)
 
         self.fea_assembler = None
 
@@ -31,6 +32,7 @@ class TacsSolver(om.ImplicitComponent):
         self.fea_assembler = self.options["fea_assembler"]
         self.conduction = self.options["conduction"]
         self.coupled = self.options["coupled"]
+        self.res_ref = self.options["res_ref"]
 
         if self.conduction:
             self.states_name = "T_conduct"
@@ -78,6 +80,7 @@ class TacsSolver(om.ImplicitComponent):
             val=np.zeros(state_size),
             desc="structural state vector",
             tags=["mphys_coupling"],
+            res_ref=self.res_ref,
         )
 
     def _need_update(self, inputs):
@@ -139,6 +142,7 @@ class TacsSolver(om.ImplicitComponent):
 
         hasConverged = self.sp.solve(Fext=Fext)
         if not hasConverged:
+            self.sp.writeSolution(baseName=f"{self.sp.name}-failed")
             # TODO: In future we could add something here to distinguish between fatal failures and those that could be recovered from
             self.sp.zeroVariables()
             raise om.AnalysisError("TACS solver did not converge")


### PR DESCRIPTION
Adds two things to the TACS MPhys wrapper:

1. A `res_ref` input argument to the TACSBuilder to specify a reference residual value that will be [used by OpenMDAO to scale the residual](https://openmdao.org/newdocs/versions/latest/features/core_features/working_with_components/scaling.html?highlight=res_ref#specifying-a-scaler-on-a-residual)
2. Adds `writeSolution` method to the mphys wrapper to allow users to write out solutions. This is useful when you want to be able to write out solution files but not necessarily after every solve.

Warning: as explained in https://github.com/OpenMDAO/OpenMDAO/issues/3072 OpenMDAO doesn't currently apply the residual scaling correctly to matrix-free partial derivatives, so any check_partials currently fails if you do any residual scaling. The total derivatives are fine though.