### PR TITLE
Fix bug in caps2tacs when DV_dict is None.

### DIFF
--- a/tacs/caps2tacs/tacs_aim.py
+++ b/tacs/caps2tacs/tacs_aim.py
@@ -208,7 +208,8 @@ class TacsAim:
                             DV_dict[dv.name] = dv.DV_dictionary
 
                 # update the DV dict
-                self.aim.input.Design_Variable = DV_dict
+                if DV_dict:
+                    self.aim.input.Design_Variable = DV_dict
 
         if self._dict_options is not None:
             self._set_dict_options()


### PR DESCRIPTION
Unexpected behavior when DV_dict was None or empty: need to check that it exists before passing it to the AIM.