### PR TITLE
Allow setting inactive thickness variables in caps2tacs.

### DIFF
--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -281,8 +281,7 @@ class TacsModel:
                     changed_design = True
 
         # update thickness prop cards in t
-        if self.tacs_aim.change_shape:
-            self.tacs_aim.update_properties()
+        self.tacs_aim.update_properties()
 
         # record whether the design has changed & first analysis flag as well
         if self._first_analysis:


### PR DESCRIPTION
Allow setting inactive thickness variable's membrane thickness without adding to DV and DVR in caps2tacs.

Also fix bug/typo from `==` to `=` in `tacs_aim.py`.

Corresponds to PR 274 on FUNtoFEM.