### PR TITLE
Add templated implementations of BCSR matrix operations

### DIFF
--- a/src/bpmat/BCSRMat.cpp
+++ b/src/bpmat/BCSRMat.cpp
@@ -1035,8 +1035,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor1;
       applylower = BCSRMatApplyLower1;
       applyupper = BCSRMatApplyUpper1;
-      bmult = BCSRMatVecMult1;
-      bmultadd = BCSRMatVecMultAdd1;
+      bmult = BCSRBlockMatVecMult<1>;
+      bmultadd = BCSRBlockMatVecMultAdd<1>;
       bmulttrans = BCSRMatVecMultTranspose1;
       bmatmult = BCSRMatMatMultAdd1;
       bfactorlower = BCSRMatFactorLower1;
@@ -1051,8 +1051,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor2;
       applylower = BCSRMatApplyLower2;
       applyupper = BCSRMatApplyUpper2;
-      bmult = BCSRMatVecMult2;
-      bmultadd = BCSRMatVecMultAdd2;
+      bmult = BCSRBlockMatVecMult<2>;
+      bmultadd = BCSRBlockMatVecMultAdd<2>;
       bmatmult = BCSRMatMatMultAdd2;
       bfactorlower = BCSRMatFactorLower2;
       bfactorupper = BCSRMatFactorUpper2;
@@ -1065,8 +1065,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor3;
       applylower = BCSRMatApplyLower3;
       applyupper = BCSRMatApplyUpper3;
-      bmult = BCSRMatVecMult3;
-      bmultadd = BCSRMatVecMultAdd3;
+      bmult = BCSRBlockMatVecMult<3>;
+      bmultadd = BCSRBlockMatVecMultAdd<3>;
       bmatmult = BCSRMatMatMultAdd3;
       bfactorlower = BCSRMatFactorLower3;
       bfactorupper = BCSRMatFactorUpper3;
@@ -1079,8 +1079,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor4;
       applylower = BCSRMatApplyLower4;
       applyupper = BCSRMatApplyUpper4;
-      bmult = BCSRMatVecMult4;
-      bmultadd = BCSRMatVecMultAdd4;
+      bmult = BCSRBlockMatVecMult<4>;
+      bmultadd = BCSRBlockMatVecMultAdd<4>;
       bmatmult = BCSRMatMatMultAdd4;
       bfactorlower = BCSRMatFactorLower4;
       bfactorupper = BCSRMatFactorUpper4;
@@ -1093,8 +1093,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor5;
       applylower = BCSRMatApplyLower5;
       applyupper = BCSRMatApplyUpper5;
-      bmult = BCSRMatVecMult5;
-      bmultadd = BCSRMatVecMultAdd5;
+      bmult = BCSRBlockMatVecMult<5>;
+      bmultadd = BCSRBlockMatVecMultAdd<5>;
       bmatmult = BCSRMatMatMultAdd5;
       bfactorlower = BCSRMatFactorLower5;
       bfactorupper = BCSRMatFactorUpper5;
@@ -1112,8 +1112,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor6;
       applylower = BCSRMatApplyLower6;
       applyupper = BCSRMatApplyUpper6;
-      bmult = BCSRMatVecMult6;
-      bmultadd = BCSRMatVecMultAdd6;
+      bmult = BCSRBlockMatVecMult<6>;
+      bmultadd = BCSRBlockMatVecMultAdd<6>;
       bmatmult = BCSRMatMatMultAdd6;
       bfactorlower = BCSRMatFactorLower6;
       bfactorupper = BCSRMatFactorUpper6;
@@ -1140,8 +1140,8 @@ void BCSRMat::initBlockImpl() {
       bfactor = BCSRMatFactor8;
       applylower = BCSRMatApplyLower8;
       applyupper = BCSRMatApplyUpper8;
-      bmult = BCSRMatVecMult8;
-      bmultadd = BCSRMatVecMultAdd8;
+      bmult = BCSRBlockMatVecMult<8>;
+      bmultadd = BCSRBlockMatVecMultAdd<8>;
       bmatmult = BCSRMatMatMultAdd8;
       bfactorlower = BCSRMatFactorLower8;
       bfactorupper = BCSRMatFactorUpper8;


### PR DESCRIPTION
I was looking into implementing transpose multiplication for BCSR matrices when I discovered that the BCSR operations have separate implementations for each possible block size. I think we could get the same performance for most of the defined operations by templating on the block size, which would drastically reduce the amount of duplicated code.

So far I've added templated implementations of the 2 basic MatVec operations. I'm opening this PR to get @gjkennedy 's opinion on this before I continue converting more functions.