### PR TITLE
pyNastran 1.4.0 update

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
         "numpy<2.0.0",
         "mpi4py>=3.1.1",
         "scipy>=1.2.1",
-        "pynastran>=1.3.3",
+        "pynastran>=1.4.0",
         "numba",
     ],
     extras_require=optional_dependencies,

--- a/tacs/pytacs.py
+++ b/tacs/pytacs.py
@@ -1736,8 +1736,8 @@ class pyTACS(BaseUI):
                                     timeSteps, dscale
                                 )
                             elif dloadInfo.type == "TLOAD2":
-                                loadScales = _tload2_get_load_at_time(
-                                    dloadInfo, timeSteps, dscale
+                                loadScales = dloadInfo.get_load_at_time(
+                                    timeSteps, dscale
                                 )
                             if dloadInfo.Type != "LOAD":
                                 self._TACSWarning(
@@ -2487,46 +2487,3 @@ class pyTACS(BaseUI):
         # Default to 6
         if self.varsPerNode is None:
             self.varsPerNode = 6
-
-
-def _tload2_get_load_at_time(tload2, time, scale=1.0):
-    """
-    This is a function for interpolating the time series for the NASTRAN TLOAD2 card.
-    Usually, this would be done through pyNastran, but there's bug in its implementation
-    that prevents it from being run.
-    """
-    if isinstance(time, float):
-        time = np.array([time])
-    else:
-        time = np.asarray(time)
-
-    if isinstance(tload2.delay, float):
-        tau = tload2.delay
-    elif tload2.delay == 0 or tload2.delay is None:
-        tau = 0.0
-    else:
-        tau = tload2.delay_ref.get_delay_at_time(time)
-
-    t1 = tload2.T1 + tau
-    t2 = tload2.T2 + tau
-    freq = tload2.frequency
-    p = tload2.phase
-    f = np.zeros(time.shape, dtype=time.dtype)
-
-    i = np.where(t1 <= time)[0]
-    j = np.where(time[i] <= t2)[0]
-    i = i[j]
-    f[i] = (
-        scale
-        * time[i] ** tload2.b
-        * np.exp(tload2.c * time[i])
-        * np.cos(2 * np.pi * freq * time[i] + p)
-    )
-
-    is_spcd = False
-    # resp = f
-    if tload2.Type == "VELO" and is_spcd:
-        f[0] = tload2.us0
-    if tload2.Type == "ACCE" and is_spcd:
-        f[0] = tload2.vs0
-    return f

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -23,13 +23,13 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
     FUNC_REFS = {
-        "ramp_compliance": 10.917589919679486,
+        "ramp_compliance": 0.6911725719135957,
         "ramp_x_disp": 0.06931471805599457,
-        "ramp_y_disp": 12.191784286714391,
+        "ramp_y_disp": 6.227712362945539,
         "ramp_z_disp": 0.06931471805599457,
         "sinusoid_compliance": 23.113858857368683,
         "sinusoid_x_disp": 0.06931471805599457,
-        "sinusoid_y_disp": 25.47755094553053,
+        "sinusoid_y_disp": 25.47755094553055,
         "sinusoid_z_disp": 0.06931471805599457,
     }
 


### PR DESCRIPTION
- pyNastran released a new update this week which fixes several long-standing errors with processing dynamic loads
- I've pinned this version as the new minimum in the setup.py

- TODO: Python 3.8 is no longer supported in pyNastran