### PR TITLE
Fix issue with delayed transient loads

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -129,7 +129,7 @@ setup(
         "numpy<2.0.0",
         "mpi4py>=3.1.1",
         "scipy>=1.2.1",
-        "pynastran>=1.3.3",
+        "pynastran>=1.4.0",
         "numba",
     ],
     extras_require=optional_dependencies,

--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -9,7 +9,7 @@ from tacs import pytacs, constitutive, elements, functions
 6 noded beam model 1 meter long in x direction with a two transient tip load cases:
     1. linear ramp
     2. sinusoidal
-The transient loads are read in from the BDF using the createTACSProbsFromBDF method. 
+The transient loads are read in from the BDF using the createTACSProbsFromBDF method.
 We apply apply various tip loads test KSDisplacement and Compliance functions and sensitivities.
 """
 
@@ -23,9 +23,9 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
     N_PROCS = 2  # this is how many MPI processes to use for this TestCase.
 
     FUNC_REFS = {
-        "ramp_compliance": 10.917589919679486,
+        "ramp_compliance": 0.6911725719135945,
         "ramp_x_disp": 0.06931471805599457,
-        "ramp_y_disp": 12.191784286714391,
+        "ramp_y_disp": 6.227712362945526,
         "ramp_z_disp": 0.06931471805599457,
         "sinusoid_compliance": 23.113858857368683,
         "sinusoid_x_disp": 0.06931471805599457,


### PR DESCRIPTION
Prior to version 1.4.0, pyNastran's `get_load_at_time` was not correctly interpolating transient loads defined using `TLOAD1` when a delay was used. 

For example, `test_trans_beam.py` uses a tip load that is supposed to ramp from 0 to 5N over 1 second with a delay of 1 second. Due to the error in pyNastran, the load was instead being applied as a constant 5N from 0 to 1 seconds and 0N from 1 to 2 seconds, resulting in this solution:

![Wrong](https://github.com/smdogroup/tacs/assets/20371123/288f17e3-1349-4f52-af51-1ee1c23f3478)

With pyNastran 1.4.0, the correct solution is:
![Right](https://github.com/smdogroup/tacs/assets/20371123/1766a219-fa7f-47e4-846d-f78780cf34ef)

This PR bumps the minimum required pyNastran version to 1.4.0 and updates the reference values for the fixed transient integration test.
