### PR TITLE
Accept Element Callbacks in caps2tacs + Adapt Mach Wing Example

### DIFF
--- a/examples/caps_wing/10_blade_stiffened.py
+++ b/examples/caps_wing/10_blade_stiffened.py
@@ -2,7 +2,7 @@
 Sean Engelstad, March 2024
 GT SMDO Lab, Dr. Graeme Kennedy
 
-Based off of Alasdair Christan Gray's Mach wing blade stiffened example in TACS : examples/mach_tutorial_wing
+Based off of Alasdair Christison Gray's Mach wing blade stiffened example in TACS : examples/mach_tutorial_wing
     Can only do analysis in caps2tacs module in TACS need FUNtoFEM + casp2tacs to perform full optimization
 """
 

--- a/examples/caps_wing/10_blade_stiffened.py
+++ b/examples/caps_wing/10_blade_stiffened.py
@@ -1,0 +1,258 @@
+"""
+Sean Engelstad, March 2024
+GT SMDO Lab, Dr. Graeme Kennedy
+
+Based off of Alasdair Christan Gray's Mach wing blade stiffened example in TACS : examples/mach_tutorial_wing
+    Can only do analysis in caps2tacs module in TACS need FUNtoFEM + casp2tacs to perform full optimization
+"""
+
+from funtofem import *
+from tacs import elements, constitutive, caps2tacs, TACS
+import openmdao.api as om
+from mpi4py import MPI
+import numpy as np
+
+tacs_dtype = TACS.dtype
+comm = MPI.COMM_WORLD
+
+# --------------------------------------------------------------#
+# Setup CAPS Problem and FUNtoFEM model
+# --------------------------------------------------------------#
+
+# define the Tacs model
+tacs_model = caps2tacs.TacsModel.build(csm_file="large_naca_wing.csm", comm=comm)
+tacs_model.mesh_aim.set_mesh(  # need a refined-enough mesh for the derivative test to pass
+    edge_pt_min=15,
+    edge_pt_max=20,
+    global_mesh_size=0.01,
+    max_surf_offset=0.01,
+    max_dihedral_angle=5,
+).register_to(
+    tacs_model
+)
+tacs_aim = tacs_model.tacs_aim
+
+# setup the thickness design variables + automatic shell properties
+# using Composite functions, this part has to go after all funtofem variables are defined...
+nribs = int(tacs_model.get_config_parameter("nribs"))
+nspars = int(tacs_model.get_config_parameter("nspars"))
+nOML = nribs - 1
+
+null_material = caps2tacs.Orthotropic.null().register_to(tacs_model)
+
+for irib in range(1, nribs + 1):
+    name = f"rib{irib}"
+    caps2tacs.CompositeProperty.null(name, null_material).register_to(tacs_model)
+    # caps2tacs.ThicknessVariable(
+    #     caps_group=f"rib{irib}", value=init_thickness
+    # ).register_to(tacs_model)
+
+for ispar in range(1, nspars + 1):
+    name = f"spar{ispar}"
+    caps2tacs.CompositeProperty.null(name, null_material).register_to(tacs_model)
+    # caps2tacs.ThicknessVariable(
+    #     caps_group=f"rib{irib}", value=init_thickness
+    # ).register_to(tacs_model)
+
+for iOML in range(1, nOML + 1):
+    name = f"OML{iOML}"
+    caps2tacs.CompositeProperty.null(name, null_material).register_to(tacs_model)
+    # caps2tacs.ThicknessVariable(
+    #     caps_group=f"rib{irib}", value=init_thickness
+    # ).register_to(tacs_model)
+
+# add constraints and loads
+caps2tacs.PinConstraint("root").register_to(tacs_model)
+caps2tacs.GridForce("OML", direction=[0, 0, 1.0], magnitude=10).register_to(tacs_model)
+
+# add in analysis functions into the tacs aim
+caps2tacs.AnalysisFunction.mass().register_to(tacs_model)
+caps2tacs.AnalysisFunction.ksfailure(safetyFactor=1.5, ksWeight=50.0).register_to(
+    tacs_model
+)
+
+# run the tacs model setup
+tacs_model.setup(include_aim=True)
+
+# define the element callback for TACS
+compositeProperties = {
+    "E11": 117.9e9,  # Young's modulus in 11 direction (Pa)
+    "E22": 9.7e9,  # Young's modulus in 22 direction (Pa)
+    "G12": 4.8e9,  # in-plane 1-2 shear modulus (Pa)
+    "G13": 4.8e9,  # Transverse 1-3 shear modulus (Pa)
+    "G23": 4.8e9,  # Transverse 2-3 shear modulus (Pa)
+    "nu12": 0.35,  # 1-2 poisson's ratio
+    "rho": 1.55e3,  # density kg/m^3
+    "T1": 1648e6,  # Tensile strength in 1 direction (Pa)
+    "C1": 1034e6,  # Compressive strength in 1 direction (Pa)
+    "T2": 64e6,  # Tensile strength in 2 direction (Pa)
+    "C2": 228e6,  # Compressive strength in 2 direction (Pa)
+    "S12": 71e6,  # Shear strength direction (Pa)
+}
+skinPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
+skinPlyFracs = np.array([44.41, 22.2, 22.2, 11.19], dtype=tacs_dtype) / 100.0
+sparRibPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
+sparRibPlyFracs = np.array([10.0, 35.0, 35.0, 20.0], dtype=tacs_dtype) / 100.0
+
+# ==============================================================================
+# Design variable values, bounds, and scaling factors
+# ==============================================================================
+# Panel length
+panelLengthMax = np.inf
+panelLengthMin = 0.0
+panelLengthScale = 1.0
+
+# Stiffener pitch
+stiffenerPitch = tacs_dtype(0.2)  # m
+stiffenerPitchMax = 0.5  # m
+stiffenerPitchMin = 0.05  # m
+stiffenerPitchScale = 1.0
+
+# Panel thickness
+panelThickness = tacs_dtype(0.02)  # m
+panelThicknessMax = 0.1  # m
+panelThicknessMin = 0.002  # m
+panelThicknessScale = 100.0
+
+# ply fraction bounds
+plyFractionMax = 1.0
+plyFractionMin = 0.1
+plyFractionScale = 1.0
+
+# Stiffener height
+stiffenerHeight = tacs_dtype(0.05)  # m
+stiffenerHeightMax = 0.1  # m
+stiffenerHeightMin = 0.002  # m
+stiffenerHeightScale = 10.0
+
+# Stiffener thickness
+stiffenerThickness = tacs_dtype(0.02)  # m
+stiffenerThicknessMax = 0.1  # m
+stiffenerThicknessMin = 0.002  # m
+stiffenerThicknessScale = 100.0
+
+# --- Stiffener axis directions ---
+TESparDirection = np.array([0.34968083, 0.93686889, 0.0])
+VerticalDirection = np.array([0.0, 0.0, 1.0])
+
+# ==============================================================================
+# Element callback function
+# ==============================================================================
+
+
+def blade_elemCallBack(
+    dvNum, compID, compDescript, elemDescripts, specialDVs, **kwargs
+):
+
+    prop = constitutive.MaterialProperties(
+        rho=compositeProperties["rho"],
+        E1=compositeProperties["E11"],
+        E2=compositeProperties["E22"],
+        G12=compositeProperties["G12"],
+        G13=compositeProperties["G13"],
+        G23=compositeProperties["G23"],
+        nu12=compositeProperties["nu12"],
+        T1=compositeProperties["T1"],
+        C1=compositeProperties["C1"],
+        T2=compositeProperties["T2"],
+        C2=compositeProperties["C2"],
+        S12=compositeProperties["S12"],
+    )
+    ply = constitutive.OrthotropicPly(1.0, prop)
+
+    # Use a 0-deg biased layup for the skin and a +-45-deg biased layup spars and ribs.
+    # Align the stiffeners in the skins with the trailing edge spar, and the stiffeners
+    # in the spars and ribs vertically.
+    # The panel length values I set here are approximate, to get the real values, you'd
+    # need to run an optimization with panel length design variables and constraints.
+    if "OML" in compDescript:
+        plyAngles = skinPlyAngles
+        panelPlyFractions = skinPlyFracs
+        refAxis = TESparDirection
+        panelLength = 0.65
+    else:
+        plyAngles = sparRibPlyAngles
+        panelPlyFractions = sparRibPlyFracs
+        refAxis = VerticalDirection
+        if "rib" in compDescript:
+            panelLength = 0.38
+        elif "spar" in compDescript:
+            panelLength = 0.36
+
+    # Always use the 0-deg biased layup for the stiffeners
+    stiffenerPlyFractions = skinPlyFracs
+    numPlies = len(plyAngles)
+
+    # --- Setup DV numbering and scaling ---
+
+    # The ordering of the DVs used by the BladeStiffenedShell model is:
+    # - panel length
+    # - stiffener pitch
+    # - panel thickness
+    # - panel ply fractions (not used in this case)
+    # - stiffener height
+    # - stiffener thickness
+    # - stiffener ply fractions (not used in this case)
+    currDVNum = dvNum
+    DVScales = []
+
+    panelLengthNum = currDVNum
+    DVScales.append(panelLengthScale)
+    currDVNum += 1
+
+    stiffenerPitchNum = currDVNum
+    DVScales.append(stiffenerPitchScale)
+    currDVNum += 1
+
+    panelThicknessNum = currDVNum
+    DVScales.append(panelThicknessScale)
+    currDVNum += 1
+
+    stiffenerHeightNum = currDVNum
+    DVScales.append(stiffenerHeightScale)
+    currDVNum += 1
+
+    stiffenerThicknessNum = currDVNum
+    DVScales.append(stiffenerThicknessScale)
+    currDVNum += 1
+
+    con = constitutive.BladeStiffenedShellConstitutive(
+        panelPly=ply,
+        stiffenerPly=ply,
+        panelLength=panelLength,
+        stiffenerPitch=stiffenerPitch,
+        panelThick=panelThickness,
+        panelPlyAngles=plyAngles,
+        panelPlyFracs=panelPlyFractions,
+        stiffenerHeight=stiffenerHeight,
+        stiffenerThick=stiffenerThickness,
+        stiffenerPlyAngles=plyAngles,
+        stiffenerPlyFracs=stiffenerPlyFractions,
+        panelLengthNum=panelLengthNum,
+        stiffenerPitchNum=stiffenerPitchNum,
+        panelThickNum=panelThicknessNum,
+        stiffenerHeightNum=stiffenerHeightNum,
+        stiffenerThickNum=stiffenerThicknessNum,
+    )
+    con.setStiffenerPitchBounds(stiffenerPitchMin, stiffenerPitchMax)
+    con.setPanelThicknessBounds(panelThicknessMin, panelThicknessMax)
+    con.setStiffenerHeightBounds(stiffenerHeightMin, stiffenerHeightMax)
+    con.setStiffenerThicknessBounds(stiffenerThicknessMin, stiffenerThicknessMax)
+
+    # --- Create reference axis transform to define the stiffener direction ---
+    transform = elements.ShellRefAxisTransform(refAxis)
+
+    # --- Create the element object ---
+    if elemDescripts[0] == "CQUAD4":
+        elem = elements.Quad4Shell(transform, con)
+    elif elemDescripts[0] == "CQUAD9":
+        elem = elements.Quad9Shell(transform, con)
+    elif elemDescripts[0] == "CQUAD16":
+        elem = elements.Quad16Shell(transform, con)
+
+    return elem, DVScales
+
+
+# build the solver manager, no tacs interface since built for each new shape
+# in the tacs driver
+tacs_model.run_analysis()

--- a/examples/caps_wing/10_blade_stiffened.py
+++ b/examples/caps_wing/10_blade_stiffened.py
@@ -6,11 +6,12 @@ Based off of Alasdair Christan Gray's Mach wing blade stiffened example in TACS 
     Can only do analysis in caps2tacs module in TACS need FUNtoFEM + casp2tacs to perform full optimization
 """
 
-from funtofem import *
-from tacs import elements, constitutive, caps2tacs, TACS
+from tacs import caps2tacs
 import openmdao.api as om
 from mpi4py import MPI
 import numpy as np
+
+from _blade_callback import blade_elemCallBack
 
 tacs_dtype = TACS.dtype
 comm = MPI.COMM_WORLD
@@ -20,7 +21,9 @@ comm = MPI.COMM_WORLD
 # --------------------------------------------------------------#
 
 # define the Tacs model
-tacs_model = caps2tacs.TacsModel.build(csm_file="large_naca_wing.csm", comm=comm)
+tacs_model = caps2tacs.TacsModel.build(
+    csm_file="large_naca_wing.csm", comm=comm, callback=blade_elemCallBack
+)
 tacs_model.mesh_aim.set_mesh(  # need a refined-enough mesh for the derivative test to pass
     edge_pt_min=15,
     edge_pt_max=20,
@@ -73,185 +76,6 @@ caps2tacs.AnalysisFunction.ksfailure(safetyFactor=1.5, ksWeight=50.0).register_t
 
 # run the tacs model setup
 tacs_model.setup(include_aim=True)
-
-# define the element callback for TACS
-compositeProperties = {
-    "E11": 117.9e9,  # Young's modulus in 11 direction (Pa)
-    "E22": 9.7e9,  # Young's modulus in 22 direction (Pa)
-    "G12": 4.8e9,  # in-plane 1-2 shear modulus (Pa)
-    "G13": 4.8e9,  # Transverse 1-3 shear modulus (Pa)
-    "G23": 4.8e9,  # Transverse 2-3 shear modulus (Pa)
-    "nu12": 0.35,  # 1-2 poisson's ratio
-    "rho": 1.55e3,  # density kg/m^3
-    "T1": 1648e6,  # Tensile strength in 1 direction (Pa)
-    "C1": 1034e6,  # Compressive strength in 1 direction (Pa)
-    "T2": 64e6,  # Tensile strength in 2 direction (Pa)
-    "C2": 228e6,  # Compressive strength in 2 direction (Pa)
-    "S12": 71e6,  # Shear strength direction (Pa)
-}
-skinPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
-skinPlyFracs = np.array([44.41, 22.2, 22.2, 11.19], dtype=tacs_dtype) / 100.0
-sparRibPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
-sparRibPlyFracs = np.array([10.0, 35.0, 35.0, 20.0], dtype=tacs_dtype) / 100.0
-
-# ==============================================================================
-# Design variable values, bounds, and scaling factors
-# ==============================================================================
-# Panel length
-panelLengthMax = np.inf
-panelLengthMin = 0.0
-panelLengthScale = 1.0
-
-# Stiffener pitch
-stiffenerPitch = tacs_dtype(0.2)  # m
-stiffenerPitchMax = 0.5  # m
-stiffenerPitchMin = 0.05  # m
-stiffenerPitchScale = 1.0
-
-# Panel thickness
-panelThickness = tacs_dtype(0.02)  # m
-panelThicknessMax = 0.1  # m
-panelThicknessMin = 0.002  # m
-panelThicknessScale = 100.0
-
-# ply fraction bounds
-plyFractionMax = 1.0
-plyFractionMin = 0.1
-plyFractionScale = 1.0
-
-# Stiffener height
-stiffenerHeight = tacs_dtype(0.05)  # m
-stiffenerHeightMax = 0.1  # m
-stiffenerHeightMin = 0.002  # m
-stiffenerHeightScale = 10.0
-
-# Stiffener thickness
-stiffenerThickness = tacs_dtype(0.02)  # m
-stiffenerThicknessMax = 0.1  # m
-stiffenerThicknessMin = 0.002  # m
-stiffenerThicknessScale = 100.0
-
-# --- Stiffener axis directions ---
-TESparDirection = np.array([0.34968083, 0.93686889, 0.0])
-VerticalDirection = np.array([0.0, 0.0, 1.0])
-
-# ==============================================================================
-# Element callback function
-# ==============================================================================
-
-
-def blade_elemCallBack(
-    dvNum, compID, compDescript, elemDescripts, specialDVs, **kwargs
-):
-
-    prop = constitutive.MaterialProperties(
-        rho=compositeProperties["rho"],
-        E1=compositeProperties["E11"],
-        E2=compositeProperties["E22"],
-        G12=compositeProperties["G12"],
-        G13=compositeProperties["G13"],
-        G23=compositeProperties["G23"],
-        nu12=compositeProperties["nu12"],
-        T1=compositeProperties["T1"],
-        C1=compositeProperties["C1"],
-        T2=compositeProperties["T2"],
-        C2=compositeProperties["C2"],
-        S12=compositeProperties["S12"],
-    )
-    ply = constitutive.OrthotropicPly(1.0, prop)
-
-    # Use a 0-deg biased layup for the skin and a +-45-deg biased layup spars and ribs.
-    # Align the stiffeners in the skins with the trailing edge spar, and the stiffeners
-    # in the spars and ribs vertically.
-    # The panel length values I set here are approximate, to get the real values, you'd
-    # need to run an optimization with panel length design variables and constraints.
-    if "OML" in compDescript:
-        plyAngles = skinPlyAngles
-        panelPlyFractions = skinPlyFracs
-        refAxis = TESparDirection
-        panelLength = 0.65
-    else:
-        plyAngles = sparRibPlyAngles
-        panelPlyFractions = sparRibPlyFracs
-        refAxis = VerticalDirection
-        if "rib" in compDescript:
-            panelLength = 0.38
-        elif "spar" in compDescript:
-            panelLength = 0.36
-
-    # Always use the 0-deg biased layup for the stiffeners
-    stiffenerPlyFractions = skinPlyFracs
-    numPlies = len(plyAngles)
-
-    # --- Setup DV numbering and scaling ---
-
-    # The ordering of the DVs used by the BladeStiffenedShell model is:
-    # - panel length
-    # - stiffener pitch
-    # - panel thickness
-    # - panel ply fractions (not used in this case)
-    # - stiffener height
-    # - stiffener thickness
-    # - stiffener ply fractions (not used in this case)
-    currDVNum = dvNum
-    DVScales = []
-
-    panelLengthNum = currDVNum
-    DVScales.append(panelLengthScale)
-    currDVNum += 1
-
-    stiffenerPitchNum = currDVNum
-    DVScales.append(stiffenerPitchScale)
-    currDVNum += 1
-
-    panelThicknessNum = currDVNum
-    DVScales.append(panelThicknessScale)
-    currDVNum += 1
-
-    stiffenerHeightNum = currDVNum
-    DVScales.append(stiffenerHeightScale)
-    currDVNum += 1
-
-    stiffenerThicknessNum = currDVNum
-    DVScales.append(stiffenerThicknessScale)
-    currDVNum += 1
-
-    con = constitutive.BladeStiffenedShellConstitutive(
-        panelPly=ply,
-        stiffenerPly=ply,
-        panelLength=panelLength,
-        stiffenerPitch=stiffenerPitch,
-        panelThick=panelThickness,
-        panelPlyAngles=plyAngles,
-        panelPlyFracs=panelPlyFractions,
-        stiffenerHeight=stiffenerHeight,
-        stiffenerThick=stiffenerThickness,
-        stiffenerPlyAngles=plyAngles,
-        stiffenerPlyFracs=stiffenerPlyFractions,
-        panelLengthNum=panelLengthNum,
-        stiffenerPitchNum=stiffenerPitchNum,
-        panelThickNum=panelThicknessNum,
-        stiffenerHeightNum=stiffenerHeightNum,
-        stiffenerThickNum=stiffenerThicknessNum,
-    )
-    con.setStiffenerPitchBounds(stiffenerPitchMin, stiffenerPitchMax)
-    con.setPanelThicknessBounds(panelThicknessMin, panelThicknessMax)
-    con.setStiffenerHeightBounds(stiffenerHeightMin, stiffenerHeightMax)
-    con.setStiffenerThicknessBounds(stiffenerThicknessMin, stiffenerThicknessMax)
-
-    # --- Create reference axis transform to define the stiffener direction ---
-    transform = elements.ShellRefAxisTransform(refAxis)
-
-    # --- Create the element object ---
-    if elemDescripts[0] == "CQUAD4":
-        elem = elements.Quad4Shell(transform, con)
-    elif elemDescripts[0] == "CQUAD9":
-        elem = elements.Quad9Shell(transform, con)
-    elif elemDescripts[0] == "CQUAD16":
-        elem = elements.Quad16Shell(transform, con)
-
-    return elem, DVScales
-
 
 # build the solver manager, no tacs interface since built for each new shape
 # in the tacs driver

--- a/examples/caps_wing/_blade_callback.py
+++ b/examples/caps_wing/_blade_callback.py
@@ -2,7 +2,7 @@ __all__ = ["blade_elemCallBack"]
 
 """
 Adapted by Sean Engelstad
-Source : Alasdair Christian Gray
+Source : Alasdair Christison Gray
 """
 
 from tacs import elements, constitutive, TACS

--- a/examples/caps_wing/_blade_callback.py
+++ b/examples/caps_wing/_blade_callback.py
@@ -1,0 +1,190 @@
+__all__ = ["blade_elemCallBack"]
+
+"""
+Adapted by Sean Engelstad
+Source : Alasdair Christian Gray
+"""
+
+from tacs import elements, constitutive, TACS
+import numpy as np
+
+tacs_dtype = TACS.dtype
+
+# define the element callback for TACS
+compositeProperties = {
+    "E11": 117.9e9,  # Young's modulus in 11 direction (Pa)
+    "E22": 9.7e9,  # Young's modulus in 22 direction (Pa)
+    "G12": 4.8e9,  # in-plane 1-2 shear modulus (Pa)
+    "G13": 4.8e9,  # Transverse 1-3 shear modulus (Pa)
+    "G23": 4.8e9,  # Transverse 2-3 shear modulus (Pa)
+    "nu12": 0.35,  # 1-2 poisson's ratio
+    "rho": 1.55e3,  # density kg/m^3
+    "T1": 1648e6,  # Tensile strength in 1 direction (Pa)
+    "C1": 1034e6,  # Compressive strength in 1 direction (Pa)
+    "T2": 64e6,  # Tensile strength in 2 direction (Pa)
+    "C2": 228e6,  # Compressive strength in 2 direction (Pa)
+    "S12": 71e6,  # Shear strength direction (Pa)
+}
+skinPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
+skinPlyFracs = np.array([44.41, 22.2, 22.2, 11.19], dtype=tacs_dtype) / 100.0
+sparRibPlyAngles = np.deg2rad(np.array([0.0, -45.0, 45.0, 90.0])).astype(tacs_dtype)
+sparRibPlyFracs = np.array([10.0, 35.0, 35.0, 20.0], dtype=tacs_dtype) / 100.0
+
+# ==============================================================================
+# Design variable values, bounds, and scaling factors
+# ==============================================================================
+# Panel length
+panelLengthMax = np.inf
+panelLengthMin = 0.0
+panelLengthScale = 1.0
+
+# Stiffener pitch
+stiffenerPitch = tacs_dtype(0.2)  # m
+stiffenerPitchMax = 0.5  # m
+stiffenerPitchMin = 0.05  # m
+stiffenerPitchScale = 1.0
+
+# Panel thickness
+panelThickness = tacs_dtype(0.02)  # m
+panelThicknessMax = 0.1  # m
+panelThicknessMin = 0.002  # m
+panelThicknessScale = 100.0
+
+# ply fraction bounds
+plyFractionMax = 1.0
+plyFractionMin = 0.1
+plyFractionScale = 1.0
+
+# Stiffener height
+stiffenerHeight = tacs_dtype(0.05)  # m
+stiffenerHeightMax = 0.1  # m
+stiffenerHeightMin = 0.002  # m
+stiffenerHeightScale = 10.0
+
+# Stiffener thickness
+stiffenerThickness = tacs_dtype(0.02)  # m
+stiffenerThicknessMax = 0.1  # m
+stiffenerThicknessMin = 0.002  # m
+stiffenerThicknessScale = 100.0
+
+# --- Stiffener axis directions ---
+TESparDirection = np.array([0.34968083, 0.93686889, 0.0])
+VerticalDirection = np.array([0.0, 0.0, 1.0])
+
+# ==============================================================================
+# Element callback function
+# ==============================================================================
+
+
+def blade_elemCallBack(
+    dvNum, compID, compDescript, elemDescripts, specialDVs, **kwargs
+):
+
+    prop = constitutive.MaterialProperties(
+        rho=compositeProperties["rho"],
+        E1=compositeProperties["E11"],
+        E2=compositeProperties["E22"],
+        G12=compositeProperties["G12"],
+        G13=compositeProperties["G13"],
+        G23=compositeProperties["G23"],
+        nu12=compositeProperties["nu12"],
+        T1=compositeProperties["T1"],
+        C1=compositeProperties["C1"],
+        T2=compositeProperties["T2"],
+        C2=compositeProperties["C2"],
+        S12=compositeProperties["S12"],
+    )
+    ply = constitutive.OrthotropicPly(1.0, prop)
+
+    # Use a 0-deg biased layup for the skin and a +-45-deg biased layup spars and ribs.
+    # Align the stiffeners in the skins with the trailing edge spar, and the stiffeners
+    # in the spars and ribs vertically.
+    # The panel length values I set here are approximate, to get the real values, you'd
+    # need to run an optimization with panel length design variables and constraints.
+    if "OML" in compDescript:
+        plyAngles = skinPlyAngles
+        panelPlyFractions = skinPlyFracs
+        refAxis = TESparDirection
+        panelLength = 0.65
+    else:
+        plyAngles = sparRibPlyAngles
+        panelPlyFractions = sparRibPlyFracs
+        refAxis = VerticalDirection
+        if "rib" in compDescript:
+            panelLength = 0.38
+        elif "spar" in compDescript:
+            panelLength = 0.36
+
+    # Always use the 0-deg biased layup for the stiffeners
+    stiffenerPlyFractions = skinPlyFracs
+    numPlies = len(plyAngles)
+
+    # --- Setup DV numbering and scaling ---
+
+    # The ordering of the DVs used by the BladeStiffenedShell model is:
+    # - panel length
+    # - stiffener pitch
+    # - panel thickness
+    # - panel ply fractions (not used in this case)
+    # - stiffener height
+    # - stiffener thickness
+    # - stiffener ply fractions (not used in this case)
+    currDVNum = dvNum
+    DVScales = []
+
+    panelLengthNum = currDVNum
+    DVScales.append(panelLengthScale)
+    currDVNum += 1
+
+    stiffenerPitchNum = currDVNum
+    DVScales.append(stiffenerPitchScale)
+    currDVNum += 1
+
+    panelThicknessNum = currDVNum
+    DVScales.append(panelThicknessScale)
+    currDVNum += 1
+
+    stiffenerHeightNum = currDVNum
+    DVScales.append(stiffenerHeightScale)
+    currDVNum += 1
+
+    stiffenerThicknessNum = currDVNum
+    DVScales.append(stiffenerThicknessScale)
+    currDVNum += 1
+
+    # print(f"making blade stiffeners")
+    con = constitutive.BladeStiffenedShellConstitutive(
+        panelPly=ply,
+        stiffenerPly=ply,
+        panelLength=panelLength,
+        stiffenerPitch=stiffenerPitch,
+        panelThick=panelThickness,
+        panelPlyAngles=plyAngles,
+        panelPlyFracs=panelPlyFractions,
+        stiffenerHeight=stiffenerHeight,
+        stiffenerThick=stiffenerThickness,
+        stiffenerPlyAngles=plyAngles,
+        stiffenerPlyFracs=stiffenerPlyFractions,
+        panelLengthNum=panelLengthNum,
+        stiffenerPitchNum=stiffenerPitchNum,
+        panelThickNum=panelThicknessNum,
+        stiffenerHeightNum=stiffenerHeightNum,
+        stiffenerThickNum=stiffenerThicknessNum,
+    )
+    con.setStiffenerPitchBounds(stiffenerPitchMin, stiffenerPitchMax)
+    con.setPanelThicknessBounds(panelThicknessMin, panelThicknessMax)
+    con.setStiffenerHeightBounds(stiffenerHeightMin, stiffenerHeightMax)
+    con.setStiffenerThicknessBounds(stiffenerThicknessMin, stiffenerThicknessMax)
+
+    # --- Create reference axis transform to define the stiffener direction ---
+    transform = elements.ShellRefAxisTransform(refAxis)
+
+    # --- Create the element object ---
+    if elemDescripts[0] == "CQUAD4":
+        elem = elements.Quad4Shell(transform, con)
+    elif elemDescripts[0] == "CQUAD9":
+        elem = elements.Quad9Shell(transform, con)
+    elif elemDescripts[0] == "CQUAD16":
+        elem = elements.Quad16Shell(transform, con)
+
+    return elem, DVScales

--- a/examples/caps_wing/simple_naca_wing.csm
+++ b/examples/caps_wing/simple_naca_wing.csm
@@ -106,8 +106,7 @@ patbeg ispar nspars
    
    # add caps attributes
    attribute capsGroup !$spar+ispar
-   attribute capsBound $spar
-   csystem spar YZcsys
+   csystem !$spar+ispar YZcsys
    ATTRIBUTE AFLR_GBC $TRANSP_UG3_GBC
    attribute _color $green
 
@@ -132,8 +131,7 @@ patbeg index ninnerRibs
    
    # add caps attributes
    attribute capsGroup !$rib+irib
-   attribute capsBound $rib
-   csystem rib XZcsys
+   csystem !$rib+irib XZcsys
    ATTRIBUTE AFLR_GBC $TRANSP_UG3_GBC
    attribute _color $green
 

--- a/tacs/caps2tacs/aflr_aim.py
+++ b/tacs/caps2tacs/aflr_aim.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["AflrAim"]
 
 

--- a/tacs/caps2tacs/analysis_function.py
+++ b/tacs/caps2tacs/analysis_function.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["AnalysisFunction", "Derivative"]
 
 from tacs.functions import (

--- a/tacs/caps2tacs/constraints.py
+++ b/tacs/caps2tacs/constraints.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["Constraint", "PinConstraint", "TemperatureConstraint"]
 
 

--- a/tacs/caps2tacs/gif_writer.py
+++ b/tacs/caps2tacs/gif_writer.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["GifWriter"]
 import imageio, os
 

--- a/tacs/caps2tacs/loads.py
+++ b/tacs/caps2tacs/loads.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["Load", "Pressure", "GridForce"]
 
 from typing import TYPE_CHECKING, List

--- a/tacs/caps2tacs/materials.py
+++ b/tacs/caps2tacs/materials.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["Material", "Isotropic", "Orthotropic"]
 
 from typing import TYPE_CHECKING
@@ -157,12 +158,13 @@ class Isotropic(Material):
     @classmethod
     def null(cls):
         """these properties need to be set then through element callback"""
-        return cls(name="null", 
-                   E=0.0,
-                   nu=0.0,
-                   rho=0.0,
-                   T1=0.0,
-                   )
+        return cls(
+            name="null",
+            E=0.0,
+            nu=0.0,
+            rho=0.0,
+            T1=1.0,
+        )
 
     @classmethod
     def madeupium(
@@ -321,18 +323,13 @@ class Orthotropic(Material):
             E2=0.0,
             G12=0.0,
             nu12=0.0,
-            T1=0.0,
-            C1=0.0,
-            T2=0.0,
-            C2=0.0,
-            S1=0.0,
-            alpha1=0.0,
-            alpha2=0.0,
-            rho=0.0,
-            kappa1=0.0,  # W/m-K
-            kappa2=0.0,  # W/m-K
-            kappa3=0.0,  # W/m-K
+            T1=1.0,
+            C1=1.0,
+            T2=1.0,
+            C2=1.0,
+            S1=1.0,
             cp=0.0,  # J / kg-K
+            rho=0.0,
         )
 
     @classmethod

--- a/tacs/caps2tacs/materials.py
+++ b/tacs/caps2tacs/materials.py
@@ -155,6 +155,16 @@ class Isotropic(Material):
         )
 
     @classmethod
+    def null(cls):
+        """these properties need to be set then through element callback"""
+        return cls(name="null", 
+                   E=0.0,
+                   nu=0.0,
+                   rho=0.0,
+                   T1=0.0,
+                   )
+
+    @classmethod
     def madeupium(
         cls,
         E=72.0e9,
@@ -300,6 +310,29 @@ class Orthotropic(Material):
             alpha1=alpha1,
             alpha2=alpha2,
             alpha3=alpha3,
+        )
+
+    @classmethod
+    def null(cls):
+        """these properties need to be set then through element callback"""
+        return cls(
+            name="null",
+            E1=0.0,
+            E2=0.0,
+            G12=0.0,
+            nu12=0.0,
+            T1=0.0,
+            C1=0.0,
+            T2=0.0,
+            C2=0.0,
+            S1=0.0,
+            alpha1=0.0,
+            alpha2=0.0,
+            rho=0.0,
+            kappa1=0.0,  # W/m-K
+            kappa2=0.0,  # W/m-K
+            kappa3=0.0,  # W/m-K
+            cp=0.0,  # J / kg-K
         )
 
     @classmethod

--- a/tacs/caps2tacs/property.py
+++ b/tacs/caps2tacs/property.py
@@ -3,7 +3,7 @@ __all__ = ["BaseProperty", "ShellProperty", "CompositeProperty"]
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
 
-from .materials import Material, Isotropic, Orthotropic
+from .materials import Material
 from typing import TYPE_CHECKING
 
 

--- a/tacs/caps2tacs/property.py
+++ b/tacs/caps2tacs/property.py
@@ -3,7 +3,7 @@ __all__ = ["BaseProperty", "ShellProperty", "CompositeProperty"]
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
 
-from .materials import Material
+from .materials import Material, Isotropic, Orthotropic
 from typing import TYPE_CHECKING
 
 
@@ -61,6 +61,15 @@ class ShellProperty(BaseProperty):
         self._membrane_thickness = membrane_thickness
         self._bending_inertia = bending_inertia
         self._shear_membrane_ratio = shear_membrane_ratio
+
+    @classmethod
+    def null(cls, caps_group:str):
+        """these properties need to be set then through element callback"""
+        return cls(
+            caps_group=caps_group,
+            material=Isotropic.null(),
+            membrane_thickness=1.0,
+        )
 
     @property
     def membrane_thickness(self) -> float:
@@ -144,6 +153,16 @@ class CompositeProperty(BaseProperty):
             shear_bond_allowable=shear_bond_allowable,
             bending_inertia=bending_inertia,
             shear_membrane_ratio=shear_membrane_ratio,
+        )
+    
+    @classmethod
+    def null(cls, caps_group:str):
+        """these properties need to be set then through element callback"""
+        return cls.one_ply(
+            caps_group=caps_group,
+            material=Isotropic.null(),
+            thickness=1.0,
+            ply_angle=0.0,
         )
 
     @property

--- a/tacs/caps2tacs/property.py
+++ b/tacs/caps2tacs/property.py
@@ -63,11 +63,11 @@ class ShellProperty(BaseProperty):
         self._shear_membrane_ratio = shear_membrane_ratio
 
     @classmethod
-    def null(cls, caps_group:str):
+    def null(cls, caps_group: str, material):
         """these properties need to be set then through element callback"""
         return cls(
             caps_group=caps_group,
-            material=Isotropic.null(),
+            material=material,
             membrane_thickness=1.0,
         )
 
@@ -154,13 +154,13 @@ class CompositeProperty(BaseProperty):
             bending_inertia=bending_inertia,
             shear_membrane_ratio=shear_membrane_ratio,
         )
-    
+
     @classmethod
-    def null(cls, caps_group:str):
+    def null(cls, caps_group: str, material):
         """these properties need to be set then through element callback"""
         return cls.one_ply(
             caps_group=caps_group,
-            material=Isotropic.null(),
+            material=material,
             thickness=1.0,
             ply_angle=0.0,
         )

--- a/tacs/caps2tacs/tacs_component.py
+++ b/tacs/caps2tacs/tacs_component.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["TacsStaticComponent"]
 
 import os, numpy as np, matplotlib.pyplot as plt

--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -28,10 +28,11 @@ f2f_loader = importlib.util.find_spec("funtofem")
 class TacsModel:
     MESH_AIMS = ["egads", "aflr"]
 
-    def __init__(self, tacs_aim: TacsAim, mesh_aim, comm=None):
+    def __init__(self, tacs_aim: TacsAim, mesh_aim, comm=None, callback=None):
         self._tacs_aim = tacs_aim
         self._mesh_aim = mesh_aim
         self.comm = comm
+        self._callback = callback  # element callback defined by the user (optional)
 
         self._analysis_functions = []
         self.SPs = None
@@ -305,7 +306,7 @@ class TacsModel:
         most important call method from the tacsAim class: SPs = tacs_aim.createTACSProbs
         """
         fea_solver = self.fea_solver(root)
-        fea_solver.initialize(callback)
+        fea_solver.initialize(self._callback)
         SPs = fea_solver.createTACSProbsFromBDF()
         self.SPs = SPs  # store the static problems as well
 

--- a/tacs/caps2tacs/tacs_model.py
+++ b/tacs/caps2tacs/tacs_model.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["TacsModel"]
 
 import pyCAPS
@@ -265,9 +266,9 @@ class TacsModel:
                         ):
                             changed_design = True
                             if shape_var.value is not None:
-                                self.geometry.despmtr[
-                                    shape_var.name
-                                ].value = shape_var.value
+                                self.geometry.despmtr[shape_var.name].value = (
+                                    shape_var.value
+                                )
                             else:
                                 shape_var.value = self.geometry.despmtr[
                                     shape_var.name
@@ -296,13 +297,15 @@ class TacsModel:
         """
         return pyTACS(self.tacs_aim.dat_file_path(root), self.comm)
 
-    def createTACSProbs(self, root=0, addFunctions: bool = True):
+    def createTACSProbs(
+        self, root=0, callback=None, addFunctions: bool = True, auto: bool = False
+    ):
         """
         creates TACS list of static, transient, or modal analysis TACS problems from the TacsAim class
         most important call method from the tacsAim class: SPs = tacs_aim.createTACSProbs
         """
         fea_solver = self.fea_solver(root)
-        fea_solver.initialize()
+        fea_solver.initialize(callback)
         SPs = fea_solver.createTACSProbsFromBDF()
         self.SPs = SPs  # store the static problems as well
 

--- a/tacs/caps2tacs/variables.py
+++ b/tacs/caps2tacs/variables.py
@@ -1,6 +1,7 @@
 """
 Written by Sean Engelstad, GT SMDO Lab, 2022-2023
 """
+
 __all__ = ["ShapeVariable", "ThicknessVariable"]
 
 from .materials import *


### PR DESCRIPTION
* Made a change in the tacsAIM of ESP/CAPS (what caps2tacs is built off of) that writes out TACS Component labels. This way the user should be able to make their own element callbacks now in TACS using BDF/DAT files created from ESP/CAPS.
* Accepts element callbacks in the `TacsModel` clas
* Adapts Alasdair Gray's blade stiffener examples in examples/mach_tutorial_wing since we are using this for an aeroelastic benchmark case in FUNtoFEM.