### PR TITLE
Fixing bug with Jacobian update that slowed down StaticProblem solve procedure

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="tacs",
-    version="3.7.0",
+    version="3.7.1",
     description="Parallel finite-element analysis package",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -1021,6 +1021,7 @@ class StaticProblem(TACSProblem):
                 self.K,
                 loadScale=self._loadScale,
             )
+            self._jacobianUpdateRequired = False
             self._preconditionerUpdateRequired = True
 
     def updatePreconditioner(self):


### PR DESCRIPTION
I noticed that the Jacobian matrix gets updated every time the static problem is called (even if the design vars/nodes haven't changed). This leads to the PC being refactored every time which significantly slows down the code for linear analysis. To fix this I add a missing statement at the end of the Jacobian update procedure that sets the `_jacobianUpdateRequired` flag to `False`.