### PR TITLE
Conda deploy fix

### DIFF
--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -74,6 +74,8 @@ jobs:
           echo "Initiated by: ${GITHUB_ACTOR}";
           echo "=============================================================";
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
+      - uses: actions/checkout@v2
+
       - name: Setup miniconda
         uses: conda-incubator/setup-miniconda@v2
         with:

--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -75,6 +75,7 @@ jobs:
         with:
           auto-update-conda: true
           python-version: 3.9
+          architecture: x64
 
       - name: Setup miniconda (macos-latest)
         if: ${{ matrix.OS == 'macos-latest' }}

--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -23,33 +23,27 @@ jobs:
         include:
           # real versions
           - OS: ubuntu-latest
-            ARCHITECTURE: x64
             TARGET: linux-64
             SCALAR: real
 
-          - OS: macos-latest
-            ARCHITECTURE: x64
+          - OS: macos-13
             TARGET: osx-64
             SCALAR: real
 
           - OS: macos-latest
-            ARCHITECTURE: arm64
             TARGET: osx-arm64
             SCALAR: real
 
           # complex versions
           - OS: ubuntu-latest
-            ARCHITECTURE: x64
             TARGET: linux-64
             SCALAR: complex
 
-          - OS: macos-latest
-            ARCHITECTURE: x64
+          - OS: macos-13
             TARGET: osx-64
             SCALAR: complex
 
           - OS: macos-latest
-            ARCHITECTURE: arm64
             TARGET: osx-arm64
             SCALAR: complex
 
@@ -75,14 +69,21 @@ jobs:
           echo "=============================================================";
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
       - uses: actions/checkout@v2
-
       - name: Setup miniconda
+        if: ${{ matrix.OS != 'macos-latest' }}
+        uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: 3.9
+
+      - name: Setup miniconda (macos-latest)
+        if: ${{ matrix.OS == 'macos-latest' }}
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           auto-update-conda: true
           python-version: 3.9
-          architecture: ${{ matrix.ARCHITECTURE }}
+          architecture: arm64
 
       - name: Build TACS package
         run: |

--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -23,27 +23,33 @@ jobs:
         include:
           # real versions
           - OS: ubuntu-latest
+            ARCHITECTURE: x64
             TARGET: linux-64
             SCALAR: real
 
           - OS: macos-latest
+            ARCHITECTURE: x64
             TARGET: osx-64
             SCALAR: real
 
-          - OS: macos-14
+          - OS: macos-latest
+            ARCHITECTURE: arm64
             TARGET: osx-arm64
             SCALAR: real
 
           # complex versions
           - OS: ubuntu-latest
+            ARCHITECTURE: x64
             TARGET: linux-64
             SCALAR: complex
 
           - OS: macos-latest
+            ARCHITECTURE: x64
             TARGET: osx-64
             SCALAR: complex
 
-          - OS: macos-14
+          - OS: macos-latest
+            ARCHITECTURE: arm64
             TARGET: osx-arm64
             SCALAR: complex
 
@@ -68,22 +74,13 @@ jobs:
           echo "Initiated by: ${GITHUB_ACTOR}";
           echo "=============================================================";
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
-      - uses: actions/checkout@v2
       - name: Setup miniconda
-        if: ${{ matrix.OS != 'macos-14' }}
-        uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: 3.9
-
-      - name: Setup miniconda (MACOS-14)
-        if: ${{ matrix.OS == 'macos-14' }}
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
           auto-update-conda: true
           python-version: 3.9
-          architecture: arm64
+          architecture: ${{ matrix.ARCHITECTURE }}
 
       - name: Build TACS package
         run: |

--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -73,6 +73,7 @@ jobs:
         if: ${{ matrix.OS != 'macos-latest' }}
         uses: conda-incubator/setup-miniconda@v2
         with:
+          miniconda-version: "latest"
           auto-update-conda: true
           python-version: 3.9
           architecture: x64

--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -26,7 +26,7 @@ jobs:
             TARGET: linux-64
             SCALAR: real
 
-          - OS: macos-13
+          - OS: macos-latest
             TARGET: osx-64
             SCALAR: real
 
@@ -39,7 +39,7 @@ jobs:
             TARGET: linux-64
             SCALAR: complex
 
-          - OS: macos-13
+          - OS: macos-latest
             TARGET: osx-64
             SCALAR: complex
 
@@ -70,7 +70,7 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it.
       - uses: actions/checkout@v2
       - name: Setup miniconda
-        if: ${{ matrix.OS != 'macos-latest' }}
+        if: ${{ matrix.TARGET != 'osx-arm64' }}
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"
@@ -79,7 +79,7 @@ jobs:
           architecture: x64
 
       - name: Setup miniconda (macos-latest)
-        if: ${{ matrix.OS == 'macos-latest' }}
+        if: ${{ matrix.TARGET == 'osx-arm64' }}
         uses: conda-incubator/setup-miniconda@v2
         with:
           miniconda-version: "latest"


### PR DESCRIPTION
Github recently changed `macos-latest` runner to an M1 build. Updating CI deploy workflow to work with new changes