### PR TITLE
Fixing errors caused by `icpx` compilation

### DIFF
--- a/src/elements/TACSPressure2D.cpp
+++ b/src/elements/TACSPressure2D.cpp
@@ -64,6 +64,9 @@ double TACSPressure2D::getFaceQuadraturePoint(int face, int n, double pt[],
 /*
   Add the residual to the provided vector
 */
+/*
+  Add the residual to the provided vector
+*/
 void TACSPressure2D::addResidual(int elemIndex, double time,
                                  const TacsScalar *Xpts, const TacsScalar *vars,
                                  const TacsScalar *dvars,
@@ -89,10 +92,12 @@ void TACSPressure2D::addResidual(int elemIndex, double time,
     area *= weight;
 
     // Evaluate the weak form of the model
-    TacsScalar DUt[3 * TACSElement2D::MAX_VARS_PER_NODE];
-    TacsScalar DUx[2 * TACSElement2D::MAX_VARS_PER_NODE];
-    memset(DUt, 0, 3 * varsPerNode * sizeof(TacsScalar));
-    memset(DUx, 0, 2 * varsPerNode * sizeof(TacsScalar));
+    const int dutSize = 3 * TACSElement2D::MAX_VARS_PER_NODE;
+    const int duxSize = 2 * TACSElement2D::MAX_VARS_PER_NODE;
+    TacsScalar DUt[dutSize];
+    TacsScalar DUx[duxSize];
+    memset(DUt, 0, dutSize * sizeof(TacsScalar));
+    memset(DUx, 0, duxSize * sizeof(TacsScalar));
 
     for (int k = 0; k < 2; k++) {
       DUt[3 * k] = -p * normal[k];
@@ -112,39 +117,9 @@ void TACSPressure2D::addJacobian(int elemIndex, double time, TacsScalar alpha,
                                  const TacsScalar *dvars,
                                  const TacsScalar *ddvars, TacsScalar *res,
                                  TacsScalar *mat) {
-  // Compute the number of quadrature points
-  const int nquad = basis->getNumFaceQuadraturePoints(faceIndex);
-
-  // Loop over each quadrature point and add the residual contribution
-  for (int n = 0; n < nquad; n++) {
-    // Get the quadrature weight
-    double pt[3], tangent[6];
-    double weight = basis->getFaceQuadraturePoint(faceIndex, n, pt, tangent);
-
-    // Get the face normal
-    TacsScalar X[3], Xd[4], normal[3];
-    TacsScalar area = basis->getFaceNormal(faceIndex, n, Xpts, X, Xd, normal);
-
-    // Compute the inverse of the transformation
-    TacsScalar J[4];
-    inv2x2(Xd, J);
-
-    // Multiply the weight by the quadrature point
-    area *= weight;
-
-    // Evaluate the weak form of the model
-    TacsScalar DUt[3 * TACSElement2D::MAX_VARS_PER_NODE];
-    TacsScalar DUx[2 * TACSElement2D::MAX_VARS_PER_NODE];
-    memset(DUt, 0, 3 * varsPerNode * sizeof(TacsScalar));
-    memset(DUx, 0, 2 * varsPerNode * sizeof(TacsScalar));
-
-    for (int k = 0; k < 2; k++) {
-      DUt[3 * k] = -p * normal[k];
-    }
-
-    // Add the weak form of the residual at this point
-    if (res) {
-      basis->addWeakResidual(n, pt, area, J, varsPerNode, DUt, DUx, res);
-    }
+  // This element has no Jacobian contributions, so just compute the residual if
+  // it's requested
+  if (res != NULL) {
+    addResidual(elemIndex, time, Xpts, vars, dvars, ddvars, res);
   }
 }

--- a/src/elements/TACSPressure2D.cpp
+++ b/src/elements/TACSPressure2D.cpp
@@ -64,9 +64,6 @@ double TACSPressure2D::getFaceQuadraturePoint(int face, int n, double pt[],
 /*
   Add the residual to the provided vector
 */
-/*
-  Add the residual to the provided vector
-*/
 void TACSPressure2D::addResidual(int elemIndex, double time,
                                  const TacsScalar *Xpts, const TacsScalar *vars,
                                  const TacsScalar *dvars,

--- a/tests/integration_tests/test_thermoelast_linquad_element_2d.py
+++ b/tests/integration_tests/test_thermoelast_linquad_element_2d.py
@@ -59,7 +59,7 @@ class ProblemTest(StaticTestCase.StaticTest):
         else:
             self.rtol = 1e-2
             self.atol = 1e-4
-            self.dh = 1e-8
+            self.dh = 1e-6
 
         # Get the MPI communicator size
         rank = comm.rank


### PR DESCRIPTION
Compiling TACS with the new intel `icpx` compiler surfaced some new errors, one in `element_tests/test_pressure_2d` and another in `integration_tests/test_thermoelast_linquad_element_2d.py`.
Changes made:

- Fix memset of incorrect size in `TACSPressure2D`
- Remove duplicated residual calculation code from the `addJacobian` method of `TACSPressure2D`
- Slightly changed the FD step size used in the `test_thermoelast_linquad_element_2d` to give more accurate FD derivatives

Example of TACSPressure2d issue:

Before fix:

```
Testing residual consistency of addJacobian method for element TACSPressure2D.
Max Err: 5.2003e+00 in component 0.
Max REr: 1.7875e+00 in component 0.
The difference between addResidual and addJacobian residuals is
Val[   ]                  Analytic               Approximate                Rel. Error                Abs. Error
res[  0]   -8.1096044075844116e+00   -2.9092966201960104e+00    1.7874794035398276e+00    5.2003077873884012e+00
res[  1]   -6.6968190566401757e+00   -2.4024640498279082e+00    1.7874794035398274e+00    4.2943550068122676e+00
res[  2]    1.8409218189066476e+00   -2.9092966201960104e+00    1.6327721299118061e+00    4.7502184391026585e+00
res[  3]    1.5202122938461484e+00   -2.4024640498279082e+00    1.6327721299118059e+00    3.9226763436740564e+00
res[  4]    4.5008934828574299e-01    0.0000000000000000e+00                         -    4.5008934828574299e-01
res[  5]    3.7167866313821141e-01    0.0000000000000000e+00                         -    3.7167866313821141e-01
```

After fix:

```
Testing residual consistency of addJacobian method for element TACSPressure2D.
Max Err: 0.0000e+00 in component 0.
Max REr: 0.0000e+00 in component 0.
The difference between addResidual and addJacobian residuals is
Val[   ]                  Analytic               Approximate                Rel. Error                Abs. Error
res[  0]   -2.9092966201960104e+00   -2.9092966201960104e+00    0.0000000000000000e+00    0.0000000000000000e+00
res[  1]   -2.4024640498279082e+00   -2.4024640498279082e+00    0.0000000000000000e+00    0.0000000000000000e+00
res[  2]   -2.9092966201960104e+00   -2.9092966201960104e+00    0.0000000000000000e+00    0.0000000000000000e+00
res[  3]   -2.4024640498279082e+00   -2.4024640498279082e+00    0.0000000000000000e+00    0.0000000000000000e+00
res[  4]    0.0000000000000000e+00    0.0000000000000000e+00                         -    0.0000000000000000e+00
res[  5]    0.0000000000000000e+00    0.0000000000000000e+00                         -    0.0000000000000000e+00
```