### PR TITLE
Update test_trans_beam FD step size

### DIFF
--- a/tests/integration_tests/test_trans_beam.py
+++ b/tests/integration_tests/test_trans_beam.py
@@ -46,7 +46,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         else:
             self.rtol = 2e-3
             self.atol = 1e-3
-            self.dh = 1e-6
+            self.dh = 1e-8
 
         # Instantiate FEA Assembler
         fea_assembler = pytacs.pyTACS(bdf_file, comm)


### PR DESCRIPTION
Similar to #316 , we are seeing some hard to reproduce test failures in the xpt sens test in `test_trans_beam`. I can't be 100% sure that this step size change fixes the error but it does reduce the largest relative error by roughly 2 orders of magnitude:

Before:
```
Testing sinusoid_compliance xpt sens:
analytic: 12.398071807030135
      FD: 12.397875767788946
    diff: 0.00019603924118882787
rel diff: 1.581207499360238e-05
```

After:
```
Testing sinusoid_compliance xpt sens:
analytic: 12.398070774567254
      FD: 12.398069415553437
    diff: 1.3590138170371802e-06
rel diff: 1.0961494265906186e-07
```