### PR TITLE
Adding version upperbound for mpi4py

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - mpich-mpicxx  # [mpi == "mpich"]
     - {{ compiler('cxx') }}
     - make
-    - mpi4py >=3.1.1
+    - mpi4py >=3.1.1,<4.0.0
     - cython >=3.0.0
     - setuptools
 
@@ -54,7 +54,7 @@ requirements:
     - lapack
     - metis ==5.1.0
     - tecio
-    - mpi4py >=3.1.1
+    - mpi4py >=3.1.1,<4.0.0
     - cython >=3.0.0
     - setuptools
 
@@ -68,7 +68,7 @@ requirements:
     - libopenblas
     - lapack
     - metis ==5.1.0
-    - mpi4py >=3.1.1
+    - mpi4py >=3.1.1,<4.0.0
     - pynastran >=1.4.0
     - numba >=0.55.2
 

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     python_requires=">=3.9.0",
     install_requires=[
         "numpy<2.0.0",
-        "mpi4py>=3.1.1",
+        "mpi4py>=3.1.1,<4.0.0",
         "scipy>=1.2.1",
         "pynastran>=1.4.0",
         "numba",


### PR DESCRIPTION
[mpi4py 4.0.0](https://pypi.org/project/mpi4py/) was officially released on pip recently and is breaking the tacs python install. I've added a version upper bound to prevent this in the future.