### PR TITLE
Update upload-artifacts action version

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -140,7 +140,7 @@ jobs:
           zip -r ../tacs-docs.zip .;
       - name: 'Upload docs'
         if: ${{ matrix.PUBLISH_DOCS }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: tacs-docs
           path: docs/tacs-docs.zip


### PR DESCRIPTION
The unit test github actions are currently failing because v2 of the `upload-artifacts` action is now deprecated (see [here](https://github.com/smdogroup/tacs/actions/runs/10833190932/job/30059356594#step:1:36))