### PR TITLE
Use dependabot to keep github actions up to date

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
A number of the pre-existing github action steps we use are quite out of date, which can cause CI jobs to fail , e.g in #329 we had to update the `upload_artifacts` action because it was killing our unit tests job, and we are currently getting warnings on our linting job because the version of the `checkout` action we use is soon to be deprecated.

![image](https://github.com/user-attachments/assets/e23ec4db-d437-4906-a787-a83d658ee74a)

To save us the effort of manually keeping them up to date, we can use GitHub's dependabot. The config I have in this PR will have the dependabot run once a month and open a PR to update any of the actions we're using that are out of date. For an example, see https://github.com/A-CGray/FEMpy/pull/68.

Someone with the relevant permissions will also have to enable dependabot in the repo settings (below are the settings I have on one of my dependabot-enabled repos)

![image](https://github.com/user-attachments/assets/784aaf4a-bc88-491e-9786-2819b3d6a61f)
