### PR TITLE
Change handling of boundary conditions

### DIFF
--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4257,7 +4257,8 @@ void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda) {
 void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
                                      TacsScalar gamma, TACSBVec *residual,
                                      TACSMat *A, MatrixOrientation matOr,
-                                     const TacsScalar lambda) {
+                                     const TacsScalar lambda,
+                                     const bool applyBCs) {
   // Zero the residual and the matrix
   if (residual) {
     residual->zeroEntries();
@@ -4365,7 +4366,9 @@ void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
   }
 
   // Apply the appropriate boundary conditions
-  A->applyBCs(bcMap);
+  if (applyBCs) {
+    A->applyBCs(bcMap);
+  }
 }
 
 /**
@@ -4898,7 +4901,8 @@ void TACSAssembler::addXptSens(TacsScalar coef, int numFuncs,
 */
 void TACSAssembler::addSVSens(TacsScalar alpha, TacsScalar beta,
                               TacsScalar gamma, int numFuncs,
-                              TACSFunction **funcs, TACSBVec **dfdu) {
+                              TACSFunction **funcs, TACSBVec **dfdu,
+                              const bool applyBCs) {
   // First check if this is the right assembly object
   for (int k = 0; k < numFuncs; k++) {
     if (funcs[k] && this != funcs[k]->getAssembler()) {
@@ -4966,7 +4970,9 @@ void TACSAssembler::addSVSens(TacsScalar alpha, TacsScalar beta,
   for (int k = 0; k < numFuncs; k++) {
     if (funcs[k]) {
       dfdu[k]->endSetValues(TACS_ADD_VALUES);
-      dfdu[k]->applyBCs(bcMap);
+      if (applyBCs) {
+        dfdu[k]->applyBCs(bcMap);
+      }
     }
   }
 }

--- a/src/TACSAssembler.cpp
+++ b/src/TACSAssembler.cpp
@@ -4127,7 +4127,8 @@ void TACSAssembler::evalEnergies(TacsScalar *Te, TacsScalar *Pe) {
   @param residual The residual vector
   @param lambda Scaling factor for the aux element contributions, by default 1
 */
-void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda) {
+void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda,
+                                const bool applyBCs) {
   // Sort the list of auxiliary elements - this only performs the
   // sort if it is required (if new elements are added)
   if (auxElements) {
@@ -4232,7 +4233,9 @@ void TACSAssembler::assembleRes(TACSBVec *residual, const TacsScalar lambda) {
   residual->endSetValues(TACS_ADD_VALUES);
 
   // Apply the boundary conditions for the residual
-  residual->applyBCs(bcMap, varsVec);
+  if (applyBCs) {
+    residual->applyBCs(bcMap, varsVec);
+  }
 }
 
 /**
@@ -4360,13 +4363,13 @@ void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
     residual->endSetValues(TACS_ADD_VALUES);
   }
 
-  // Apply the boundary conditions
-  if (residual) {
-    residual->applyBCs(bcMap, varsVec);
-  }
-
-  // Apply the appropriate boundary conditions
   if (applyBCs) {
+    // Apply the boundary conditions to the residual
+    if (residual) {
+      residual->applyBCs(bcMap, varsVec);
+    }
+
+    // Apply the appropriate boundary conditions to the matrix
     A->applyBCs(bcMap);
   }
 }
@@ -4383,7 +4386,8 @@ void TACSAssembler::assembleJacobian(TacsScalar alpha, TacsScalar beta,
 */
 void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
                                     MatrixOrientation matOr,
-                                    const TacsScalar lambda) {
+                                    const TacsScalar lambda,
+                                    const bool applyBCs) {
   // Zero the matrix
   A->zeroEntries();
 
@@ -4463,7 +4467,9 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
   A->beginAssembly();
   A->endAssembly();
 
-  A->applyBCs(bcMap);
+  if (applyBCs) {
+    A->applyBCs(bcMap);
+  }
 }
 
 /**
@@ -4481,8 +4487,8 @@ void TACSAssembler::assembleMatType(ElementMatrixType matType, TACSMat *A,
 */
 void TACSAssembler::assembleMatCombo(ElementMatrixType matTypes[],
                                      TacsScalar scale[], int nmats, TACSMat *A,
-                                     MatrixOrientation matOr,
-                                     TacsScalar lambda) {
+                                     MatrixOrientation matOr, TacsScalar lambda,
+                                     const bool applyBCs) {
   // Zero the matrix
   A->zeroEntries();
 
@@ -4558,7 +4564,9 @@ void TACSAssembler::assembleMatCombo(ElementMatrixType matTypes[],
   A->beginAssembly();
   A->endAssembly();
 
-  A->applyBCs(bcMap);
+  if (applyBCs) {
+    A->applyBCs(bcMap);
+  }
 }
 
 /**
@@ -5307,7 +5315,8 @@ void TACSAssembler::addMatXptSensInnerProduct(TacsScalar scale,
 */
 void TACSAssembler::evalMatSVSensInnerProduct(ElementMatrixType matType,
                                               TACSBVec *psi, TACSBVec *phi,
-                                              TACSBVec *dfdu) {
+                                              TACSBVec *dfdu,
+                                              const bool applyBCs) {
   // Zero the entries in the residual vector
   dfdu->zeroEntries();
 
@@ -5351,7 +5360,9 @@ void TACSAssembler::evalMatSVSensInnerProduct(ElementMatrixType matType,
   dfdu->endSetValues(TACS_ADD_VALUES);
 
   // Apply the boundary conditions to the fully assembled vector
-  dfdu->applyBCs(bcMap);
+  if (applyBCs) {
+    dfdu->applyBCs(bcMap);
+  }
 }
 
 /**
@@ -5379,7 +5390,8 @@ void TACSAssembler::addJacobianVecProduct(TacsScalar scale, TacsScalar alpha,
                                           TacsScalar beta, TacsScalar gamma,
                                           TACSBVec *x, TACSBVec *y,
                                           MatrixOrientation matOr,
-                                          const TacsScalar lambda) {
+                                          const TacsScalar lambda,
+                                          const bool applyBCs) {
   x->beginDistributeValues();
   x->endDistributeValues();
 
@@ -5451,7 +5463,9 @@ void TACSAssembler::addJacobianVecProduct(TacsScalar scale, TacsScalar alpha,
   y->endSetValues(TACS_ADD_VALUES);
 
   // Set the boundary conditions
-  y->applyBCs(bcMap);
+  if (applyBCs) {
+    y->applyBCs(bcMap);
+  }
 }
 
 /*
@@ -5578,12 +5592,10 @@ void TACSAssembler::assembleMatrixFreeData(ElementMatrixType matType,
   @param matOr The orientation of the matrix
   @param lambda Scaling factor for the aux element contributions, by default 1
 */
-void TACSAssembler::addMatrixFreeVecProduct(ElementMatrixType matType,
-                                            const TacsScalar data[],
-                                            TacsScalar temp[], TACSBVec *x,
-                                            TACSBVec *y,
-                                            MatrixOrientation matOr,
-                                            const TacsScalar lambda) {
+void TACSAssembler::addMatrixFreeVecProduct(
+    ElementMatrixType matType, const TacsScalar data[], TacsScalar temp[],
+    TACSBVec *x, TACSBVec *y, MatrixOrientation matOr, const TacsScalar lambda,
+    const bool applyBCs) {
   x->beginDistributeValues();
   x->endDistributeValues();
 
@@ -5657,7 +5669,9 @@ void TACSAssembler::addMatrixFreeVecProduct(ElementMatrixType matType,
   y->endSetValues(TACS_ADD_VALUES);
 
   // Set the boundary conditions
-  y->applyBCs(bcMap);
+  if (applyBCs) {
+    y->applyBCs(bcMap);
+  }
 }
 
 /**

--- a/src/TACSAssembler.h
+++ b/src/TACSAssembler.h
@@ -218,7 +218,8 @@ class TACSAssembler : public TACSObject {
 
   // Residual and Jacobian assembly
   // ------------------------------
-  void assembleRes(TACSBVec *residual, const TacsScalar lambda = 1.0);
+  void assembleRes(TACSBVec *residual, const TacsScalar lambda = 1.0,
+                   const bool applyBCs = true);
   void assembleJacobian(TacsScalar alpha, TacsScalar beta, TacsScalar gamma,
                         TACSBVec *residual, TACSMat *A,
                         MatrixOrientation matOr = TACS_MAT_NORMAL,
@@ -226,16 +227,19 @@ class TACSAssembler : public TACSObject {
                         const bool applyBCs = true);
   void assembleMatType(ElementMatrixType matType, TACSMat *A,
                        MatrixOrientation matOr = TACS_MAT_NORMAL,
-                       const TacsScalar lambda = 1.0);
+                       const TacsScalar lambda = 1.0,
+                       const bool applyBCs = true);
   void assembleMatCombo(ElementMatrixType matTypes[], TacsScalar scale[],
                         int nmats, TACSMat *A,
                         MatrixOrientation matOr = TACS_MAT_NORMAL,
-                        const TacsScalar lambda = 1.0);
+                        const TacsScalar lambda = 1.0,
+                        const bool applyBCs = true);
   void addJacobianVecProduct(TacsScalar scale, TacsScalar alpha,
                              TacsScalar beta, TacsScalar gamma, TACSBVec *x,
                              TACSBVec *y,
                              MatrixOrientation matOr = TACS_MAT_NORMAL,
-                             const TacsScalar lambda = 1.0);
+                             const TacsScalar lambda = 1.0,
+                             const bool applyBCs = true);
 
   // Assemble data for and compute matrix-free matrix-vector products
   // ----------------------------------------------------------------
@@ -248,7 +252,8 @@ class TACSAssembler : public TACSObject {
                                const TacsScalar data[], TacsScalar temp[],
                                TACSBVec *x, TACSBVec *y,
                                MatrixOrientation matOr = TACS_MAT_NORMAL,
-                               const TacsScalar lambda = 1.0);
+                               const TacsScalar lambda = 1.0,
+                               const bool applyBCs = true);
 
   // Design variable handling
   // ------------------------
@@ -290,7 +295,8 @@ class TACSAssembler : public TACSObject {
                                  TACSBVec *psi, TACSBVec *phi,
                                  TACSBVec *dfdXpts);
   void evalMatSVSensInnerProduct(ElementMatrixType matType, TACSBVec *psi,
-                                 TACSBVec *phi, TACSBVec *res);
+                                 TACSBVec *phi, TACSBVec *res,
+                                 const bool applyBCs = true);
 
   // Return elements and node numbers
   // --------------------------------

--- a/src/TACSAssembler.h
+++ b/src/TACSAssembler.h
@@ -222,7 +222,8 @@ class TACSAssembler : public TACSObject {
   void assembleJacobian(TacsScalar alpha, TacsScalar beta, TacsScalar gamma,
                         TACSBVec *residual, TACSMat *A,
                         MatrixOrientation matOr = TACS_MAT_NORMAL,
-                        const TacsScalar lambda = 1.0);
+                        const TacsScalar lambda = 1.0,
+                        const bool applyBCs = true);
   void assembleMatType(ElementMatrixType matType, TACSMat *A,
                        MatrixOrientation matOr = TACS_MAT_NORMAL,
                        const TacsScalar lambda = 1.0);
@@ -265,7 +266,8 @@ class TACSAssembler : public TACSObject {
   void addDVSens(TacsScalar coef, int numFuncs, TACSFunction **funcs,
                  TACSBVec **dfdx);
   void addSVSens(TacsScalar alpha, TacsScalar beta, TacsScalar gamma,
-                 int numFuncs, TACSFunction **funcs, TACSBVec **dfdu);
+                 int numFuncs, TACSFunction **funcs, TACSBVec **dfdu,
+                 const bool applyBCs = true);
   void addAdjointResProducts(TacsScalar scale, int numAdjoints,
                              TACSBVec **adjoint, TACSBVec **dfdx,
                              const TacsScalar lambda = 1.0);
@@ -500,7 +502,7 @@ class TACSAssembler : public TACSObject {
     // Information for adjoint-dR/dx products
     int numAdjoints;
     TACSBVec **adjoints;
-  } * tacsPInfo;
+  } *tacsPInfo;
 
   // The pthread data required to pthread tacs operations
   int numCompletedElements;     // Keep track of how much work has been done

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -2152,7 +2152,8 @@ cdef class Assembler:
     def assembleJacobian(self, double alpha, double beta, double gamma,
                          Vec residual, Mat A,
                          MatrixOrientation matOr=TACS_MAT_NORMAL,
-                         TacsScalar loadScale=1.0):
+                         TacsScalar loadScale=1.0,
+                         bool applyBCs=True):
         """
         Assemble the Jacobian matrix
 
@@ -2177,7 +2178,7 @@ cdef class Assembler:
             res = residual.getBVecPtr()
 
         self.ptr.assembleJacobian(alpha, beta, gamma,
-                                  res, A.ptr, matOr, loadScale)
+                                  res, A.ptr, matOr, loadScale, applyBCs)
         return
 
     def assembleMatType(self, ElementMatrixType matType,
@@ -2285,7 +2286,7 @@ cdef class Assembler:
         return
 
     def addSVSens(self, funclist, dfdulist, double alpha=1.0,
-                  double beta=0.0, double gamma=0.0):
+                  double beta=0.0, double gamma=0.0, bool applyBCs=True):
 
         """
         Evaluate the derivative of the function w.r.t. the state
@@ -2315,7 +2316,7 @@ cdef class Assembler:
             dfdu[i] = (<Vec>dfdulist[i]).getBVecPtr()
 
         # Evaluate the derivative of the functions
-        self.ptr.addSVSens(alpha, beta, gamma, num_funcs, funcs, dfdu)
+        self.ptr.addSVSens(alpha, beta, gamma, num_funcs, funcs, dfdu, applyBCs)
 
         free(funcs)
         free(dfdu)

--- a/tacs/TACS.pyx
+++ b/tacs/TACS.pyx
@@ -2133,7 +2133,7 @@ cdef class Assembler:
         self.ptr.evalEnergies(&Te, &Pe)
         return Te, Pe
 
-    def assembleRes(self, Vec residual, TacsScalar loadScale=1.0):
+    def assembleRes(self, Vec residual, TacsScalar loadScale=1.0, bool applyBCs=True):
         """
         Assemble the residual associated with the input load case.
 
@@ -2146,7 +2146,7 @@ cdef class Assembler:
         rhs:        the residual output
         loadScale:  Scaling factor for the aux element contributions, by default 1
         """
-        self.ptr.assembleRes(residual.getBVecPtr(), loadScale)
+        self.ptr.assembleRes(residual.getBVecPtr(), loadScale, applyBCs)
         return
 
     def assembleJacobian(self, double alpha, double beta, double gamma,
@@ -2183,7 +2183,7 @@ cdef class Assembler:
 
     def assembleMatType(self, ElementMatrixType matType,
                         Mat A, MatrixOrientation matOr=TACS_MAT_NORMAL,
-                        TacsScalar loadScale=1.0):
+                        TacsScalar loadScale=1.0, bool applyBCs=True):
 
         """
         Assemble the Jacobian matrix
@@ -2205,13 +2205,13 @@ cdef class Assembler:
         matOr:      the matrix orientation NORMAL or TRANSPOSE
         loadScale: Scaling factor for the aux element contributions, by default 1
         """
-        self.ptr.assembleMatType(matType, A.ptr, matOr, loadScale)
+        self.ptr.assembleMatType(matType, A.ptr, matOr, loadScale, applyBCs)
         return
 
     def assembleMatCombo(self, ElementMatrixType matType1, double scale1,
                          ElementMatrixType matType2, double scale2, Mat A,
                          MatrixOrientation matOr=NORMAL,
-                         TacsScalar loadScale=1.0):
+                         TacsScalar loadScale=1.0, bool applyBCs=True):
         """
         Assemble a combination of two matrices
         """
@@ -2223,7 +2223,7 @@ cdef class Assembler:
         matTypes[1] = matType2
         scale[0] = scale1
         scale[1] = scale2
-        self.ptr.assembleMatCombo(matTypes, scale, 2, A.ptr, matOr, loadScale)
+        self.ptr.assembleMatCombo(matTypes, scale, 2, A.ptr, matOr, loadScale, applyBCs)
         return
 
     def evalFunctions(self, funclist):
@@ -2439,20 +2439,20 @@ cdef class Assembler:
         return
 
     def evalMatSVSensInnerProduct(self, ElementMatrixType matType,
-                                  Vec psi, Vec phi, Vec res):
+                                  Vec psi, Vec phi, Vec res, bool applyBCs=True):
         self.ptr.evalMatSVSensInnerProduct(matType,
-                                           psi.getBVecPtr(), phi.getBVecPtr(), res.getBVecPtr())
+                                           psi.getBVecPtr(), phi.getBVecPtr(), res.getBVecPtr(), applyBCs)
         return
 
     def addJacobianVecProduct(self, TacsScalar scale,
                               double alpha, double beta, double gamma,
                               Vec x, Vec y, MatrixOrientation matOr=TACS_MAT_NORMAL,
-                              TacsScalar loadScale=1.0):
+                              TacsScalar loadScale=1.0, bool applyBCs=True):
         """
         Compute the Jacobian-vector product
         """
         self.ptr.addJacobianVecProduct(scale, alpha, beta, gamma,
-                                       x.getBVecPtr(), y.getBVecPtr(), matOr, loadScale)
+                                       x.getBVecPtr(), y.getBVecPtr(), matOr, loadScale, applyBCs)
         return
 
     def testElement(self, int elemNum, int print_level,

--- a/tacs/cpp_headers/TACS.pxd
+++ b/tacs/cpp_headers/TACS.pxd
@@ -377,7 +377,8 @@ cdef extern from "TACSAssembler.h":
         void assembleJacobian(double alpha, double beta, double gamma,
                               TACSBVec *residual, TACSMat *A,
                               MatrixOrientation matOr,
-                              TacsScalar loadScale)
+                              TacsScalar loadScale,
+                              bool applyBCs)
         void assembleMatType(ElementMatrixType matType,
                              TACSMat *A, MatrixOrientation matOr,
                              TacsScalar loadScale)
@@ -395,7 +396,8 @@ cdef extern from "TACSAssembler.h":
                        TACSBVec **dfdx)
         void addSVSens(double alpha, double beta, double gamma,
                        int numFuncs, TACSFunction **funcs,
-                       TACSBVec **fuSens)
+                       TACSBVec **fuSens,
+                       bool applyBCs)
         void addAdjointResProducts(double scale, int numAdjoints,
                                    TACSBVec **adjoint, TACSBVec **dfdx,
                                    TacsScalar loadScale)

--- a/tacs/cpp_headers/TACS.pxd
+++ b/tacs/cpp_headers/TACS.pxd
@@ -373,7 +373,7 @@ cdef extern from "TACSAssembler.h":
         void getInitConditions(TACSBVec*, TACSBVec*, TACSBVec*)
         void setInitConditions(TACSBVec*, TACSBVec*, TACSBVec*)
         void evalEnergies(TacsScalar*, TacsScalar*)
-        void assembleRes(TACSBVec *residual, TacsScalar loadScale)
+        void assembleRes(TACSBVec *residual, TacsScalar loadScale, bool applyBCs)
         void assembleJacobian(double alpha, double beta, double gamma,
                               TACSBVec *residual, TACSMat *A,
                               MatrixOrientation matOr,
@@ -381,23 +381,22 @@ cdef extern from "TACSAssembler.h":
                               bool applyBCs)
         void assembleMatType(ElementMatrixType matType,
                              TACSMat *A, MatrixOrientation matOr,
-                             TacsScalar loadScale)
+                             TacsScalar loadScale, bool applyBCs)
         void assembleMatCombo(ElementMatrixType*, TacsScalar*, int,
                               TACSMat*, MatrixOrientation matOr,
-                              TacsScalar loadScale)
+                              TacsScalar loadScale, bool applyBCs)
         void addJacobianVecProduct(TacsScalar scale,
                                    double alpha, double beta, double gamma,
                                    TACSBVec *x, TACSBVec *y,
                                    MatrixOrientation matOr,
-                                   TacsScalar loadScale)
+                                   TacsScalar loadScale, bool applyBCs)
         void evalFunctions(int numFuncs, TACSFunction **functions,
                            TacsScalar *funcVals)
         void addDVSens(double coef, int numFuncs, TACSFunction **funcs,
                        TACSBVec **dfdx)
         void addSVSens(double alpha, double beta, double gamma,
                        int numFuncs, TACSFunction **funcs,
-                       TACSBVec **fuSens,
-                       bool applyBCs)
+                       TACSBVec **fuSens, bool applyBCs)
         void addAdjointResProducts(double scale, int numAdjoints,
                                    TACSBVec **adjoint, TACSBVec **dfdx,
                                    TacsScalar loadScale)
@@ -413,7 +412,7 @@ cdef extern from "TACSAssembler.h":
                                       TACSBVec *dfdx)
         void evalMatSVSensInnerProduct(ElementMatrixType matType,
                                        TACSBVec *psi, TACSBVec *phi,
-                                       TACSBVec *res)
+                                       TACSBVec *res, bool applyBCs)
 
         void testElement(int elemNum, int print_level, double dh,
                          double rtol, double atol)

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -1666,8 +1666,18 @@ class StaticProblem(TACSProblem):
 
         # Set problem vars to assembler
         self._updateAssemblerVars()
-
-        self.K.mult(self.phi, self.res)
+        self.res.zeroEntries()
+        self.assembler.addJacobianVecProduct(
+            1.0,
+            1.0,
+            0.0,
+            0.0,
+            self.phi,
+            self.res,
+            tacs.TACS.TRANSPOSE,
+            self._loadScale,
+            applyBCs=False,
+        )
         # Add bc terms back in
         self.res.axpy(1.0, bcTerms)
 


### PR DESCRIPTION
## Problems
In the static problem class, I noticed that we overwrite the constrained DOF with the correct Dirichlet values inside the static problem's `setVariables` method. This shouldn't be necessary as the boundary conditions are already accounted for in the residual and jacobian such that the solution of the static problem automatically satisfies the BCs. Additionally, overwriting these BC values means our MPhys wrapper is not allowing OpenMDAO to set the states it thinks it is (which has the potential to cause bugs depending on how you're using TACS through MPhys). It also means we cannot perform displacement control for nonlinear solutions, since the dirichlet BCs cannot be applied incrementally. Digging a bit deeper, I found that the reason we do this overwriting is primarily to make OpenMDAO's finite difference partial derivative checks pass for some partial derivatives terms that are not quite computed correctly by TACS as stands:

### addTransposeVectorProduct
- TACS doesn't doesn't have the ability to compute a MatVec product with a transposed `TACSSchurMat` with boundary conditions correctly applied
  - Therefore, the `addTransposeVectorProduct` of the static problem uses the non-transposed matrix, which produces a slightly incorrect result
  - This should result in the MPhys partial derivatives tests failing, but we get around this in a few ways:
    - We use quite a slack tolerance on the mphys partial derivatives tests (`rtol=1e-1`)
    - We overwrite the constrained DOF with the correct Dirichlet values inside the static problem's `setVariables` method. This makes the jacobian computed by OpenMDAO's finite differencing slightly more like the one computed using `addTransposeVectorProduct`
    - Because OpenMDAO tests the norm of the error over the whole jacobian, the test can pass even though some entries related to the BCs are completely wrong

### addSVSens
- The `addSVSens` method of the `TACSAssembler` zeroes out the derivatives of function w.r.t DOFs that are subject to BCs, this is incorrect because the values of those DOFs still affect function values
  - This should mean that the MPhys tests of the function partial derivatives w.r.t states fail.
  - However, overwriting the constrained DOF with the correct Dirichlet values inside the static problem's `setVariables` method means the finite-difference partials with respect the constrained DOF appear to be zero, matching the result of `addSVSens` and thus passing the `check_partials` tests.

## Proposed changes
- [x] Remove call to`setBCs` in `setVariables` so that we're not overwriting the states OpenMDAO thinks it is setting
- [x] Do not zero out boundary condition terms when calling `addSVSens` in static problem
- [x] Add an `applyBCs` argument (that defaults to `true`) to the `TACSAssembler` functions that involve applying BCs:
    - [x] `assembleRes`
    - [x] `assembleJacobian`
    - [x] `assembleMatType`
    - [x] `assembleMatCombo`
    - [x] `addSVSens`
    - [x] `evalMatSVSensInnerProduct`
    - [x] `addJacobianVecProduct`
    - [x] `addMatrixFreeVecProduct`
- [x] Fix `addTransposeJacVecProduct` in static problem by using the `TACSAssembler` `addJacVecProduct` method with the transpose option enabled and the boundary conditions not applied so that it gives the correct result
- [ ] Tighten tolerances in MPhys derivative tests since our partial derivatives should now be correct
- [ ] Implement a scaling factor on the Dirichlet BC residual analagous to the load factor we have for scaling external forces, so that load control and displacement control can be performed using a single scaling factor.

For a more thorough description of the math and why I think this way of handling the BCs is more correct, see [TACS Static Problem Boundary Condition Handling.pdf](https://github.com/user-attachments/files/17601067/TACS.Static.Problem.Boundary.Condition.Handling.pdf)

## Open questions
- How does this BC handling apply to transient and buckling problems?