### PR TITLE
Making mpi4py 3.1.5 new minimum version for build

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -37,7 +37,7 @@ requirements:
     - mpich-mpicxx  # [mpi == "mpich"]
     - {{ compiler('cxx') }}
     - make
-    - mpi4py >=3.1.1,<4.0.0
+    - mpi4py >=3.1.5,<4.0.0
     - cython >=3.0.0
     - setuptools
 
@@ -54,7 +54,7 @@ requirements:
     - lapack
     - metis ==5.1.0
     - tecio
-    - mpi4py >=3.1.1,<4.0.0
+    - mpi4py >=3.1.5,<4.0.0
     - cython >=3.0.0
     - setuptools
 
@@ -68,7 +68,7 @@ requirements:
     - libopenblas
     - lapack
     - metis ==5.1.0
-    - mpi4py >=3.1.1,<4.0.0
+    - mpi4py >=3.1.5,<4.0.0
     - pynastran >=1.4.0
     - numba >=0.55.2
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,5 @@
 [build-system]
 # Minimum requirements for the build system to execute.
 requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=3.0.0', 'numpy>=1.25,<2.0.0',
-            # Build against an old version (3.1.1) of mpi4py for forward compatibility
-            "mpi4py==3.1.1; python_version<'3.11'",
-            # Python 3.11 requires 3.1.4+
-            "mpi4py==3.1.4; python_version>='3.11'"]
+            # Build against an old version (3.1.5) of mpi4py for forward compatibility
+            'mpi4py==3.1.5']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@
 # Minimum requirements for the build system to execute.
 requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=3.0.0', 'numpy>=1.25,<2.0.0',
             # Build against an old version (3.1.5) of mpi4py for forward compatibility
-            'mpi4py==3.1.6']
+            'mpi4py==3.1.5']

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,4 +3,4 @@
 # Minimum requirements for the build system to execute.
 requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=3.0.0', 'numpy>=1.25,<2.0.0',
             # Build against an old version (3.1.5) of mpi4py for forward compatibility
-            'mpi4py==3.1.5']
+            'mpi4py==3.1.6']

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     python_requires=">=3.9.0",
     install_requires=[
         "numpy<2.0.0",
-        "mpi4py>=3.1.1,<4.0.0",
+        "mpi4py>=3.1.5,<4.0.0",
         "scipy>=1.2.1",
         "pynastran>=1.4.0",
         "numba",

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     python_requires=">=3.9.0",
     install_requires=[
         "numpy<2.0.0",
-        "mpi4py>=3.1.6,<4.0.0",
+        "mpi4py>=3.1.5,<4.0.0",
         "scipy>=1.2.1",
         "pynastran>=1.4.0",
         "numba",

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
     python_requires=">=3.9.0",
     install_requires=[
         "numpy<2.0.0",
-        "mpi4py>=3.1.5,<4.0.0",
+        "mpi4py>=3.1.6,<4.0.0",
         "scipy>=1.2.1",
         "pynastran>=1.4.0",
         "numba",


### PR DESCRIPTION
Python 3.12+ seems to be incompatible with older versions of mpi4py. In order to fix this we'll need to bump up minimum mpi4py version to 3.1.5.