### PR TITLE
Version bump 3.8.0

### DIFF
--- a/.github/workflows/deploy_conda_package.yml
+++ b/.github/workflows/deploy_conda_package.yml
@@ -101,5 +101,5 @@ jobs:
           conda install anaconda-client conda-build conda-verify -q -y;
           conda config --set anaconda_upload no;
           cd ${TACS_DIR}/conda;
-          conda build --variants "{scalar: ${{ matrix.SCALAR }}}" -c conda-forge -c smdogroup $BUILD_ARGS --output-folder . .;
+          conda build --variants "{scalar: ${{ matrix.SCALAR }}}" -c smdogroup -c conda-forge $BUILD_ARGS --output-folder . .;
           anaconda upload --label $LABEL ${{ matrix.TARGET }}/*.tar.bz2 --force;

--- a/conda/build.sh
+++ b/conda/build.sh
@@ -32,7 +32,7 @@ mv ${TACS_DIR}/lib/libtacs.${SO_EXT} ${PREFIX}/lib;
 mkdir ${PREFIX}/include/tacs;
 find ${TACS_DIR}/src/ -name '*.h' -exec cp -prv '{}' ${PREFIX}/include/tacs ';'
 
-CFLAGS=${PIP_FLAGS} ${PYTHON} -m pip install --no-deps --prefix=${PREFIX} . -vv;
+CPPFLAGS=${PIP_FLAGS} ${PYTHON} -m pip install --no-deps --prefix=${PREFIX} . -vv;
 
 cd ${TACS_DIR}/extern/f5tovtk;
 make default TACS_DIR=${TACS_DIR} \

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
 optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
-    "mphys": ["mphys>=1.1.0,<2.0.0", "openmdao>=3.25.0"],
+    "mphys": ["mphys>=2.0.0,<3.0.0", "openmdao>=3.25.0"],
     "caps2tacs": ["imageio>=2.16.1"],
 }
 
@@ -119,7 +119,7 @@ optional_dependencies["all"] = sorted(
 
 setup(
     name="tacs",
-    version="3.7.2",
+    version="3.8.0",
     description="Parallel finite-element analysis package",
     long_description=long_description,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
This version bump updates TACS MPhys wrapper to support MPhys 2.0. 
This will be a backwards-incompatible update for any MPhys users.
To be merged in after PR #315 and #337