### PR TITLE
Add support for discontinuous tecplot output

### DIFF
--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -1,6 +1,6 @@
 name: clang-format Check
 
-on: 
+on:
   push:
     branches: [ master ]
   pull_request:
@@ -14,6 +14,7 @@ jobs:
         path:
           - 'src'
           - 'examples'
+          - 'extern'
     steps:
     - uses: actions/checkout@v4
     - name: Run clang-format style check for C/C++ programs.

--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,12 @@ syntax: glob
 !*.*
 !*/
 
-extern/
-!extern/Makefile*
-!extern/f5to*/
+extern/*/
+extern/*.tar.gz
+extern/*.tgz
+!extern/f5totec/
+!extern/f5tovtk/
+
 *~
 *.in
 *.pyc

--- a/extern/f5totec/f5totec.cpp
+++ b/extern/f5totec/f5totec.cpp
@@ -17,8 +17,8 @@
   FH5 files. (This is designed primarily to work with TACS).
 */
 
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 // Include FH5 header files
@@ -29,11 +29,18 @@
 // Include Tecplot header files
 #include "TECIO.h"
 
-enum FileType { FULL=0, GRID=1, SOLUTION=2 };
+enum FileType { FULL = 0, GRID = 1, SOLUTION = 2 };
 
-enum ZoneType { ORDERED=0, FELINESEG, FETRIANGLE,
-                FEQUADRILATERAL, FETETRAHEDRON, FEBRICK,
-                FEPOLYGON, FEPOLYHEDRA };
+enum ZoneType {
+  ORDERED = 0,
+  FELINESEG,
+  FETRIANGLE,
+  FEQUADRILATERAL,
+  FETETRAHEDRON,
+  FEBRICK,
+  FEPOLYGON,
+  FEPOLYHEDRA
+};
 
 /*
   Initialize a data file.
@@ -44,14 +51,13 @@ enum ZoneType { ORDERED=0, FELINESEG, FETRIANGLE,
   dir_name  == Name of the directory
   file_type == Type of data
 */
-int create_tec_file( char *data_info, char *var_names,
-                     char *file_name, char *dir_name,
-                     enum FileType _file_type ){
+int create_tec_file(char *data_info, char *var_names, char *file_name,
+                    char *dir_name, enum FileType _file_type) {
   INTEGER4 file_type = _file_type;
   INTEGER4 debug = 0;
   INTEGER4 variables_are_double = 0;
-  return TECINI112(data_info, var_names, file_name, dir_name,
-                   &file_type, &debug, &variables_are_double);
+  return TECINI112(data_info, var_names, file_name, dir_name, &file_type,
+                   &debug, &variables_are_double);
 }
 
 /*
@@ -62,14 +68,13 @@ int create_tec_file( char *data_info, char *var_names,
   num_points   == The number of points
   num_elements == The number of elements
 */
-int create_fe_tec_zone( char *zone_name, ZoneType _zone_type,
-                        int _num_points, int _num_elements,
-                        int use_strands=0,
-                        double solution_time=0.0 ){
-  if (_zone_type == ORDERED ||
-      _zone_type == FEPOLYGON ||
-      _zone_type == FEPOLYHEDRA ){
-    fprintf(stderr, "Cannot create finite element zone with given \
+int create_fe_tec_zone(char *zone_name, ZoneType _zone_type, int _num_points,
+                       int _num_elements, int use_strands = 0,
+                       double solution_time = 0.0) {
+  if (_zone_type == ORDERED || _zone_type == FEPOLYGON ||
+      _zone_type == FEPOLYHEDRA) {
+    fprintf(stderr,
+            "Cannot create finite element zone with given \
 zone type\n");
     return -1;
   }
@@ -77,35 +82,34 @@ zone type\n");
   INTEGER4 zone_type = _zone_type;
   INTEGER4 num_points = _num_points;
   INTEGER4 num_elements = _num_elements;
-  INTEGER4 num_faces = 0; // For all zones allowed here
-  INTEGER4 icmax = 0, jcmax = 0, kcmax = 0; // Ignored
+  INTEGER4 num_faces = 0;                    // For all zones allowed here
+  INTEGER4 icmax = 0, jcmax = 0, kcmax = 0;  // Ignored
   INTEGER4 strand_id = 0;
   INTEGER4 parent_zone = 0;
-  INTEGER4 is_block = 1; // Apparently this always needs to be 1
+  INTEGER4 is_block = 1;  // Apparently this always needs to be 1
   // These are only for cell-based finite element data - we use node-based
   INTEGER4 num_face_connections = 0;
   INTEGER4 face_neighbour_mode = 0;
   INTEGER4 total_num_face_nodes = 0;
   INTEGER4 num_connected_boundary_faces = 0;
   INTEGER4 total_num_boundary_connections = 0;
-  INTEGER4 *passive_var_list = NULL; // No passive variables
-  INTEGER4 *value_location = NULL; // All values are nodal values
+  INTEGER4 *passive_var_list = NULL;  // No passive variables
+  INTEGER4 *value_location = NULL;    // All values are nodal values
   INTEGER4 *share_var_from_zone = NULL;
   INTEGER4 share_con_from_zone = 0;
 
   // If we're using strands, set the strand ID
-  if (use_strands){
+  if (use_strands) {
     strand_id = 1;
   }
 
   return TECZNE112(zone_name, &zone_type, &num_points, &num_elements,
-                   &num_faces, &icmax, &jcmax, &kcmax,
-                   &solution_time, &strand_id, &parent_zone, &is_block,
-                   &num_face_connections, &face_neighbour_mode,
-                   &total_num_face_nodes, &num_connected_boundary_faces,
-                   &total_num_boundary_connections,
-                   passive_var_list, value_location,
-                   share_var_from_zone, &share_con_from_zone);
+                   &num_faces, &icmax, &jcmax, &kcmax, &solution_time,
+                   &strand_id, &parent_zone, &is_block, &num_face_connections,
+                   &face_neighbour_mode, &total_num_face_nodes,
+                   &num_connected_boundary_faces,
+                   &total_num_boundary_connections, passive_var_list,
+                   value_location, share_var_from_zone, &share_con_from_zone);
 }
 
 /*
@@ -114,7 +118,7 @@ zone type\n");
   len  == Length of the data
   data == The array of data
 */
-int write_tec_double_data( int _len, double *data ){
+int write_tec_double_data(int _len, double *data) {
   INTEGER4 len = _len;
   INTEGER4 is_double = 1;
   return TECDAT112(&len, data, &is_double);
@@ -123,7 +127,7 @@ int write_tec_double_data( int _len, double *data ){
 /*
   Write float data to a tecplot file
 */
-int write_tec_float_data( int _len, float *data ){
+int write_tec_float_data(int _len, float *data) {
   INTEGER4 len = _len;
   INTEGER4 is_double = 0;
   return TECDAT112(&len, data, &is_double);
@@ -132,148 +136,150 @@ int write_tec_float_data( int _len, float *data ){
 /*
   Write the connectivity data
 */
-int write_con_data( int * con_data ){
-  return TECNOD112(con_data);
-}
+int write_con_data(int *con_data) { return TECNOD112(con_data); }
 
 /*
   End the file output
 */
-int close_tec_file(){
-  return TECEND112();
-}
+int close_tec_file() { return TECEND112(); }
 
-int main( int argc, char * argv[] ){
+int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
   // Check if we're going to use strands or not
   int use_strands = 0;
-  for ( int k = 0; k < argc; k++ ){
-    if (strcmp(argv[k], "--use_strands") == 0){
+  for (int k = 0; k < argc; k++) {
+    if (strcmp(argv[k], "--use_strands") == 0) {
       use_strands = 1;
     }
   }
 
   // Convert hdf5 file argv[1] to tecplot file argv[2]
-  if (argc == 1){
+  if (argc == 1) {
     fprintf(stderr, "Error, no input files\n");
     return (1);
   }
 
-  for ( int k = 1; k < argc; k++ ){
-    char *infile = new char[ strlen(argv[k])+1 ];
+  for (int k = 1; k < argc; k++) {
+    char *infile = new char[strlen(argv[k]) + 1];
     strcpy(infile, argv[k]);
 
     FILE *fp = fopen(infile, "r");
-    if (fp){
+    if (fp) {
       fclose(fp);
-    }
-    else {
-      delete [] infile;
+    } else {
+      delete[] infile;
       continue;
     }
 
     // Set the output file
-    char *outfile = new char[ strlen(infile)+5 ];
+    char *outfile = new char[strlen(infile) + 5];
     int len = strlen(infile);
-    int i = len-1;
-    for ( ; i >= 0; i-- ){
-      if (infile[i] == '.'){ break; }
+    int i = len - 1;
+    for (; i >= 0; i--) {
+      if (infile[i] == '.') {
+        break;
+      }
     }
     strcpy(outfile, infile);
     strcpy(&outfile[i], ".plt");
 
-    printf("Trying to convert FH5 file %s to tecplot file %s\n",
-           infile, outfile);
+    printf("Trying to convert FH5 file %s to tecplot file %s\n", infile,
+           outfile);
 
     char data_info[] = "Created by f5totec";
-    char dir_name[] = "."; // We'll be working with the current directory
-    int tec_init = 0;      // Tecplot initialized flag
+    char dir_name[] = ".";  // We'll be working with the current directory
+    int tec_init = 0;       // Tecplot initialized flag
 
     // Create the loader object
     TACSFH5Loader *loader = new TACSFH5Loader();
     loader->incref();
 
     int fail = loader->loadData(infile);
-    if (fail){
+    if (fail) {
       fprintf(stderr, "Failed to open the file %s\n", infile);
       return (1);
     }
 
     int num_elements;
     int *element_comp_num, *ltypes, *ptr, *conn;
-    loader->getConnectivity(&num_elements, &element_comp_num, &ltypes, &ptr, &conn);
+    loader->getConnectivity(&num_elements, &element_comp_num, &ltypes, &ptr,
+                            &conn);
 
     const char *cname, *var_names;
     int num_points, num_variables;
     float *cdata;
-    loader->getContinuousData(&cname, &var_names, &num_points, &num_variables, &cdata);
+    loader->getContinuousData(&cname, &var_names, &num_points, &num_variables,
+                              &cdata);
 
     const char *ename, *evar_names;
     int edim1, num_evariables;
     float *edata;
-    loader->getElementData(&ename, &evar_names, &edim1, &num_evariables, &edata);
+    loader->getElementData(&ename, &evar_names, &edim1, &num_evariables,
+                           &edata);
 
     double solution_time = 0.0;
 
     // Initialize the tecplot file with the variables
     // Concatenate continuous and element variable names
-    char *all_vars = new char[ strlen(var_names)+strlen(evar_names)+2 ];
+    char *all_vars = new char[strlen(var_names) + strlen(evar_names) + 2];
     strcpy(all_vars, var_names);
     all_vars[strlen(var_names)] = ',';
-    strcpy(&all_vars[strlen(var_names)+1], evar_names);
+    strcpy(&all_vars[strlen(var_names) + 1], evar_names);
     create_tec_file(data_info, all_vars, outfile, dir_name, FULL);
     tec_init = 1;
-    delete [] all_vars;
+    delete[] all_vars;
 
     // Count up the number of times each node is referred to
     // in the discontinuous element-wise data
-    float *counts = new float[ num_points ];
-    memset(counts, 0, num_points*sizeof(float));
-    for ( int j = 0; j < ptr[num_elements]; j++ ){
+    float *counts = new float[num_points];
+    memset(counts, 0, num_points * sizeof(float));
+    for (int j = 0; j < ptr[num_elements]; j++) {
       counts[conn[j]] += 1.0;
     }
-    for ( int i = 0; i < num_points; i++ ){
-      if (counts[i] != 0.0){
-        counts[i] = 1.0/counts[i];
+    for (int i = 0; i < num_points; i++) {
+      if (counts[i] != 0.0) {
+        counts[i] = 1.0 / counts[i];
       }
     }
 
     // For each component, average the nodal data
-    float *avg_edata = new float[ num_points * num_evariables ];
+    float *avg_edata = new float[num_points * num_evariables];
     // Nodally average the data
-    memset(avg_edata, 0, num_points * num_evariables*sizeof(float));
-    for ( int j = 0; j < num_evariables; j++ ){
-      for ( int k = 0; k < ptr[num_elements]; k++ ){
-        avg_edata[num_evariables*conn[k] + j] += counts[conn[k]]*edata[num_evariables*k + j];
+    memset(avg_edata, 0, num_points * num_evariables * sizeof(float));
+    for (int j = 0; j < num_evariables; j++) {
+      for (int k = 0; k < ptr[num_elements]; k++) {
+        avg_edata[num_evariables * conn[k] + j] +=
+            counts[conn[k]] * edata[num_evariables * k + j];
       }
     }
 
-    delete [] counts;
+    delete[] counts;
 
-    if (!(element_comp_num && conn && cdata)){
-      fprintf(stderr, "Error, data, connectivity or \
+    if (!(element_comp_num && conn && cdata)) {
+      fprintf(stderr,
+              "Error, data, connectivity or \
               component numbers not defined in file\n");
     }
 
     // Setup visualization elements
     int num_basic_elements = 0;
     int basic_conn_size = 0;
-    for ( int k = 0; k < num_elements; k++ ){
+    for (int k = 0; k < num_elements; k++) {
       int ntypes = 0, nconn = 0;
       ElementLayout ltype = (ElementLayout)ltypes[k];
       TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
       // For triangular elements we'll add a 4th dummy node
       // to the connectivity that's just the third node repeated
-      // This way triangles can be treated as degenerate quads from Tecplot's perspective
-      if (ltype == TACS_TRI_ELEMENT ||
-          ltype == TACS_TRI_QUADRATIC_ELEMENT ||
-          ltype == TACS_TRI_CUBIC_ELEMENT){
+      // This way triangles can be treated as degenerate quads from Tecplot's
+      // perspective
+      if (ltype == TACS_TRI_ELEMENT || ltype == TACS_TRI_QUADRATIC_ELEMENT ||
+          ltype == TACS_TRI_CUBIC_ELEMENT) {
         nconn = nconn + ntypes;
       }
       // Plot higher order tetrahedral elements as a single linear element
       else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT ||
-               ltype == TACS_TETRA_CUBIC_ELEMENT){
+               ltype == TACS_TETRA_CUBIC_ELEMENT) {
         nconn = 4;
         ntypes = 1;
       }
@@ -281,50 +287,46 @@ int main( int argc, char * argv[] ){
       basic_conn_size += nconn;
     }
 
-    int *basic_ltypes = new int[ num_basic_elements ];
-    int *basic_element_comp_num = new int[ num_basic_elements ];
-    int *basic_conn = new int[ basic_conn_size ];
+    int *basic_ltypes = new int[num_basic_elements];
+    int *basic_element_comp_num = new int[num_basic_elements];
+    int *basic_conn = new int[basic_conn_size];
 
     int *btypes = basic_ltypes;
     int *belem_comp_num = basic_element_comp_num;
     int *bconn = basic_conn;
-    for ( int k = 0; k < num_elements; k++ ){
+    for (int k = 0; k < num_elements; k++) {
       int ntypes = 0, nconn = 0;
       ElementLayout ltype = (ElementLayout)ltypes[k];
       // Add our dummy nodes for triangular elements
-      if (ltype == TACS_TRI_ELEMENT ||
-          ltype == TACS_TRI_QUADRATIC_ELEMENT ||
-          ltype == TACS_TRI_CUBIC_ELEMENT){
+      if (ltype == TACS_TRI_ELEMENT || ltype == TACS_TRI_QUADRATIC_ELEMENT ||
+          ltype == TACS_TRI_CUBIC_ELEMENT) {
         TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
-        int *tri_conn = new int[ nconn ];
-        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]],
-                                    btypes, tri_conn);
+        int *tri_conn = new int[nconn];
+        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]], btypes, tri_conn);
 
         const int convert[] = {0, 1, 2, 2};
-        for (int jj = 0; jj < ntypes; jj++){
-          for (int ii = 0; ii < 4; ii++){
-            bconn[4*jj+ii] = tri_conn[3*jj+convert[ii]];
+        for (int jj = 0; jj < ntypes; jj++) {
+          for (int ii = 0; ii < 4; ii++) {
+            bconn[4 * jj + ii] = tri_conn[3 * jj + convert[ii]];
           }
           btypes[jj] = TACS_QUAD_ELEMENT;
         }
         nconn = nconn + ntypes;
-        delete [] tri_conn;
+        delete[] tri_conn;
       }
       // Plot only the first four nodes (conrners) of higher order tets
       else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT ||
-               ltype == TACS_TETRA_CUBIC_ELEMENT){
-        memcpy(bconn, &conn[ptr[k]], 4*sizeof(int));
+               ltype == TACS_TETRA_CUBIC_ELEMENT) {
+        memcpy(bconn, &conn[ptr[k]], 4 * sizeof(int));
         nconn = 4;
         ntypes = 1;
         btypes[0] = TACS_TETRA_ELEMENT;
-      }
-      else {
+      } else {
         TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
-        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]],
-                                    btypes, bconn);
+        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]], btypes, bconn);
       }
       // Set the basic element component to match the parent
-      for ( int ii = 0; ii < ntypes; ii++ ){
+      for (int ii = 0; ii < ntypes; ii++) {
         belem_comp_num[ii] = element_comp_num[k];
       }
       btypes += ntypes;
@@ -334,62 +336,59 @@ int main( int argc, char * argv[] ){
 
     int num_comp = loader->getNumComponents();
 
-    int *reduced_points = new int[ num_points ];
-    int *reduced_conn = new int[ basic_conn_size ];
+    int *reduced_points = new int[num_points];
+    int *reduced_conn = new int[basic_conn_size];
     float *reduced_float_data = NULL;
-    reduced_float_data = new float[ num_points ];
+    reduced_float_data = new float[num_points];
 
-    for ( int k = 0; k < num_comp; k++ ){
+    for (int k = 0; k < num_comp; k++) {
       // Count up the number of elements that use the connectivity
       char *comp_name = loader->getComponentName(k);
-      //printf("Converting zone %d: %s at time %g\n",
-      // k, comp_name, solution_time);
+      // printf("Converting zone %d: %s at time %g\n",
+      //  k, comp_name, solution_time);
 
-      memset(reduced_points, 0, num_points*sizeof(int));
-      memset(reduced_conn, 0, basic_conn_size*sizeof(int));
+      memset(reduced_points, 0, num_points * sizeof(int));
+      memset(reduced_conn, 0, basic_conn_size * sizeof(int));
 
       int npts = 1, nelems = 0;
       int zone_btype = -1;
       int basic_conn_offset = 0;
       // Count up the number of points/elements in this sub-domain
-      for ( int i = 0; i < num_basic_elements; i++ ){
+      for (int i = 0; i < num_basic_elements; i++) {
         ElementLayout ltype = (ElementLayout)basic_ltypes[i];
         int conn_size = TacsGetNumVisNodes(ltype);
 
-        if (basic_element_comp_num[i] == k){
+        if (basic_element_comp_num[i] == k) {
           // Make sure all elements in this zone are the same type
-          if (zone_btype == -1){
+          if (zone_btype == -1) {
             zone_btype = basic_ltypes[i];
-          }
-          else if (zone_btype != basic_ltypes[i]){
+          } else if (zone_btype != basic_ltypes[i]) {
             fprintf(stderr, "Component %d has conflicting element types\n", k);
             return (1);
           }
 
           int pt;
-          for ( int j = 0; j < conn_size; j++ ){
+          for (int j = 0; j < conn_size; j++) {
             // Add this element to the reduced connectivity
-            if (basic_ltypes[k] == TACS_QUAD_ELEMENT){
+            if (basic_ltypes[k] == TACS_QUAD_ELEMENT) {
               const int convert[] = {0, 1, 3, 2};
               pt = basic_conn[basic_conn_offset + convert[j]];
-            }
-            else if (basic_ltypes[k] == TACS_HEXA_ELEMENT){
+            } else if (basic_ltypes[k] == TACS_HEXA_ELEMENT) {
               const int convert[] = {0, 1, 3, 2, 4, 5, 7, 6};
               pt = basic_conn[basic_conn_offset + convert[j]];
-            }
-            else {
-              pt = basic_conn[basic_conn_offset+j];
+            } else {
+              pt = basic_conn[basic_conn_offset + j];
             }
 
             // If a reduced numbering has not been applied to this point,
             // create a new number for it
-            if (reduced_points[pt] == 0){
+            if (reduced_points[pt] == 0) {
               reduced_points[pt] = npts;
               npts++;
             }
 
             // Set the reduced connectivity
-            reduced_conn[conn_size*nelems + j] = reduced_points[pt];
+            reduced_conn[conn_size * nelems + j] = reduced_points[pt];
           }
 
           nelems++;
@@ -403,45 +402,42 @@ int main( int argc, char * argv[] ){
 
       // Set the element type to use
       ZoneType zone_type;
-      if (zone_btype == TACS_LINE_ELEMENT){
+      if (zone_btype == TACS_LINE_ELEMENT) {
         zone_type = FELINESEG;
-      }
-      else if (zone_btype == TACS_QUAD_ELEMENT){
+      } else if (zone_btype == TACS_QUAD_ELEMENT) {
         zone_type = FEQUADRILATERAL;
-      }
-      else if (zone_btype == TACS_TETRA_ELEMENT){
+      } else if (zone_btype == TACS_TETRA_ELEMENT) {
         zone_type = FETETRAHEDRON;
-      }
-      else if (zone_btype == TACS_HEXA_ELEMENT){
+      } else if (zone_btype == TACS_HEXA_ELEMENT) {
         zone_type = FEBRICK;
-      }
-      else {
-        fprintf(stderr, "Component %d has unsupported element types for f5totec\n", k);
+      } else {
+        fprintf(stderr,
+                "Component %d has unsupported element types for f5totec\n", k);
         return (1);
       }
 
-      if (nelems > 0 && npts > 0){
+      if (nelems > 0 && npts > 0) {
         // Create the zone with the solution time
-        create_fe_tec_zone(comp_name, zone_type, npts, nelems,
-                           use_strands, solution_time);
+        create_fe_tec_zone(comp_name, zone_type, npts, nelems, use_strands,
+                           solution_time);
 
         // Retrieve the continuous data
-        for ( int j = 0; j < num_variables; j++ ){
-          for ( int i = 0; i < num_points; i++ ){
-            if (reduced_points[i] > 0){
-              reduced_float_data[reduced_points[i]-1] =
-                cdata[i*num_variables + j];
+        for (int j = 0; j < num_variables; j++) {
+          for (int i = 0; i < num_points; i++) {
+            if (reduced_points[i] > 0) {
+              reduced_float_data[reduced_points[i] - 1] =
+                  cdata[i * num_variables + j];
             }
           }
           write_tec_float_data(npts, reduced_float_data);
         }
 
         // Retrieve the element data
-        for ( int j = 0; j < num_evariables; j++ ){
-          for ( int i = 0; i < num_points; i++ ){
-            if (reduced_points[i] > 0){
-              reduced_float_data[reduced_points[i]-1] =
-                avg_edata[num_evariables*i + j];
+        for (int j = 0; j < num_evariables; j++) {
+          for (int i = 0; i < num_points; i++) {
+            if (reduced_points[i] > 0) {
+              reduced_float_data[reduced_points[i] - 1] =
+                  avg_edata[num_evariables * i + j];
             }
           }
           write_tec_float_data(npts, reduced_float_data);
@@ -452,28 +448,27 @@ int main( int argc, char * argv[] ){
       }
     }
 
-    if (tec_init){
+    if (tec_init) {
       close_tec_file();
     }
 
     loader->decref();
 
     // Clean up memory
-    delete [] reduced_points;
-    delete [] reduced_conn;
-    delete [] reduced_float_data;
-    delete [] avg_edata;
+    delete[] reduced_points;
+    delete[] reduced_conn;
+    delete[] reduced_float_data;
+    delete[] avg_edata;
 
-    delete [] basic_ltypes;
-    delete [] basic_conn;
-    delete [] basic_element_comp_num;
+    delete[] basic_ltypes;
+    delete[] basic_conn;
+    delete[] basic_element_comp_num;
 
-    delete [] infile;
-    delete [] outfile;
+    delete[] infile;
+    delete[] outfile;
   }
 
   MPI_Finalize();
 
   return (0);
 }
-

--- a/extern/f5totec/f5totec.cpp
+++ b/extern/f5totec/f5totec.cpp
@@ -42,6 +42,25 @@ enum ZoneType {
   FEPOLYHEDRA
 };
 
+/**
+ * @brief Convert from TACS element node ordering to tecplot node ordering
+ *
+ * @param eltype Element type
+ * @param ind TACS node number
+ * @return int Tecplot node number
+ */
+int convertLocalNodeInd(const ElementLayout eltype, const int ind) {
+  if (eltype == TACS_QUAD_ELEMENT) {
+    const int convert[] = {0, 1, 3, 2};
+    return convert[ind];
+  } else if (eltype == TACS_HEXA_ELEMENT) {
+    const int convert[] = {0, 1, 3, 2, 4, 5, 7, 6};
+    return convert[ind];
+  } else {
+    return ind;
+  }
+}
+
 /*
   Initialize a data file.
 
@@ -202,21 +221,21 @@ int main(int argc, char *argv[]) {
     }
 
     int num_elements;
-    int *element_comp_num, *ltypes, *ptr, *conn;
-    loader->getConnectivity(&num_elements, &element_comp_num, &ltypes, &ptr,
+    int *element_comp_num, *eltypes, *ptr, *conn;
+    loader->getConnectivity(&num_elements, &element_comp_num, &eltypes, &ptr,
                             &conn);
 
     const char *cname, *var_names;
-    int num_points, num_variables;
+    int num_points, num_cvars_per_node;
     float *cdata;
-    loader->getContinuousData(&cname, &var_names, &num_points, &num_variables,
-                              &cdata);
+    loader->getContinuousData(&cname, &var_names, &num_points,
+                              &num_cvars_per_node, &cdata);
 
     const char *ename, *evar_names;
-    int edim1, num_evariables;
+    int num_enodes, num_evars_per_node;
     float *edata;
-    loader->getElementData(&ename, &evar_names, &edim1, &num_evariables,
-                           &edata);
+    loader->getElementData(&ename, &evar_names, &num_enodes,
+                           &num_evars_per_node, &edata);
 
     double solution_time = 0.0;
 
@@ -243,14 +262,13 @@ int main(int argc, char *argv[]) {
       }
     }
 
-    // For each component, average the nodal data
-    float *avg_edata = new float[num_points * num_evariables];
     // Nodally average the data
-    memset(avg_edata, 0, num_points * num_evariables * sizeof(float));
-    for (int j = 0; j < num_evariables; j++) {
+    float *avg_edata = new float[num_points * num_evars_per_node];
+    memset(avg_edata, 0, num_points * num_evars_per_node * sizeof(float));
+    for (int j = 0; j < num_evars_per_node; j++) {
       for (int k = 0; k < ptr[num_elements]; k++) {
-        avg_edata[num_evariables * conn[k] + j] +=
-            counts[conn[k]] * edata[num_evariables * k + j];
+        avg_edata[num_evars_per_node * conn[k] + j] +=
+            counts[conn[k]] * edata[num_evars_per_node * k + j];
       }
     }
 
@@ -266,72 +284,110 @@ int main(int argc, char *argv[]) {
     int num_basic_elements = 0;
     int basic_conn_size = 0;
     for (int k = 0; k < num_elements; k++) {
-      int ntypes = 0, nconn = 0;
-      ElementLayout ltype = (ElementLayout)ltypes[k];
-      TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
+      int numNewElems = 0, numNewNodes = 0;
+      const ElementLayout eltype = (ElementLayout)eltypes[k];
+      TacsConvertVisLayoutToBasicCount(eltype, &numNewElems, &numNewNodes);
       // For triangular elements we'll add a 4th dummy node
       // to the connectivity that's just the third node repeated
       // This way triangles can be treated as degenerate quads from Tecplot's
       // perspective
-      if (ltype == TACS_TRI_ELEMENT || ltype == TACS_TRI_QUADRATIC_ELEMENT ||
-          ltype == TACS_TRI_CUBIC_ELEMENT) {
-        nconn = nconn + ntypes;
+      if (eltype == TACS_TRI_ELEMENT || eltype == TACS_TRI_QUADRATIC_ELEMENT ||
+          eltype == TACS_TRI_CUBIC_ELEMENT) {
+        numNewNodes = numNewNodes + numNewElems;
       }
       // Plot higher order tetrahedral elements as a single linear element
-      else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT ||
-               ltype == TACS_TETRA_CUBIC_ELEMENT) {
-        nconn = 4;
-        ntypes = 1;
+      else if (eltype == TACS_TETRA_QUADRATIC_ELEMENT ||
+               eltype == TACS_TETRA_CUBIC_ELEMENT) {
+        numNewNodes = 4;
+        numNewElems = 1;
       }
-      num_basic_elements += ntypes;
-      basic_conn_size += nconn;
+      num_basic_elements += numNewElems;
+      basic_conn_size += numNewNodes;
     }
 
-    int *basic_ltypes = new int[num_basic_elements];
+    int *const basic_element_data_map =
+        new int[num_basic_elements];  // For each basic element, where does the
+                                      // data for the corresponding original
+                                      // element start in the element data array
+    int *elem_data_map_ptr = basic_element_data_map;
+
+    int *basic_eltypes = new int[num_basic_elements];
     int *basic_element_comp_num = new int[num_basic_elements];
     int *basic_conn = new int[basic_conn_size];
+    int *const basic_node_map =
+        new int[basic_conn_size];  // Which node in the original element is this
+                                   // node in the basic element
+    int *basic_node_map_ptr = basic_node_map;
 
-    int *btypes = basic_ltypes;
+    int *btypes = basic_eltypes;
     int *belem_comp_num = basic_element_comp_num;
     int *bconn = basic_conn;
+
+    int origNodeCount = 0;
+
     for (int k = 0; k < num_elements; k++) {
-      int ntypes = 0, nconn = 0;
-      ElementLayout ltype = (ElementLayout)ltypes[k];
+      int numNewElems = 0, numNewNodes = 0;
+      ElementLayout eltype = (ElementLayout)eltypes[k];
+      const int nodes_per_elem = TacsGetNumVisNodes(eltype);
       // Add our dummy nodes for triangular elements
-      if (ltype == TACS_TRI_ELEMENT || ltype == TACS_TRI_QUADRATIC_ELEMENT ||
-          ltype == TACS_TRI_CUBIC_ELEMENT) {
-        TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
-        int *tri_conn = new int[nconn];
-        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]], btypes, tri_conn);
+      if (eltype == TACS_TRI_ELEMENT || eltype == TACS_TRI_QUADRATIC_ELEMENT ||
+          eltype == TACS_TRI_CUBIC_ELEMENT) {
+        TacsConvertVisLayoutToBasicCount(eltype, &numNewElems, &numNewNodes);
+        int *tri_conn = new int[numNewNodes];
+        TacsConvertVisLayoutToBasic(eltype, &conn[ptr[k]], btypes, tri_conn);
 
         const int convert[] = {0, 1, 2, 2};
-        for (int jj = 0; jj < ntypes; jj++) {
+        for (int jj = 0; jj < numNewElems; jj++) {
           for (int ii = 0; ii < 4; ii++) {
             bconn[4 * jj + ii] = tri_conn[3 * jj + convert[ii]];
           }
           btypes[jj] = TACS_QUAD_ELEMENT;
         }
-        nconn = nconn + ntypes;
+        numNewNodes = numNewNodes + numNewElems;
         delete[] tri_conn;
       }
       // Plot only the first four nodes (conrners) of higher order tets
-      else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT ||
-               ltype == TACS_TETRA_CUBIC_ELEMENT) {
+      else if (eltype == TACS_TETRA_QUADRATIC_ELEMENT ||
+               eltype == TACS_TETRA_CUBIC_ELEMENT) {
         memcpy(bconn, &conn[ptr[k]], 4 * sizeof(int));
-        nconn = 4;
-        ntypes = 1;
+        numNewNodes = 4;
+        numNewElems = 1;
         btypes[0] = TACS_TETRA_ELEMENT;
       } else {
-        TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
-        TacsConvertVisLayoutToBasic(ltype, &conn[ptr[k]], btypes, bconn);
+        TacsConvertVisLayoutToBasicCount(eltype, &numNewElems, &numNewNodes);
+        TacsConvertVisLayoutToBasic(eltype, &conn[ptr[k]], btypes, bconn);
       }
       // Set the basic element component to match the parent
-      for (int ii = 0; ii < ntypes; ii++) {
+      for (int ii = 0; ii < numNewElems; ii++) {
         belem_comp_num[ii] = element_comp_num[k];
       }
-      btypes += ntypes;
-      belem_comp_num += ntypes;
-      bconn += nconn;
+      // Copy data to the basic element data
+      for (int ii = 0; ii < numNewNodes; ii++) {
+        // Find which node this is in the original element
+        int elemLocalInd = -1;
+        for (int jj = 0; jj < nodes_per_elem; jj++) {
+          if (conn[ptr[k] + jj] == bconn[ii]) {
+            elemLocalInd = jj;
+            break;
+          }
+        }
+        if (elemLocalInd == -1) {
+          fprintf(stderr, "Error, node not found in original element\n");
+          return 1;
+        }
+        basic_node_map_ptr[ii] = elemLocalInd;
+      }
+
+      for (int jj = 0; jj < numNewElems; jj++) {
+        elem_data_map_ptr[jj] = origNodeCount * num_evars_per_node;
+      }
+      origNodeCount += nodes_per_elem;
+      elem_data_map_ptr += numNewElems;
+
+      btypes += numNewElems;
+      belem_comp_num += numNewElems;
+      bconn += numNewNodes;
+      basic_node_map_ptr += numNewNodes;
     }
 
     int num_comp = loader->getNumComponents();
@@ -340,6 +396,14 @@ int main(int argc, char *argv[]) {
     int *reduced_conn = new int[basic_conn_size];
     float *reduced_float_data = NULL;
     reduced_float_data = new float[num_points];
+    int *const compNodeGlobalInd =
+        new int[basic_conn_size];  // Map from the duplicated node index within
+                                   // a component to the index of that node in
+                                   // the original full mesh
+    int *const compBasicElemInd =
+        new int[num_basic_elements];  // Map from the index of a basic element
+                                      // within a component to the index of that
+                                      // basic element in the full mesh
 
     for (int k = 0; k < num_comp; k++) {
       // Count up the number of elements that use the connectivity
@@ -348,37 +412,33 @@ int main(int argc, char *argv[]) {
       //  k, comp_name, solution_time);
 
       memset(reduced_points, 0, num_points * sizeof(int));
+      memset(compNodeGlobalInd, 0, basic_conn_size * sizeof(int));
       memset(reduced_conn, 0, basic_conn_size * sizeof(int));
+      memset(compBasicElemInd, 0, num_basic_elements * sizeof(int));
 
-      int npts = 1, nelems = 0;
+      int npts = 1, num_elements = 0;
       int zone_btype = -1;
       int basic_conn_offset = 0;
       // Count up the number of points/elements in this sub-domain
       for (int i = 0; i < num_basic_elements; i++) {
-        ElementLayout ltype = (ElementLayout)basic_ltypes[i];
-        int conn_size = TacsGetNumVisNodes(ltype);
+        ElementLayout eltype = (ElementLayout)basic_eltypes[i];
+        int num_node_per_elem = TacsGetNumVisNodes(eltype);
 
         if (basic_element_comp_num[i] == k) {
           // Make sure all elements in this zone are the same type
           if (zone_btype == -1) {
-            zone_btype = basic_ltypes[i];
-          } else if (zone_btype != basic_ltypes[i]) {
+            zone_btype = basic_eltypes[i];
+          } else if (zone_btype != basic_eltypes[i]) {
             fprintf(stderr, "Component %d has conflicting element types\n", k);
             return (1);
           }
+          compBasicElemInd[num_elements] = i;
 
           int pt;
-          for (int j = 0; j < conn_size; j++) {
+          for (int j = 0; j < num_node_per_elem; j++) {
             // Add this element to the reduced connectivity
-            if (basic_ltypes[k] == TACS_QUAD_ELEMENT) {
-              const int convert[] = {0, 1, 3, 2};
-              pt = basic_conn[basic_conn_offset + convert[j]];
-            } else if (basic_ltypes[k] == TACS_HEXA_ELEMENT) {
-              const int convert[] = {0, 1, 3, 2, 4, 5, 7, 6};
-              pt = basic_conn[basic_conn_offset + convert[j]];
-            } else {
-              pt = basic_conn[basic_conn_offset + j];
-            }
+            pt = basic_conn[basic_conn_offset + convertLocalNodeInd(eltype, j)];
+            compNodeGlobalInd[num_elements * num_node_per_elem + j] = pt;
 
             // If a reduced numbering has not been applied to this point,
             // create a new number for it
@@ -388,12 +448,13 @@ int main(int argc, char *argv[]) {
             }
 
             // Set the reduced connectivity
-            reduced_conn[conn_size * nelems + j] = reduced_points[pt];
+            reduced_conn[num_node_per_elem * num_elements + j] =
+                reduced_points[pt];
           }
 
-          nelems++;
+          num_elements++;
         }
-        basic_conn_offset += conn_size;
+        basic_conn_offset += num_node_per_elem;
       }
 
       // Since we started at npts = 1, we have one more point
@@ -416,35 +477,119 @@ int main(int argc, char *argv[]) {
         return (1);
       }
 
-      if (nelems > 0 && npts > 0) {
-        // Create the zone with the solution time
-        create_fe_tec_zone(comp_name, zone_type, npts, nelems, use_strands,
-                           solution_time);
+      if (num_elements > 0 && npts > 0) {
+        const bool duplicateNodes = true;
+        if (duplicateNodes) {
+          // In this case, we duplicate nodes so that every element has its own
+          // nodes (e.g first element has nodes 0->n, second elements has nodes
+          // n+1->2n etc) and we can plot discontinuous data
 
-        // Retrieve the continuous data
-        for (int j = 0; j < num_variables; j++) {
-          for (int i = 0; i < num_points; i++) {
-            if (reduced_points[i] > 0) {
-              reduced_float_data[reduced_points[i] - 1] =
-                  cdata[i * num_variables + j];
+          // Create the zone with the solution time
+          const int nodes_per_elem =
+              TacsGetNumVisNodes((ElementLayout)zone_btype);
+          const int num_dup_nodes = num_elements * nodes_per_elem;
+          create_fe_tec_zone(comp_name, zone_type, num_dup_nodes, num_elements,
+                             use_strands, solution_time);
+
+          // Allocate a new array for the nodal data
+          float *const nodalData = new float[num_dup_nodes];
+
+          // Continuous data
+          for (int jj = 0; jj < num_cvars_per_node; jj++) {
+            for (int elemInd = 0; elemInd < num_elements; elemInd++) {
+              for (int nodeInd = 0; nodeInd < nodes_per_elem; nodeInd++) {
+                const int dupNodeInd = elemInd * nodes_per_elem + nodeInd;
+                const int globalNodeInd = compNodeGlobalInd[dupNodeInd];
+                nodalData[dupNodeInd] =
+                    cdata[globalNodeInd * num_cvars_per_node + jj];
+              }
             }
+            write_tec_float_data(num_dup_nodes, nodalData);
           }
-          write_tec_float_data(npts, reduced_float_data);
-        }
+          // Element data
+          // The TACS data is stored such that all variable values for a given
+          // node are contiguous, tecplot wants the data to be stored such that
+          // all values for a given variable are contiguous
+          for (int jj = 0; jj < num_evars_per_node; jj++) {
+            for (int elemInd = 0; elemInd < num_elements; elemInd++) {
+              const int globalElemInd =
+                  compBasicElemInd[elemInd];  // Global basic element index
+              const int elemDataStartInd =
+                  basic_element_data_map[globalElemInd];  // Start of data for
+                                                          // this element in the
+                                                          // element data array
+              const float *const origElementData =
+                  &edata[elemDataStartInd];  // Start of data for this element
 
-        // Retrieve the element data
-        for (int j = 0; j < num_evariables; j++) {
-          for (int i = 0; i < num_points; i++) {
-            if (reduced_points[i] > 0) {
-              reduced_float_data[reduced_points[i] - 1] =
-                  avg_edata[num_evariables * i + j];
+              for (int nodeInd = 0; nodeInd < nodes_per_elem; nodeInd++) {
+                // At this point I know:
+                // - Which basic element I'm handling
+                // - Which original element that basic element came from
+                // - Where in the element data array does the data for this
+                // original element start
+                // - Which node (in TACS ordering) within the basic element I'm
+                // handling
+                // - Which node of the basic element this in the tecplot
+                // ordering
+                // - Which node in the original element is this
+
+                const int dupNodeInd = elemInd * nodes_per_elem + nodeInd;
+
+                const int basicElemLocalNodeInd =
+                    convertLocalNodeInd((ElementLayout)zone_btype, nodeInd);
+
+                const int originalElemLocalNodeInd =
+                    basic_node_map[globalElemInd * nodes_per_elem +
+                                   basicElemLocalNodeInd];
+
+                nodalData[dupNodeInd] =
+                    origElementData[originalElemLocalNodeInd *
+                                        num_evars_per_node +
+                                    jj];
+              }
             }
+            write_tec_float_data(num_dup_nodes, nodalData);
           }
-          write_tec_float_data(npts, reduced_float_data);
-        }
 
-        // Now, write the connectivity
-        write_con_data(reduced_conn);
+          // Now create the connectivity, because of the way we duplicate the
+          // nodal values, the connectivity is just 1,2,3,4...
+          int *const dupConn = new int[num_dup_nodes];
+          for (int i = 0; i < num_dup_nodes; i++) {
+            dupConn[i] = i + 1;
+          }
+          write_con_data(dupConn);
+          delete[] nodalData;
+          delete[] dupConn;
+        } else {
+          // Create the zone with the solution time
+          create_fe_tec_zone(comp_name, zone_type, npts, num_elements,
+                             use_strands, solution_time);
+
+          // Retrieve the continuous data
+          for (int j = 0; j < num_cvars_per_node; j++) {
+            for (int i = 0; i < num_points; i++) {
+              if (reduced_points[i] > 0) {
+                reduced_float_data[reduced_points[i] - 1] =
+                    cdata[i * num_cvars_per_node + j];
+              }
+            }
+            write_tec_float_data(npts, reduced_float_data);
+          }
+
+          // Retrieve the element data
+          for (int j = 0; j < num_evars_per_node; j++) {
+            for (int i = 0; i < num_points; i++) {
+              if (reduced_points[i] > 0) {
+                reduced_float_data[reduced_points[i] - 1] =
+                    avg_edata[num_evars_per_node * i + j];
+              }
+            }
+            write_tec_float_data(npts, reduced_float_data);
+          }
+
+          // Now, write the connectivity
+          write_con_data(reduced_conn);
+        }
       }
     }
 
@@ -460,9 +605,13 @@ int main(int argc, char *argv[]) {
     delete[] reduced_float_data;
     delete[] avg_edata;
 
-    delete[] basic_ltypes;
+    delete[] basic_eltypes;
     delete[] basic_conn;
     delete[] basic_element_comp_num;
+    delete[] basic_node_map;
+    delete[] basic_element_data_map;
+    delete[] compNodeGlobalInd;
+    delete[] compBasicElemInd;
 
     delete[] infile;
     delete[] outfile;

--- a/extern/f5totec/f5totec.cpp
+++ b/extern/f5totec/f5totec.cpp
@@ -165,11 +165,15 @@ int close_tec_file() { return TECEND112(); }
 int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
-  // Check if we're going to use strands or not
+  // Parse command line arguments
   int use_strands = 0;
+  bool duplicateNodes = false;
   for (int k = 0; k < argc; k++) {
     if (strcmp(argv[k], "--use_strands") == 0) {
       use_strands = 1;
+    }
+    if (strcmp(argv[k], "--discontinuous") == 0) {
+      duplicateNodes = true;
     }
   }
 
@@ -478,7 +482,6 @@ int main(int argc, char *argv[]) {
       }
 
       if (num_elements > 0 && npts > 0) {
-        const bool duplicateNodes = true;
         if (duplicateNodes) {
           // In this case, we duplicate nodes so that every element has its own
           // nodes (e.g first element has nodes 0->n, second elements has nodes

--- a/extern/f5tovtk/f5tovtk_element.cpp
+++ b/extern/f5tovtk/f5tovtk_element.cpp
@@ -18,8 +18,8 @@
 */
 
 // Include FH5 header files
-#include "TACSFH5Loader.h"
 #include "TACSElementTypes.h"
+#include "TACSFH5Loader.h"
 
 const int VTK_VERTEX = 1;
 const int VTK_LINE = 3;
@@ -30,38 +30,39 @@ const int VTK_HEXAHEDRON = 12;
 const int VTK_QUADRATIC_TRIANGLE = 22;
 const int VTK_QUADRATIC_TETRA = 24;
 
-int main( int argc, char * argv[] ){
+int main(int argc, char *argv[]) {
   MPI_Init(&argc, &argv);
 
   // Convert hdf5 file argv[1] to
-  if (argc == 1){
+  if (argc == 1) {
     fprintf(stderr, "Error, no input files\n");
     return (1);
   }
 
-  for ( int iter = 1; iter < argc; iter++ ){
-    char *infile = new char[ strlen(argv[iter])+1 ];
+  for (int iter = 1; iter < argc; iter++) {
+    char *infile = new char[strlen(argv[iter]) + 1];
     strcpy(infile, argv[iter]);
 
     // Set the output file
-    char *outfile = new char[ strlen(infile)+5 ];
+    char *outfile = new char[strlen(infile) + 5];
     int len = strlen(infile);
-    int i = len-1;
-    for ( ; i >= 0; i-- ){
-      if (infile[i] == '.'){ break; }
+    int i = len - 1;
+    for (; i >= 0; i--) {
+      if (infile[i] == '.') {
+        break;
+      }
     }
     strcpy(outfile, infile);
     strcpy(&outfile[i], ".vtk");
 
-    printf("Trying to convert FH5 file %s to vtk file %s\n",
-           infile, outfile);
+    printf("Trying to convert FH5 file %s to vtk file %s\n", infile, outfile);
 
     // Create the loader object
     TACSFH5Loader *loader = new TACSFH5Loader();
     loader->incref();
 
     int fail = loader->loadData(infile);
-    if (fail){
+    if (fail) {
       fprintf(stderr, "Failed to open the file %s\n", infile);
       return (1);
     }
@@ -82,7 +83,7 @@ int main( int argc, char * argv[] ){
 
     // Open the output file
     FILE *fp = fopen(outfile, "w");
-    if (!fp){
+    if (!fp) {
       fprintf(stderr, "Failed to open the output file %s\n", outfile);
       return (1);
     }
@@ -95,89 +96,83 @@ int main( int argc, char * argv[] ){
     // Write out the points
     fprintf(fp, "POINTS %d double\n", ptr[num_elements]);
 
-    int *conn_element = new int[ ptr[num_elements] ];
-    for ( int k = 0; k < ptr[num_elements]; k++ ){
-      const float *d = &cdata[cdim2*conn[k]];
+    int *conn_element = new int[ptr[num_elements]];
+    for (int k = 0; k < ptr[num_elements]; k++) {
+      const float *d = &cdata[cdim2 * conn[k]];
       fprintf(fp, "%e %e %e\n", d[0], d[1], d[2]);
       conn_element[k] = k;
     }
 
     int num_basic_elements = 0;
     int basic_conn_size = 0;
-    for ( int k = 0; k < num_elements; k++ ){
+    for (int k = 0; k < num_elements; k++) {
       int ntypes = 0, nconn = 0;
       ElementLayout ltype = (ElementLayout)ltypes[k];
-      if (ltype == TACS_TRI_QUADRATIC_ELEMENT){
+      if (ltype == TACS_TRI_QUADRATIC_ELEMENT) {
         ntypes = 1;
         nconn = 6;
-      }
-      else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT){
+      } else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT) {
         ntypes = 1;
         nconn = 10;
-      }
-      else {
+      } else {
         TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
       }
       num_basic_elements += ntypes;
       basic_conn_size += nconn;
     }
 
-    int *basic_ltypes = new int[ num_basic_elements ];
-    int *basic_conn = new int[ basic_conn_size ];
+    int *basic_ltypes = new int[num_basic_elements];
+    int *basic_conn = new int[basic_conn_size];
 
     int *btypes = basic_ltypes;
     int *bconn = basic_conn;
-    for ( int k = 0; k < num_elements; k++ ){
+    for (int k = 0; k < num_elements; k++) {
       int ntypes = 0, nconn = 0;
       ElementLayout ltype = (ElementLayout)ltypes[k];
-      if (ltype == TACS_TRI_QUADRATIC_ELEMENT){
+      if (ltype == TACS_TRI_QUADRATIC_ELEMENT) {
         btypes[0] = ltype;
         ntypes = 1;
         nconn = 6;
-        memcpy(bconn, &conn_element[ptr[k]], 6*sizeof(int));
-      }
-      else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT){
+        memcpy(bconn, &conn_element[ptr[k]], 6 * sizeof(int));
+      } else if (ltype == TACS_TETRA_QUADRATIC_ELEMENT) {
         btypes[0] = ltype;
         ntypes = 1;
         nconn = 10;
-        memcpy(bconn, &conn_element[ptr[k]], 10*sizeof(int));
-      }
-      else {
+        memcpy(bconn, &conn_element[ptr[k]], 10 * sizeof(int));
+      } else {
         TacsConvertVisLayoutToBasicCount(ltype, &ntypes, &nconn);
-        TacsConvertVisLayoutToBasic(ltype, &conn_element[ptr[k]],
-                                    btypes, bconn);
+        TacsConvertVisLayoutToBasic(ltype, &conn_element[ptr[k]], btypes,
+                                    bconn);
       }
       btypes += ntypes;
       bconn += nconn;
     }
 
-    delete [] conn_element;
+    delete[] conn_element;
 
     // Write out the cell values
     fprintf(fp, "\nCELLS %d %d\n", num_basic_elements,
             num_basic_elements + basic_conn_size);
 
     int basic_conn_offset = 0;
-    for ( int k = 0; k < num_basic_elements; k++ ){
+    for (int k = 0; k < num_basic_elements; k++) {
       ElementLayout ltype = (ElementLayout)basic_ltypes[k];
       int conn_size = TacsGetNumVisNodes(ltype);
       fprintf(fp, "%d ", conn_size);
-      if (basic_ltypes[k] == TACS_QUAD_ELEMENT){
+      if (basic_ltypes[k] == TACS_QUAD_ELEMENT) {
         const int convert[] = {0, 1, 3, 2};
-        for ( int j = 0; j < conn_size; j++ ){
+        for (int j = 0; j < conn_size; j++) {
           fprintf(fp, "%d ", basic_conn[basic_conn_offset + convert[j]]);
         }
         basic_conn_offset += 4;
-      }
-      else if (basic_ltypes[k] == TACS_HEXA_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_HEXA_ELEMENT) {
         const int convert[] = {0, 1, 3, 2, 4, 5, 7, 6};
-        for ( int j = 0; j < conn_size; j++ ){
+        for (int j = 0; j < conn_size; j++) {
           fprintf(fp, "%d ", basic_conn[basic_conn_offset + convert[j]]);
         }
         basic_conn_offset += 8;
-      }
-      else {
-        for ( int j = 0; j < conn_size; j++, basic_conn_offset++ ){
+      } else {
+        for (int j = 0; j < conn_size; j++, basic_conn_offset++) {
           fprintf(fp, "%d ", basic_conn[basic_conn_offset]);
         }
       }
@@ -186,67 +181,62 @@ int main( int argc, char * argv[] ){
 
     // All tetrahedrals...
     fprintf(fp, "\nCELL_TYPES %d\n", num_basic_elements);
-    for ( int k = 0; k < num_basic_elements; k++ ){
-      if (basic_ltypes[k] == TACS_POINT_ELEMENT){
+    for (int k = 0; k < num_basic_elements; k++) {
+      if (basic_ltypes[k] == TACS_POINT_ELEMENT) {
         fprintf(fp, "%d\n", VTK_VERTEX);
-      }
-      else if (basic_ltypes[k] == TACS_LINE_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_LINE_ELEMENT) {
         fprintf(fp, "%d\n", VTK_LINE);
-      }
-      else if (basic_ltypes[k] == TACS_TRI_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_TRI_ELEMENT) {
         fprintf(fp, "%d\n", VTK_TRIANGLE);
-      }
-      else if (basic_ltypes[k] == TACS_TRI_QUADRATIC_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_TRI_QUADRATIC_ELEMENT) {
         fprintf(fp, "%d\n", VTK_QUADRATIC_TRIANGLE);
-      }
-      else if (basic_ltypes[k] == TACS_QUAD_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_QUAD_ELEMENT) {
         fprintf(fp, "%d\n", VTK_QUAD);
-      }
-      else if (basic_ltypes[k] == TACS_TETRA_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_TETRA_ELEMENT) {
         fprintf(fp, "%d\n", VTK_TETRA);
-      }
-      else if (basic_ltypes[k] == TACS_TETRA_QUADRATIC_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_TETRA_QUADRATIC_ELEMENT) {
         fprintf(fp, "%d\n", VTK_QUADRATIC_TETRA);
-      }
-      else if (basic_ltypes[k] == TACS_HEXA_ELEMENT){
+      } else if (basic_ltypes[k] == TACS_HEXA_ELEMENT) {
         fprintf(fp, "%d\n", VTK_HEXAHEDRON);
       }
     }
-    delete [] basic_conn;
-    delete [] basic_ltypes;
+    delete[] basic_conn;
+    delete[] basic_ltypes;
 
     // Print out the rest as fields one-by-one
     fprintf(fp, "POINT_DATA %d\n", edim1);
 
-    for ( int j = 0; j < cdim2; j++ ){
+    for (int j = 0; j < cdim2; j++) {
       char name[256];
       int index = 0;
-      while (strlen(cvars) > 0 && cvars[0] != ','){
+      while (strlen(cvars) > 0 && cvars[0] != ',') {
         name[index] = cvars[0];
-        index++; cvars++;
+        index++;
+        cvars++;
       }
       name[index] = '\0';
       cvars++;
 
       // Write out the zone names
-      if (j >= 3){
+      if (j >= 3) {
         fprintf(fp, "SCALARS %s double 1\n", name);
         fprintf(fp, "LOOKUP_TABLE default\n");
 
-        for ( int k = 0; k < ptr[num_elements]; k++ ){
-          const float d = cdata[cdim2*conn[k] + j];
+        for (int k = 0; k < ptr[num_elements]; k++) {
+          const float d = cdata[cdim2 * conn[k] + j];
           fprintf(fp, "%.3e\n", d);
         }
       }
     }
 
     // For each component, average the nodal data
-    for ( int j = 0; j < edim2; j++ ){
+    for (int varIndex = 0; varIndex < edim2; varIndex++) {
       char name[256];
       int index = 0;
-      while (strlen(evars) > 0 && evars[0] != ','){
+      while (strlen(evars) > 0 && evars[0] != ',') {
         name[index] = evars[0];
-        index++; evars++;
+        index++;
+        evars++;
       }
       name[index] = '\0';
       evars++;
@@ -255,8 +245,8 @@ int main( int argc, char * argv[] ){
       fprintf(fp, "SCALARS %s double 1\n", name);
       fprintf(fp, "LOOKUP_TABLE default\n");
 
-      for ( int k = 0; k < edim1; k++ ){
-        fprintf(fp, "%.3e\n", edata[edim2*k + j]);
+      for (int nodeIndex = 0; nodeIndex < edim1; nodeIndex++) {
+        fprintf(fp, "%.3e\n", edata[edim2 * nodeIndex + varIndex]);
       }
     }
 
@@ -264,12 +254,11 @@ int main( int argc, char * argv[] ){
 
     loader->decref();
 
-    delete [] infile;
-    delete [] outfile;
+    delete[] infile;
+    delete[] outfile;
   }
 
   MPI_Finalize();
 
   return (0);
 }
-


### PR DESCRIPTION
1. Modifies f5totec to take a `--discontinuous` command line argument, in which case nodes are duplicated so that element data is plotted as it is written out by TACS, rather than averaging values at nodes which leads to unphysical looking results for shells and beams etc. Some examples are shown below.
2. Ran clang format on f5totec and f5tovtk
3. Add f5totec and f5tovtk to clang format checks run on PRs

![image](https://github.com/user-attachments/assets/663e4d3c-c2bc-4c5c-9b28-96b346834aac)

![image](https://github.com/user-attachments/assets/fd554b8c-cb67-444b-8b77-c7783a267936)

![image](https://github.com/user-attachments/assets/0853f0da-f194-42a1-b5ae-c00c56ee9b60)

