### PR TITLE
Fixing remaining check_partials attributes in mphys wrappers

### DIFF
--- a/tacs/mphys/builder.py
+++ b/tacs/mphys/builder.py
@@ -200,7 +200,7 @@ class TacsBuilder(Builder):
         self.constraint_setup = constraint_setup
         self.buckling_setup = buckling_setup
         self.pytacs_options = pytacs_options
-        self.check_partials = check_partials
+        self.under_check_partials = check_partials
         self.conduction = conduction
         if isinstance(coupling_loads, str):
             self.coupling_loads = [coupling_loads]
@@ -260,7 +260,7 @@ class TacsBuilder(Builder):
         return TacsCouplingGroup(
             fea_assembler=self.fea_assembler,
             discipline_vars=self.discipline_vars,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
             coupling_loads=self.coupling_loads,
             scenario_name=scenario_name,
             problem_setup=self.problem_setup,
@@ -323,7 +323,7 @@ class TacsBuilder(Builder):
         """
         return TacsPostcouplingGroup(
             fea_assembler=self.fea_assembler,
-            check_partials=self.check_partials,
+            check_partials=self.under_check_partials,
             discipline_vars=self.discipline_vars,
             write_solution=self.write_solution,
             scenario_name=scenario_name,

--- a/tacs/mphys/coupling.py
+++ b/tacs/mphys/coupling.py
@@ -25,7 +25,7 @@ class TacsCouplingGroup(om.Group):
 
     def setup(self):
         self.fea_assembler = self.options["fea_assembler"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.coupling_loads = self.options["coupling_loads"]
         self.coupled = len(self.coupling_loads) > 0
         self.discipline_vars = self.options["discipline_vars"]
@@ -93,7 +93,7 @@ class TacsCouplingGroup(om.Group):
             "solver",
             TacsSolver(
                 fea_assembler=self.fea_assembler,
-                check_partials=self.check_partials,
+                check_partials=self.under_check_partials,
                 coupling_loads=self.coupling_loads,
                 discipline_vars=self.discipline_vars,
                 res_ref=self.res_ref,

--- a/tacs/mphys/functions.py
+++ b/tacs/mphys/functions.py
@@ -24,11 +24,11 @@ class TacsFunctions(om.ExplicitComponent):
         self.options.declare("write_solution")
 
         self.fea_assembler = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         self.fea_assembler = self.options["fea_assembler"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.auto_write_solution = self.options["write_solution"]
         self.discipline_vars = self.options["discipline_vars"]
         self.solution_counter = 0
@@ -104,7 +104,7 @@ class TacsFunctions(om.ExplicitComponent):
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         if mode == "fwd":
-            if not self.check_partials:
+            if not self.under_check_partials:
                 raise ValueError("TACS forward mode requested but not implemented")
         if mode == "rev":
             # always update internal because same tacs object could be used by multiple scenarios
@@ -139,11 +139,11 @@ class MassFunctions(om.ExplicitComponent):
         self.options.declare("check_partials")
 
         self.fea_assembler = None
-        self.check_partials = False
+        self.under_check_partials = False
 
     def setup(self):
         self.fea_assembler = self.options["fea_assembler"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.discipline_vars = self.options["discipline_vars"]
 
         self.coords_name = self.discipline_vars.COORDINATES
@@ -197,7 +197,7 @@ class MassFunctions(om.ExplicitComponent):
 
     def compute_jacvec_product(self, inputs, d_inputs, d_outputs, mode):
         if mode == "fwd":
-            if not self.check_partials:
+            if not self.under_check_partials:
                 raise ValueError("TACS forward mode requested but not implemented")
         if mode == "rev":
             # always update internal because same tacs object could be used by multiple scenarios

--- a/tacs/mphys/postcoupling.py
+++ b/tacs/mphys/postcoupling.py
@@ -20,7 +20,7 @@ class TacsPostcouplingGroup(om.Group):
 
     def setup(self):
         self.fea_assembler = self.options["fea_assembler"]
-        self.check_partials = self.options["check_partials"]
+        self.under_check_partials = self.options["check_partials"]
         self.discipline_vars = self.options["discipline_vars"]
         self.auto_write_solution = self.options["write_solution"]
 
@@ -58,7 +58,7 @@ class TacsPostcouplingGroup(om.Group):
             "eval_funcs",
             TacsFunctions(
                 fea_assembler=self.fea_assembler,
-                check_partials=self.check_partials,
+                check_partials=self.under_check_partials,
                 discipline_vars=self.discipline_vars,
                 write_solution=self.auto_write_solution,
             ),
@@ -80,7 +80,7 @@ class TacsPostcouplingGroup(om.Group):
                 "mass_funcs",
                 MassFunctions(
                     fea_assembler=self.fea_assembler,
-                    check_partials=self.check_partials,
+                    check_partials=self.under_check_partials,
                     discipline_vars=self.discipline_vars,
                 ),
                 promotes_inputs=promotes_inputs,
@@ -105,7 +105,7 @@ class TacsPostcouplingGroup(om.Group):
                     "buckling",
                     TacsBuckling(
                         fea_assembler=self.fea_assembler,
-                        check_partials=self.check_partials,
+                        check_partials=self.under_check_partials,
                         write_solution=self.write_solution,
                     ),
                     promotes_inputs=promotes_inputs + promotes_states,


### PR DESCRIPTION
Apparently I missed a few `check_partials` attributes in PR #348 