### PR TITLE
black CI fix

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -12,5 +12,4 @@ jobs:
       - uses: actions/checkout@v4
       - uses: psf/black@stable
         with:
-          version: "24.1"
-          options: "--check --diff --verbose"
+          version: "~=24.10"

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -13,3 +13,4 @@ jobs:
       - uses: psf/black@stable
         with:
           version: "24.1"
+          options: "--check --diff --verbose"


### PR DESCRIPTION
There seems to be a minor issue in black 24.1.0 that was causing most of our python files to be ignored in the CI check (see [here](https://github.com/smdogroup/tacs/actions/runs/13633865001)). bumping the version up to 24.10.0 which seems to fix issue.