### PR TITLE
Clean up compiler warnings

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -103,11 +103,11 @@ jobs:
           conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
           cd $TACS_DIR/examples;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
       - name: Install f5totec/f5tovtk
         run: |
           # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later
@@ -116,10 +116,10 @@ jobs:
           cd $TACS_DIR/extern/f5totec;
           make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${CONDA_PREFIX}/include/ TECIO_LIB=${CONDA_PREFIX}/lib/libtecio.a\
             METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis"\
-            EXTRA_DEBUG_CC_FLAGS+="-Werror";
+            EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
           cd ..;
           cd f5tovtk;
-          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
+          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
       - name: Install optional dependencies
         run: |
           # Install petsc for openmdao tests (there's a problem with 3.22.3 on mac runner)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -103,13 +103,11 @@ jobs:
           conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/\ 
-            METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
           cd $TACS_DIR/examples;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/\
-            METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
       - name: Install f5totec/f5tovtk
         run: |
           # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -103,11 +103,13 @@ jobs:
           conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/\ 
+            METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
           cd $TACS_DIR/examples;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/\
+            METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="-Werror";
       - name: Install f5totec/f5tovtk
         run: |
           # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later
@@ -115,7 +117,8 @@ jobs:
           # Compile f5totec/f5tovtk
           cd $TACS_DIR/extern/f5totec;
           make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${CONDA_PREFIX}/include/ TECIO_LIB=${CONDA_PREFIX}/lib/libtecio.a\
-            METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
+            METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis"\
+            EXTRA_DEBUG_CC_FLAGS+="-Werror";
           cd ..;
           cd f5tovtk;
           make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -103,11 +103,11 @@ jobs:
           conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
           cd $TACS_DIR/examples;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
       - name: Install f5totec/f5tovtk
         run: |
           # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later
@@ -115,11 +115,10 @@ jobs:
           # Compile f5totec/f5tovtk
           cd $TACS_DIR/extern/f5totec;
           make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${CONDA_PREFIX}/include/ TECIO_LIB=${CONDA_PREFIX}/lib/libtecio.a\
-            METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis"\
-            EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
+            METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd ..;
           cd f5tovtk;
-          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
+          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
       - name: Install optional dependencies
         run: |
           # Install petsc for openmdao tests (there's a problem with 3.22.3 on mac runner)

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -103,11 +103,11 @@ jobs:
           conda install -c conda-forge metis=5.1.0 -q -y;
           cd $TACS_DIR;
           cp Makefile.in.info Makefile.in;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
           cd $TACS_DIR;
           make ${{ matrix.INTERFACE }};
           cd $TACS_DIR/examples;
-          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
+          make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
       - name: Install f5totec/f5tovtk
         run: |
           # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later
@@ -116,10 +116,10 @@ jobs:
           cd $TACS_DIR/extern/f5totec;
           make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${CONDA_PREFIX}/include/ TECIO_LIB=${CONDA_PREFIX}/lib/libtecio.a\
             METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis"\
-            EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
+            EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
           cd ..;
           cd f5tovtk;
-          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS+="${EXTRA_DEBUG_CC_FLAGS} -Werror";
+          make TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis" EXTRA_DEBUG_CC_FLAGS="-fPIC -g -Werror";
       - name: Install optional dependencies
         run: |
           # Install petsc for openmdao tests (there's a problem with 3.22.3 on mac runner)

--- a/examples/cylinder/cylinder_verify.cpp
+++ b/examples/cylinder/cylinder_verify.cpp
@@ -1105,9 +1105,11 @@ int main(int argc, char *argv[]) {
   if (grid_study_flag) {
     char file_name[128];
     if (orthotropic_flag) {
-      snprintf(file_name, sizeof(file_name), "ortho_grid_study_order=%d_P=%d.dat", order, P);
+      snprintf(file_name, sizeof(file_name),
+               "ortho_grid_study_order=%d_P=%d.dat", order, P);
     } else {
-      snprintf(file_name, sizeof(file_name), "iso_grid_study_order=%d_P=%d.dat", order, P);
+      snprintf(file_name, sizeof(file_name), "iso_grid_study_order=%d_P=%d.dat",
+               order, P);
     }
     meshStudy(file_name, P, transform, stiffness, load, R, L, alpha, beta,
               order, 8 - order);
@@ -1166,9 +1168,11 @@ int main(int argc, char *argv[]) {
 
   char file_name[128];
   if (orthotropic_flag) {
-    snprintf(file_name, sizeof(file_name), "ortho_cylinder_func_order=%d_nx=%d.dat", order, nx);
+    snprintf(file_name, sizeof(file_name),
+             "ortho_cylinder_func_order=%d_nx=%d.dat", order, nx);
   } else {
-    snprintf(file_name, sizeof(file_name), "iso_cylinder_func_order=%d_nx=%d.dat", order, nx);
+    snprintf(file_name, sizeof(file_name),
+             "iso_cylinder_func_order=%d_nx=%d.dat", order, nx);
   }
 
   FILE *fp = fopen(file_name, "w");

--- a/examples/cylinder/cylinder_verify.cpp
+++ b/examples/cylinder/cylinder_verify.cpp
@@ -1105,9 +1105,9 @@ int main(int argc, char *argv[]) {
   if (grid_study_flag) {
     char file_name[128];
     if (orthotropic_flag) {
-      sprintf(file_name, "ortho_grid_study_order=%d_P=%d.dat", order, P);
+      snprintf(file_name, sizeof(file_name), "ortho_grid_study_order=%d_P=%d.dat", order, P);
     } else {
-      sprintf(file_name, "iso_grid_study_order=%d_P=%d.dat", order, P);
+      snprintf(file_name, sizeof(file_name), "iso_grid_study_order=%d_P=%d.dat", order, P);
     }
     meshStudy(file_name, P, transform, stiffness, load, R, L, alpha, beta,
               order, 8 - order);
@@ -1166,9 +1166,9 @@ int main(int argc, char *argv[]) {
 
   char file_name[128];
   if (orthotropic_flag) {
-    sprintf(file_name, "ortho_cylinder_func_order=%d_nx=%d.dat", order, nx);
+    snprintf(file_name, sizeof(file_name), "ortho_cylinder_func_order=%d_nx=%d.dat", order, nx);
   } else {
-    sprintf(file_name, "iso_cylinder_func_order=%d_nx=%d.dat", order, nx);
+    snprintf(file_name, sizeof(file_name), "iso_cylinder_func_order=%d_nx=%d.dat", order, nx);
   }
 
   FILE *fp = fopen(file_name, "w");

--- a/examples/four_bar_mechanism/four_bar_mechanism.cpp
+++ b/examples/four_bar_mechanism/four_bar_mechanism.cpp
@@ -400,7 +400,7 @@ int main(int argc, char *argv[]) {
   // Extra the data to a file
   for (int pt = 0; pt < 3; pt++) {
     char filename[128];
-    snprintf(filename, sizeof(file_name), "mid_beam_%d.dat", pt + 1);
+    snprintf(filename, sizeof(filename), "mid_beam_%d.dat", pt + 1);
     FILE *fp = fopen(filename, "w");
 
     fprintf(fp, "Variables = t, u0, v0, w0, quantity\n");

--- a/examples/four_bar_mechanism/four_bar_mechanism.cpp
+++ b/examples/four_bar_mechanism/four_bar_mechanism.cpp
@@ -400,7 +400,7 @@ int main(int argc, char *argv[]) {
   // Extra the data to a file
   for (int pt = 0; pt < 3; pt++) {
     char filename[128];
-    sprintf(filename, "mid_beam_%d.dat", pt + 1);
+    snprintf(filename, sizeof(file_name), "mid_beam_%d.dat", pt + 1);
     FILE *fp = fopen(filename, "w");
 
     fprintf(fp, "Variables = t, u0, v0, w0, quantity\n");

--- a/examples/stiffened_panel/skewed_plate.cpp
+++ b/examples/stiffened_panel/skewed_plate.cpp
@@ -303,7 +303,8 @@ int main(int argc, char *argv[]) {
     // Set the local variables
     tacs->setVariables(vec);
     char file_name[256];
-    snprintf(file_name, sizeof(file_name), "results/tacs_buckling_mode%02d.f5", k);
+    snprintf(file_name, sizeof(file_name), "results/tacs_buckling_mode%02d.f5",
+             k);
     f5->writeToFile(file_name);
   }
 

--- a/examples/stiffened_panel/skewed_plate.cpp
+++ b/examples/stiffened_panel/skewed_plate.cpp
@@ -303,7 +303,7 @@ int main(int argc, char *argv[]) {
     // Set the local variables
     tacs->setVariables(vec);
     char file_name[256];
-    sprintf(file_name, "results/tacs_buckling_mode%02d.f5", k);
+    snprintf(file_name, sizeof(file_name), "results/tacs_buckling_mode%02d.f5", k);
     f5->writeToFile(file_name);
   }
 
@@ -322,7 +322,7 @@ int main(int argc, char *argv[]) {
     // Set the local variables
     tacs->setVariables(vec);
     char file_name[256];
-    sprintf(file_name, "results/tacs_mode%02d.f5", k);
+    snprintf(file_name, sizeof(file_name), "results/tacs_mode%02d.f5", k);
     f5->writeToFile(file_name);
 
     if (rank == 0) {

--- a/examples/stiffened_panel/stiffened_panel.cpp
+++ b/examples/stiffened_panel/stiffened_panel.cpp
@@ -439,7 +439,7 @@ int main(int argc, char *argv[]) {
   //     // Set the local variables
   //     tacs->setVariables(vec);
   //     char file_name[256];
-  //     sprintf(file_name, "results/tacs_buckling_mode%02d.f5", k);
+  //     snprintf(file_name, sizeof(file_name), "results/tacs_buckling_mode%02d.f5", k);
   //     f5->writeToFile(file_name);
   //   }
 

--- a/examples/stiffened_panel/stiffened_panel.cpp
+++ b/examples/stiffened_panel/stiffened_panel.cpp
@@ -439,8 +439,8 @@ int main(int argc, char *argv[]) {
   //     // Set the local variables
   //     tacs->setVariables(vec);
   //     char file_name[256];
-  //     snprintf(file_name, sizeof(file_name), "results/tacs_buckling_mode%02d.f5", k);
-  //     f5->writeToFile(file_name);
+  //     snprintf(file_name, sizeof(file_name),
+  //     "results/tacs_buckling_mode%02d.f5", k); f5->writeToFile(file_name);
   //   }
 
   //   linear_buckling->decref();

--- a/src/TACSBuckling.cpp
+++ b/src/TACSBuckling.cpp
@@ -834,7 +834,7 @@ void TACSFrequencyAnalysis::solve(KSMPrint *ksm_print, int print_level) {
       t0 = MPI_Wtime() - t0;
 
       char line[256];
-      sprintf(line, "JD computational time: %15.6f\n", t0);
+      snprintf(line, sizeof(line), "JD computational time: %15.6f\n", t0);
       ksm_print->print(line);
     }
   } else {
@@ -880,7 +880,7 @@ void TACSFrequencyAnalysis::solve(KSMPrint *ksm_print, int print_level) {
       t0 = MPI_Wtime() - t0;
 
       char line[256];
-      sprintf(line, "Lanczos computational time: %15.6f\n", t0);
+      snprintf(line, sizeof(line), "Lanczos computational time: %15.6f\n", t0);
       ksm_print->print(line);
     }
   }

--- a/src/TACSContinuation.cpp
+++ b/src/TACSContinuation.cpp
@@ -310,7 +310,7 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
     if (ksm_print) {
       char line[256];
       ksm_print->print("Performing initial Newton iterations\n");
-      sprintf(line, "%5s %9s %10s\n", "Iter", "t", "|R|");
+      snprintf(line, sizeof(line), "%5s %9s %10s\n", "Iter", "t", "|R|");
       ksm_print->print(line);
     }
 
@@ -343,7 +343,7 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
       TacsScalar res_norm = res->norm();
       if (ksm_print) {
         char line[256];
-        sprintf(line, "%5d %9.4f %10.4e\n", k + 1, MPI_Wtime() - t0,
+        snprintf(line, sizeof(line), "%5d %9.4f %10.4e\n", k + 1, MPI_Wtime() - t0,
                 TacsRealPart(res_norm));
         ksm_print->print(line);
       }
@@ -469,10 +469,10 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
 
     if (ksm_print) {
       char line[256];
-      sprintf(line, "Outer iteration %3d: t: %9.4f dp_ds: %10.4e\n",
+      snprintf(line, sizeof(line), "Outer iteration %3d: t: %9.4f dp_ds: %10.4e\n",
               iteration_count, MPI_Wtime() - t0, TacsRealPart(dlambda_ds));
       ksm_print->print(line);
-      sprintf(line, "%5s %9s %10s %10s %10s\n", "Iter", "t", "|R|", "lambda",
+      snprintf(line, sizeof(line), "%5s %9s %10s %10s %10s\n", "Iter", "t", "|R|", "lambda",
               "|u|");
       ksm_print->print(line);
     }
@@ -507,7 +507,7 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
         TacsScalar res_norm = res->norm();
         if (ksm_print) {
           char line[256];
-          sprintf(line, "%5d %9.4f %10.3e %10.3e %10.3e\n", j, MPI_Wtime() - t0,
+          snprintf(line, sizeof(line), "%5d %9.4f %10.3e %10.3e %10.3e\n", j, MPI_Wtime() - t0,
                   TacsRealPart(res_norm), TacsRealPart(lambda),
                   TacsRealPart(vars->norm()));
           ksm_print->print(line);
@@ -542,7 +542,7 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
 
         if (ksm_print) {
           char line[256];
-          sprintf(line,
+          snprintf(line, sizeof(line),
                   "Failed to converge, retrying with step size = %10.3e\n",
                   TacsRealPart(delta_s));
           ksm_print->print(line);

--- a/src/TACSContinuation.cpp
+++ b/src/TACSContinuation.cpp
@@ -343,8 +343,8 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
       TacsScalar res_norm = res->norm();
       if (ksm_print) {
         char line[256];
-        snprintf(line, sizeof(line), "%5d %9.4f %10.4e\n", k + 1, MPI_Wtime() - t0,
-                TacsRealPart(res_norm));
+        snprintf(line, sizeof(line), "%5d %9.4f %10.4e\n", k + 1,
+                 MPI_Wtime() - t0, TacsRealPart(res_norm));
         ksm_print->print(line);
       }
       if (k == 0) {
@@ -469,11 +469,12 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
 
     if (ksm_print) {
       char line[256];
-      snprintf(line, sizeof(line), "Outer iteration %3d: t: %9.4f dp_ds: %10.4e\n",
-              iteration_count, MPI_Wtime() - t0, TacsRealPart(dlambda_ds));
+      snprintf(line, sizeof(line),
+               "Outer iteration %3d: t: %9.4f dp_ds: %10.4e\n", iteration_count,
+               MPI_Wtime() - t0, TacsRealPart(dlambda_ds));
       ksm_print->print(line);
-      snprintf(line, sizeof(line), "%5s %9s %10s %10s %10s\n", "Iter", "t", "|R|", "lambda",
-              "|u|");
+      snprintf(line, sizeof(line), "%5s %9s %10s %10s %10s\n", "Iter", "t",
+               "|R|", "lambda", "|u|");
       ksm_print->print(line);
     }
 
@@ -507,9 +508,9 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
         TacsScalar res_norm = res->norm();
         if (ksm_print) {
           char line[256];
-          snprintf(line, sizeof(line), "%5d %9.4f %10.3e %10.3e %10.3e\n", j, MPI_Wtime() - t0,
-                  TacsRealPart(res_norm), TacsRealPart(lambda),
-                  TacsRealPart(vars->norm()));
+          snprintf(line, sizeof(line), "%5d %9.4f %10.3e %10.3e %10.3e\n", j,
+                   MPI_Wtime() - t0, TacsRealPart(res_norm),
+                   TacsRealPart(lambda), TacsRealPart(vars->norm()));
           ksm_print->print(line);
         }
 
@@ -543,8 +544,8 @@ void TACSContinuation::solve_tangent(TACSMat *mat, TACSPc *pc, TACSKsm *ksm,
         if (ksm_print) {
           char line[256];
           snprintf(line, sizeof(line),
-                  "Failed to converge, retrying with step size = %10.3e\n",
-                  TacsRealPart(delta_s));
+                   "Failed to converge, retrying with step size = %10.3e\n",
+                   TacsRealPart(delta_s));
           ksm_print->print(line);
         }
       }

--- a/src/TACSIntegrator.cpp
+++ b/src/TACSIntegrator.cpp
@@ -35,7 +35,7 @@ TACSIntegrator::TACSIntegrator(TACSAssembler *_assembler, double tinit,
   assembler->incref();
 
   // Set the default prefix = results
-  sprintf(prefix, "./");
+  snprintf(prefix, sizeof(prefix), "./");
 
   // Allocate the total number of time steps
   num_time_steps = int(num_steps);

--- a/src/TACSMg.cpp
+++ b/src/TACSMg.cpp
@@ -692,8 +692,9 @@ void TACSMg::applyFactor(TACSVec *bvec, TACSVec *xvec) {
     if (monitor) {
       for (int k = 0; k < nlevels; k++) {
         char descript[128];
-        snprintf(descript, sizeof(descript), "TACSMg cumulative level %2d time %15.8e\n", k,
-                cumulative_level_time[k]);
+        snprintf(descript, sizeof(descript),
+                 "TACSMg cumulative level %2d time %15.8e\n", k,
+                 cumulative_level_time[k]);
         monitor->print(descript);
       }
     }

--- a/src/TACSMg.cpp
+++ b/src/TACSMg.cpp
@@ -692,7 +692,7 @@ void TACSMg::applyFactor(TACSVec *bvec, TACSVec *xvec) {
     if (monitor) {
       for (int k = 0; k < nlevels; k++) {
         char descript[128];
-        sprintf(descript, "TACSMg cumulative level %2d time %15.8e\n", k,
+        snprintf(descript, sizeof(descript), "TACSMg cumulative level %2d time %15.8e\n", k,
                 cumulative_level_time[k]);
         monitor->print(descript);
       }

--- a/src/bpmat/GSEP.cpp
+++ b/src/bpmat/GSEP.cpp
@@ -572,14 +572,14 @@ void SEP::solve(KSMPrint *ksm_print, KSMPrint *ksm_file) {
   // Print out a summary of the eigenvalues and errors
   if (ksm_print) {
     char line[256];
-    sprintf(line, "%3s %18s %18s %10s\n", " ", "eigenvalue", "shift-invert eig",
+    snprintf(line, sizeof(line), "%3s %18s %18s %10s\n", " ", "eigenvalue", "shift-invert eig",
             "error");
     ksm_print->print(line);
 
     for (int i = 0; i < niters; i++) {
       int index = perm[i];
       char line[256];
-      sprintf(line, "%3d %18.10e %18.10e %10.3e\n", i,
+      snprintf(line, sizeof(line), "%3d %18.10e %18.10e %10.3e\n", i,
               TacsRealPart(Op->convertEigenvalue(eigs[index])),
               TacsRealPart(eigs[index]),
               fabs(TacsRealPart(Beta[niters - 1] *
@@ -590,7 +590,7 @@ void SEP::solve(KSMPrint *ksm_print, KSMPrint *ksm_file) {
   // Print the iteration count to file
   if (ksm_file) {
     char line[256];
-    sprintf(line, "%2d\n", niters);
+    snprintf(line, sizeof(line), "%2d\n", niters);
     ksm_file->print(line);
   }
 }

--- a/src/bpmat/GSEP.cpp
+++ b/src/bpmat/GSEP.cpp
@@ -572,18 +572,18 @@ void SEP::solve(KSMPrint *ksm_print, KSMPrint *ksm_file) {
   // Print out a summary of the eigenvalues and errors
   if (ksm_print) {
     char line[256];
-    snprintf(line, sizeof(line), "%3s %18s %18s %10s\n", " ", "eigenvalue", "shift-invert eig",
-            "error");
+    snprintf(line, sizeof(line), "%3s %18s %18s %10s\n", " ", "eigenvalue",
+             "shift-invert eig", "error");
     ksm_print->print(line);
 
     for (int i = 0; i < niters; i++) {
       int index = perm[i];
       char line[256];
       snprintf(line, sizeof(line), "%3d %18.10e %18.10e %10.3e\n", i,
-              TacsRealPart(Op->convertEigenvalue(eigs[index])),
-              TacsRealPart(eigs[index]),
-              fabs(TacsRealPart(Beta[niters - 1] *
-                                eigvecs[index * niters + (niters - 1)] * er)));
+               TacsRealPart(Op->convertEigenvalue(eigs[index])),
+               TacsRealPart(eigs[index]),
+               fabs(TacsRealPart(Beta[niters - 1] *
+                                 eigvecs[index * niters + (niters - 1)] * er)));
       ksm_print->print(line);
     }
   }

--- a/src/bpmat/JacobiDavidson.cpp
+++ b/src/bpmat/JacobiDavidson.cpp
@@ -555,7 +555,7 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
 
   if (ksm_print && print_level > 0) {
     char line[256];
-    sprintf(line, "%4s %15s %15s %10s\n", "Iter", "JD Residual", "Ritz value",
+    snprintf(line, sizeof(line), "%4s %15s %15s %10s\n", "Iter", "JD Residual", "Ritz value",
             "toler");
     ksm_print->print(line);
   }
@@ -653,7 +653,7 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
 
       if (ksm_print && print_level > 0) {
         char line[256];
-        sprintf(line, "%4d %15.5e %15.5e %10.2e\n", iteration,
+        snprintf(line, sizeof(line), "%4d %15.5e %15.5e %10.2e\n", iteration,
                 TacsRealPart(w_norm), theta, toler);
         ksm_print->print(line);
       }
@@ -897,14 +897,14 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
     char line[256];
     for (int i = 0; i < nconverged; i++) {
       int index = eigindex[i];
-      sprintf(line, "Eigenvalue[%2d]: %25.10e Eig. error[%2d]: %25.10e\n", i,
+      snprintf(line, sizeof(line), "Eigenvalue[%2d]: %25.10e Eig. error[%2d]: %25.10e\n", i,
               TacsRealPart(eigvals[index]), i, TacsRealPart(eigerror[index]));
       ksm_print->print(line);
     }
 
-    sprintf(line, "JD number of outer iterations: %2d\n", iteration);
+    snprintf(line, sizeof(line), "JD number of outer iterations: %2d\n", iteration);
     ksm_print->print(line);
-    sprintf(line, "JD number of inner GMRES iterations: %2d\n",
+    snprintf(line, sizeof(line), "JD number of inner GMRES iterations: %2d\n",
             gmres_iteration);
     ksm_print->print(line);
   }

--- a/src/bpmat/JacobiDavidson.cpp
+++ b/src/bpmat/JacobiDavidson.cpp
@@ -555,8 +555,8 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
 
   if (ksm_print && print_level > 0) {
     char line[256];
-    snprintf(line, sizeof(line), "%4s %15s %15s %10s\n", "Iter", "JD Residual", "Ritz value",
-            "toler");
+    snprintf(line, sizeof(line), "%4s %15s %15s %10s\n", "Iter", "JD Residual",
+             "Ritz value", "toler");
     ksm_print->print(line);
   }
 
@@ -654,7 +654,7 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
       if (ksm_print && print_level > 0) {
         char line[256];
         snprintf(line, sizeof(line), "%4d %15.5e %15.5e %10.2e\n", iteration,
-                TacsRealPart(w_norm), theta, toler);
+                 TacsRealPart(w_norm), theta, toler);
         ksm_print->print(line);
       }
 
@@ -897,15 +897,17 @@ void TACSJacobiDavidson::solve(KSMPrint *ksm_print, int print_level) {
     char line[256];
     for (int i = 0; i < nconverged; i++) {
       int index = eigindex[i];
-      snprintf(line, sizeof(line), "Eigenvalue[%2d]: %25.10e Eig. error[%2d]: %25.10e\n", i,
-              TacsRealPart(eigvals[index]), i, TacsRealPart(eigerror[index]));
+      snprintf(line, sizeof(line),
+               "Eigenvalue[%2d]: %25.10e Eig. error[%2d]: %25.10e\n", i,
+               TacsRealPart(eigvals[index]), i, TacsRealPart(eigerror[index]));
       ksm_print->print(line);
     }
 
-    snprintf(line, sizeof(line), "JD number of outer iterations: %2d\n", iteration);
+    snprintf(line, sizeof(line), "JD number of outer iterations: %2d\n",
+             iteration);
     ksm_print->print(line);
     snprintf(line, sizeof(line), "JD number of inner GMRES iterations: %2d\n",
-            gmres_iteration);
+             gmres_iteration);
     ksm_print->print(line);
   }
 

--- a/src/bpmat/KSM.cpp
+++ b/src/bpmat/KSM.cpp
@@ -944,9 +944,9 @@ int GMRES::solve(TACSVec *b, TACSVec *x, int zero_guess) {
   if (monitor_time && monitor) {
     t_total = MPI_Wtime() - t_total;
     char str_mat[80], str_ort[80], str_tot[80];
-    sprintf(str_mat, "pc-mat time %10.6f\n", t_pc);
-    sprintf(str_ort, "ortho time  %10.6f\n", t_ortho);
-    sprintf(str_tot, "total time  %10.6f\n", t_total);
+    snprintf(str_mat, sizeof(str_mat), "pc-mat time %10.6f\n", t_pc);
+    snprintf(str_ort, sizeof(str_ort), "ortho time  %10.6f\n", t_ortho);
+    snprintf(str_tot, sizeof(str_tot), "total time  %10.6f\n", t_total);
     monitor->print(str_mat);
     monitor->print(str_ort);
     monitor->print(str_tot);

--- a/src/constitutive/TACSGPBladeStiffenedShellConstitutive.h
+++ b/src/constitutive/TACSGPBladeStiffenedShellConstitutive.h
@@ -198,21 +198,21 @@ class TACSGPBladeStiffenedShellConstitutive
   }
 
   // Retrieve the global design variable numbers
-  int getDesignVarNums(int elemIndex, int dvLen, int dvNums[]);
+  int getDesignVarNums(int elemIndex, int dvLen, int dvNums[]) override;
 
   // Set the element design variable from the design vector
-  int setDesignVars(int elemIndex, int dvLen, const TacsScalar dvs[]);
+  int setDesignVars(int elemIndex, int dvLen, const TacsScalar dvs[]) override;
 
   // Get the element design variables values
-  int getDesignVars(int elemIndex, int dvLen, TacsScalar dvs[]);
+  int getDesignVars(int elemIndex, int dvLen, TacsScalar dvs[]) override;
 
   // Get the lower and upper bounds for the design variable values
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
-                        TacsScalar ub[]);
+                        TacsScalar ub[]) override;
 
   // Retrieve the design variable for plotting purposes
   TacsScalar evalDesignFieldValue(int elemIndex, const double pt[],
-                                  const TacsScalar X[], int index);
+                                  const TacsScalar X[], int index) override;
 
   // set the KS weight for the failure constraints and the GP models (if GP
   // models are active)

--- a/src/constitutive/TACSPanelAnalysis.cpp
+++ b/src/constitutive/TACSPanelAnalysis.cpp
@@ -1717,7 +1717,7 @@ int TACSPanelAnalysis::computeBucklingLoads(TacsScalar Nx, TacsScalar Nxy,
     char *file_name = new char[file_len];
 
     for (int i = 0; i < nloads; i++) {
-      sprintf(file_name, "%sbuckling_mode%02d.dat", prefix, i);
+      snprintf(file_name, file_len, "%sbuckling_mode%02d.dat", prefix, i);
       printPanelMode(file_name, &eigvecs[nvars * i], 125);
     }
 
@@ -2176,7 +2176,7 @@ int TACSPanelAnalysis::computeFrequencies(TacsScalar freq[], int nfreq,
     char *file_name = new char[file_len];
 
     for (int i = 0; i < nfreq; i++) {
-      sprintf(file_name, "%spanel_mode%02d.dat", prefix, i);
+      snprintf(file_name, sizeof(file_name), "%spanel_mode%02d.dat", prefix, i);
       printPanelMode(file_name, &eigvecs[nvars * i], 125);
     }
 

--- a/src/elements/dynamics/MITC3.cpp
+++ b/src/elements/dynamics/MITC3.cpp
@@ -3068,7 +3068,7 @@ void MITC3::testStrain(const TacsScalar X[]) {
 
   // Write out the error components
   char descript[64];
-  sprintf(descript, "strain after rigid rotation");
+  snprintf(descript, sizeof(descript), "strain after rigid rotation");
   writeErrorComponents(stdout, descript, e, fd, 6);
 
   // Compute the bmatrix
@@ -3111,7 +3111,7 @@ void MITC3::testStrain(const TacsScalar X[]) {
 
     // Write out the error components
     char descript[64];
-    sprintf(descript, "B%d", k);
+    snprintf(descript, sizeof(descript), "B%d", k);
     writeErrorComponents(stdout, descript, &B[6 * k], fd, 6);
   }
 
@@ -3148,6 +3148,6 @@ void MITC3::testStrain(const TacsScalar X[]) {
   getStrain(&u, X, vars, fd);
 
   // Write out the error components of the strain
-  sprintf(descript, "strain before/after rigid rotation");
+  snprintf(descript, sizeof(descript), "strain before/after rigid rotation");
   writeErrorComponents(stdout, descript, e, fd, 6);
 }

--- a/src/elements/dynamics/MITC9.cpp
+++ b/src/elements/dynamics/MITC9.cpp
@@ -6142,7 +6142,7 @@ void MITC9::testStrain(const TacsScalar X[]) {
 
     // Write out the error components
     char descript[64];
-    sprintf(descript, "B%d", k);
+    snprintf(descript, sizeof(descript), "B%d", k);
     writeErrorComponents(stdout, descript, &B[8 * k], fd, 8);
   }
 }

--- a/src/elements/dynamics/TACSRigidBody.cpp
+++ b/src/elements/dynamics/TACSRigidBody.cpp
@@ -1517,7 +1517,7 @@ void TACSRigidBody::testJacobian(double dh, TacsScalar alpha, TacsScalar beta,
 
     // Print out the results to stdout
     char outname[128];
-    sprintf(outname, "Jacobian col %d", ii);
+    snprintf(outname, sizeof(outname), "Jacobian col %d", ii);
     writeErrorComponents(stdout, outname, res, fd, 8);
   }
 }

--- a/src/io/TACSMeshLoader.cpp
+++ b/src/io/TACSMeshLoader.cpp
@@ -1109,7 +1109,7 @@ TACSToFH5 *TACSMeshLoader::createTACSToFH5(TACSAssembler *tacs,
   for (int k = 0; k < num_components; k++) {
     if (strlen(&component_descript[33 * k]) == 0) {
       char name[64];
-      sprintf(name, "Component %d", k);
+      snprintf(name, sizeof(name), "Component %d", k);
       f5->setComponentName(k, name);
     } else {
       f5->setComponentName(k, &component_descript[33 * k]);

--- a/src/io/TACSToFH5.cpp
+++ b/src/io/TACSToFH5.cpp
@@ -66,7 +66,7 @@ TACSToFH5::TACSToFH5(TACSAssembler *_assembler, ElementType _elem_type,
 
   for (int k = 0; k < num_components; k++) {
     char comp_name[128];
-    sprintf(comp_name, "Component %d", k);
+    snprintf(comp_name, sizeof(comp_name), "Component %d", k);
     setComponentName(k, comp_name);
   }
 }
@@ -164,7 +164,7 @@ int TACSToFH5::writeToFile(const char *filename) {
     }
     for (; k < vars_per_node; k++) {
       char stemp[64];
-      sprintf(stemp, "v%d", k);
+      snprintf(stemp, sizeof(stemp), "v%d", k);
       str_len += strlen(stemp) + 1;
     }
     int nl = TacsGetOutputComponentCount(elem_type, TACS_OUTPUT_LOADS);
@@ -176,17 +176,16 @@ int TACSToFH5::writeToFile(const char *filename) {
     }
     for (; k < vars_per_node; k++) {
       char stemp[64];
-      sprintf(stemp, "f%d", k);
+      snprintf(stemp, sizeof(stemp), "f%d", k);
       str_len += strlen(stemp) + 1;
     }
 
     char *var_names = new char[str_len];
     var_names[0] = '\0';
     if (write_flag & TACS_OUTPUT_NODES) {
-      sprintf(var_names, "X,Y,Z");
+      snprintf(var_names, sizeof(var_names), "X,Y,Z");
     }
     if (write_flag & TACS_OUTPUT_DISPLACEMENTS) {
-      str_len = strlen(var_names);
       nd = TacsGetOutputComponentCount(elem_type, TACS_OUTPUT_DISPLACEMENTS);
       k = 0;
       for (; (k < nd && k < vars_per_node); k++) {
@@ -194,18 +193,17 @@ int TACSToFH5::writeToFile(const char *filename) {
             TacsGetOutputComponentName(elem_type, TACS_OUTPUT_DISPLACEMENTS, k);
         size_t len = strlen(var_names);
         if (k == 0 && !(write_flag & TACS_OUTPUT_NODES)) {
-          sprintf(&(var_names[len]), "%s", stemp);
+          snprintf(&(var_names[len]), str_len - len, "%s", stemp);
         } else {
-          sprintf(&(var_names[len]), ",%s", stemp);
+          snprintf(&(var_names[len]), str_len - len, ",%s", stemp);
         }
       }
       for (; k < vars_per_node; k++) {
         size_t len = strlen(var_names);
-        sprintf(&(var_names[len]), ",v%d", k);
+        snprintf(&(var_names[len]), str_len - len, ",v%d", k);
       }
     }
     if (write_flag & TACS_OUTPUT_LOADS) {
-      str_len = strlen(var_names);
       nl = TacsGetOutputComponentCount(elem_type, TACS_OUTPUT_LOADS);
       k = 0;
       for (; (k < nl && k < vars_per_node); k++) {
@@ -214,14 +212,14 @@ int TACSToFH5::writeToFile(const char *filename) {
         size_t len = strlen(var_names);
         if (k == 0 && !(write_flag & TACS_OUTPUT_NODES ||
                         write_flag & TACS_OUTPUT_DISPLACEMENTS)) {
-          sprintf(&(var_names[len]), "%s", stemp);
+          snprintf(&(var_names[len]), str_len - len, "%s", stemp);
         } else {
-          sprintf(&(var_names[len]), ",%s", stemp);
+          snprintf(&(var_names[len]), str_len - len, ",%s", stemp);
         }
       }
       for (; k < vars_per_node; k++) {
         size_t len = strlen(var_names);
-        sprintf(&(var_names[len]), ",f%d", k);
+        snprintf(&(var_names[len]), str_len - len, ",f%d", k);
       }
     }
 
@@ -324,7 +322,7 @@ int TACSToFH5::writeToFile(const char *filename) {
     // Write the data with a time stamp from the simulation in TACS
     char data_name[128];
     double t = assembler->getSimulationTime();
-    sprintf(data_name, "continuous data t=%.10e", t);
+    snprintf(data_name, sizeof(data_name), "continuous data t=%.10e", t);
     file->writeZoneData(data_name, var_names, TACSFH5File::FH5_FLOAT, dim1,
                         dim2, float_data);
     delete[] float_data;
@@ -351,7 +349,7 @@ int TACSToFH5::writeToFile(const char *filename) {
     // Write the data with a time stamp from the simulation in TACS
     char data_name[128];
     double t = assembler->getSimulationTime();
-    sprintf(data_name, "element data t=%.10e", t);
+    snprintf(data_name, sizeof(data_name), "element data t=%.10e", t);
     file->writeZoneData(data_name, variable_names, TACSFH5File::FH5_FLOAT, dim1,
                         dim2, float_data);
     delete[] float_data;
@@ -518,7 +516,7 @@ char *TACSToFH5::getElementVarNames(int flag) {
         for (int i = 1; i < nd; i++) {
           stemp = TacsGetOutputComponentName(elem_type, out_types[k], i);
           size_t len = strlen(temp);
-          sprintf(&(temp[len]), ",%s", stemp);
+          snprintf(&(temp[len]), str_len - len, ",%s", stemp);
         }
       }
       output_names[k] = temp;
@@ -550,7 +548,7 @@ char *TACSToFH5::getElementVarNames(int flag) {
   for (; k < 4; k++) {
     if (output_names[k]) {
       int len = strlen(elem_vars);
-      sprintf(&elem_vars[len], ",%s", output_names[k]);
+      snprintf(&elem_vars[len], elem_size - len, ",%s", output_names[k]);
     }
   }
 


### PR DESCRIPTION
Minor edit to replace all `sprintf` functions with safer `snprintf` in C++ code.