### PR TITLE
Update minimum supported OpenMDAO version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
 optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
-    "mphys": ["mphys>=2.0.0,<3.0.0", "openmdao>=3.27.0"],
+    "mphys": ["mphys>=2.0.0,<3.0.0", "openmdao>=3.28.0"],
     "caps2tacs": ["imageio>=2.16.1"],
 }
 

--- a/setup.py
+++ b/setup.py
@@ -104,7 +104,7 @@ with open(os.path.join(tacs_root, "README.md"), encoding="utf-8") as f:
 optional_dependencies = {
     "testing": ["testflo>=1.4.7"],
     "docs": ["sphinx", "breathe", "sphinxcontrib-programoutput"],
-    "mphys": ["mphys>=2.0.0,<3.0.0", "openmdao>=3.25.0"],
+    "mphys": ["mphys>=2.0.0,<3.0.0", "openmdao>=3.27.0"],
     "caps2tacs": ["imageio>=2.16.1"],
 }
 


### PR DESCRIPTION
The TACS MPhys wrapper uses the `always_opt` OpenMDAO component option, which was only [added](https://github.com/OpenMDAO/OpenMDAO/commit/fec0bc3a075ada90a0e5072be7730ca61c8c4283) to OpenMDAO in v3.27