### PR TITLE
removing numpy 2.0 upperbound

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 #pyproject.toml
 [build-system]
 # Minimum requirements for the build system to execute.
-requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=3.0.0', 'numpy>=1.25,<2.0.0',
+requires = ['setuptools>=45.0,<72.0', 'wheel', 'cython>=3.0.0', 'numpy>=1.25',
             # Build against an old version (3.1.5) of mpi4py for forward compatibility
             'mpi4py==3.1.5']

--- a/setup.py
+++ b/setup.py
@@ -127,7 +127,7 @@ setup(
     author_email="graeme.kennedy@ae.gatech.edu",
     python_requires=">=3.9.0",
     install_requires=[
-        "numpy<2.0.0",
+        "numpy",
         "mpi4py>=3.1.5,<4.0.0",
         "scipy>=1.2.1",
         "pynastran>=1.4.0",

--- a/tacs/mphys/functions.py
+++ b/tacs/mphys/functions.py
@@ -112,7 +112,8 @@ class TacsFunctions(om.ExplicitComponent):
             self._update_internal(inputs)
 
             for func_name in d_outputs:
-                d_func = d_outputs[func_name]
+                # Convert seed to scalar
+                d_func = d_outputs[func_name].item()
 
                 if "tacs_dvs" in d_inputs:
                     self.sp.addDVSens([func_name], [d_inputs["tacs_dvs"]], scale=d_func)
@@ -205,7 +206,8 @@ class MassFunctions(om.ExplicitComponent):
             self._update_internal(inputs)
 
             for func_name in d_outputs:
-                d_func = d_outputs[func_name]
+                # Convert seed to scalar
+                d_func = d_outputs[func_name].item()
 
                 if "tacs_dvs" in d_inputs:
                     self.sp.addDVSens([func_name], [d_inputs["tacs_dvs"]], scale=d_func)


### PR DESCRIPTION
I've tested numpy 2.0 and it works with pyNastran 1.5.0-dev, so I'm removing the version upperbound from the tacs requirements