### PR TITLE
Fixing bug with `StaticProblem`/`BucklingProblem` `setOption` method

### DIFF
--- a/tacs/problems/buckling.py
+++ b/tacs/problems/buckling.py
@@ -139,6 +139,8 @@ class BucklingProblem(TACSProblem):
 
         # Create problem-specific variables
         self._createVariables()
+        # Create solver objects
+        self._createSolver()
 
     def _createVariables(self):
         """
@@ -156,6 +158,9 @@ class BucklingProblem(TACSProblem):
         self.rhs = self.assembler.createVec()
         # Auxiliary element object for applying tractions/pressure
         self.auxElems = tacs.TACS.AuxElements()
+
+    def _createSolver(self):
+        """Internal to create the solver objects required by TACS"""
 
         self.aux = self.assembler.createSchurMat()
         self.G = self.assembler.createSchurMat()
@@ -226,7 +231,7 @@ class BucklingProblem(TACSProblem):
             pass
         # Reset solver for all other option changes
         else:
-            self._createVariables()
+            self._createSolver()
 
     def setValName(self, valName):
         """

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -128,6 +128,7 @@ class StaticProblem(TACSProblem):
         ],
     }
 
+    # TACS Jacobian coefficients for stiffness matrix
     ALPHA = 1.0
     BETA = 0.0
     GAMMA = 0.0

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -128,6 +128,10 @@ class StaticProblem(TACSProblem):
         ],
     }
 
+    ALPHA = 1.0
+    BETA = 0.0
+    GAMMA = 0.0
+
     def __init__(
         self,
         name,
@@ -178,6 +182,8 @@ class StaticProblem(TACSProblem):
 
         # Create problem-specific variables
         self._createVariables()
+        # Create solver objects
+        self._createSolver()
 
         # Setup solver and solver history objects for nonlinear problems
         if self.isNonlinear:
@@ -236,8 +242,6 @@ class StaticProblem(TACSProblem):
     def _createVariables(self):
         """Internal to create the variable required by TACS"""
 
-        opt = self.getOption
-
         # Generic residual vector
         self.res = self.assembler.createVec()
         self.rhs = self.assembler.createVec()
@@ -277,6 +281,14 @@ class StaticProblem(TACSProblem):
         # Load scaling factor
         self._loadScale = 1.0
 
+        # Additional Vecs for updates
+        self.update = self.assembler.createVec()
+
+    def _createSolver(self):
+        """Internal to create the solver objects required by TACS"""
+
+        opt = self.getOption
+
         # Tangent Stiffness --- process the ordering option here:
         ordering = opt("orderingType")
 
@@ -285,22 +297,14 @@ class StaticProblem(TACSProblem):
         # Artificial stiffness for RBE numerical stabilization to stabilize PC
         self.rbeArtificialStiffness = self.assembler.createSchurMat(ordering)
 
-        # Additional Vecs for updates
-        self.update = self.assembler.createVec()
-
-        # Setup PCScMat and KSM solver
-        self.alpha = 1.0
-        self.beta = 0.0
-        self.gamma = 0.0
-
         # Computes stiffness matrix w/o art. terms
         # Set artificial stiffness factors in rbe class to zero
         tacs.elements.RBE2.setScalingParameters(opt("RBEStiffnessScaleFactor"), 0.0)
         tacs.elements.RBE3.setScalingParameters(opt("RBEStiffnessScaleFactor"), 0.0)
         self.assembler.assembleJacobian(
-            self.alpha,
-            self.beta,
-            self.gamma,
+            self.ALPHA,
+            self.BETA,
+            self.GAMMA,
             self.res,
             self.K,
             loadScale=self.loadScale,
@@ -314,8 +318,9 @@ class StaticProblem(TACSProblem):
         tacs.elements.RBE3.setScalingParameters(
             opt("RBEStiffnessScaleFactor"), opt("RBEArtificialStiffness")
         )
+        # Setup PCScMat and KSM solver
         self.assembler.assembleJacobian(
-            self.alpha, self.beta, self.gamma, None, self.rbeArtificialStiffness
+            self.ALPHA, self.BETA, self.GAMMA, None, self.rbeArtificialStiffness
         )
         # Subtract full stiffness w/o artificial terms from full stiffness w/ terms
         # to isolate  artificial stiffness terms
@@ -397,7 +402,7 @@ class StaticProblem(TACSProblem):
         # Default setOption for common problem class objects
         TACSProblem.setOption(self, name, value)
 
-        createVariables = True
+        recreateSolver = True
 
         if self.linearSolver is not None:
             # Update tolerances
@@ -417,11 +422,11 @@ class StaticProblem(TACSProblem):
                 "outputdir",
                 "printLevel",
             ]:
-                createVariables = False
+                recreateSolver = False
 
             # Reset solver for all other option changes
-            if createVariables:
-                self._createVariables()
+            if recreateSolver:
+                self._createSolver()
 
     @property
     def loadScale(self):
@@ -1035,9 +1040,9 @@ class StaticProblem(TACSProblem):
         if self._jacobianUpdateRequired:
             # Assemble residual and stiffness matrix (w/o artificial terms)
             self.assembler.assembleJacobian(
-                self.alpha,
-                self.beta,
-                self.gamma,
+                self.ALPHA,
+                self.BETA,
+                self.GAMMA,
                 res,
                 self.K,
                 loadScale=self._loadScale,
@@ -1320,7 +1325,7 @@ class StaticProblem(TACSProblem):
             svSensBVecList = svSensList
 
         self.assembler.addSVSens(
-            funcHandles, svSensBVecList, self.alpha, self.beta, self.gamma
+            funcHandles, svSensBVecList, self.ALPHA, self.BETA, self.GAMMA
         )
 
         # Update from the BVec values, if the input was a numpy array

--- a/tests/integration_tests/test_shell_cylinder_quad.py
+++ b/tests/integration_tests/test_shell_cylinder_quad.py
@@ -62,5 +62,6 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         for problem in tacs_probs:
             problem.addFunction("mass", functions.StructuralMass)
             problem.addFunction("compliance", functions.Compliance)
+            problem.setOption("useMonitor", True)
 
         return tacs_probs, fea_assembler

--- a/tests/integration_tests/test_shell_plate_buckling_axial.py
+++ b/tests/integration_tests/test_shell_plate_buckling_axial.py
@@ -68,9 +68,9 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         fea_assembler.initialize(elem_call_back)
 
         buckle_prob = fea_assembler.createBucklingProblem("buckling", 10.0, 10)
+        buckle_prob.addLoadFromBDF(loadID=1)
         buckle_prob.setOption("L2Convergence", 1e-20)
         buckle_prob.setOption("L2ConvergenceRel", 1e-20)
-        buckle_prob.addLoadFromBDF(loadID=1)
 
         return [buckle_prob], fea_assembler
 


### PR DESCRIPTION
There's currently a bug in the `setOption` method that causes all saved loads and eval functions to be deleted if it is called after the loads and functions are added to the problem. This PR resolves the issue by splitting the variable object initialization from the solver initialization, so the solver can be updated after an option change with out zeroing out previously populated tacs objects and vectors