### PR TITLE
Some fixes for installing extern packages with latest CMake and GCC versions

### DIFF
--- a/Makefile.in.info
+++ b/Makefile.in.info
@@ -56,7 +56,7 @@ METIS_LIB = ${METIS_DIR}/lib/libmetis.a
 
 # AMD is a set of routines for ordering matrices, included in the SuiteSparse package. It is not required by default.
 
-# SUITESPARSE_DIR = ${TACS_DIR}/extern/SuiteSparse-7.0.1
+# SUITESPARSE_DIR = ${TACS_DIR}/extern/SuiteSparse-7.10.3
 # The variables below should not need to be altered if you are installing SuiteSparse from the standard release tarball
 
 # SUITESPARSE_CONFIG_DIR = ${SUITESPARSE_DIR}/SuiteSparse_config

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -126,7 +126,7 @@ If you already have these libraries installed, simply adjust the variables in ``
 Go to the directory ``tacs/extern``. Download ``metis-5.1.0`` from `<https://src.fedoraproject.org/lookaside/pkgs/metis/metis-5.1.0.tar.gz/5465e67079419a69e0116de24fce58fe/>`_ and place the file ``metis-5.1.0.tar.gz`` there.
 Note that METIS needs CMake to build and install.
 
-Optionally, you can also place ``SuiteSparse-5.13.0.tar.gz`` (available from `<https://github.com/DrTimothyAldenDavis/SuiteSparse/releases>`_) in the same directory if you want to use the approximate minimum degree ordering routines from SuiteSparse.
+Optionally, you can also place the tarball for latest version of SuiteSparse (e.g ``SuiteSparse-7.10.3.tar.gz`` available from `<https://github.com/DrTimothyAldenDavis/SuiteSparse/releases>`_) in the same directory if you want to use the approximate minimum degree ordering routines from SuiteSparse.
 
 Also optionally, place ``tecio.tgz`` (available from `<https://www.tecplot.com/products/tecio-library/>`_) in the same directory if you want to build ``f5totec``.
 Note that TecIO requires the boost library, which can be install with ``sudo apt-get install libboost-dev`` on debian systems.
@@ -223,7 +223,7 @@ We have successfully built TACS on the NASA High End Computing Capability system
 A number of changes are necessary to the default ``Makefile.in`` file:
 
 - If using intel compilers and one of the ``mpi-hpe`` modules, use ``CXX = icpc -lmpi``
-- To build a TACS binary that will work on all node types, use the optimization flags recommended in the `HECC documentation <https://www.nas.nasa.gov/hecc/support/kb/recommended-compiler-options_99.html>`_, ``-O3 -axCORE-AVX512,CORE-AVX2 -xAVX`` 
+- To build a TACS binary that will work on all node types, use the optimization flags recommended in the `HECC documentation <https://www.nas.nasa.gov/hecc/support/kb/recommended-compiler-options_99.html>`_, ``-O3 -axCORE-AVX512,CORE-AVX2 -xAVX``
 - If you run into issues related to OpenMP, add ``-qopenmp`` to the end of the `SO_LINK_FLAGS`` entry
 - To link to Intel's MKL in place of standard blas and lapack, replace the default ``LAPACK_LIBS`` line with:
 

--- a/extern/Makefile
+++ b/extern/Makefile
@@ -2,6 +2,19 @@ include ../Makefile.in
 
 EXTERN_DIR=${shell pwd}
 
+# --- CMake Version Check ---
+# If you have CMake>=4 then you need to set CMAKE_POLICY_VERSION_MINIMUM=3.5 for METIS to configure correctly.
+# This block checks the installed CMake version and sets CMAKE_POLICY_FLAG if the major version is 4 or greater. The
+# flag will be empty otherwise.
+# We redirect stderr to /dev/null to suppress errors if cmake is not found and then pass "version 0" to the rest of the
+# command to ensure the variable is set even if cmake is not installed.
+CMAKE_MAJOR_VERSION := $(shell (cmake --version 2>/dev/null || echo "version 0") | head -n 1 | awk '{print $$3}' | cut -d. -f1)
+
+# Conditionally set the flag. The shell command inside the if will execute.
+# If the condition [ ... ] is true, it echoes the flag; otherwise, it echoes nothing.
+CMAKE_POLICY_FLAG := $(shell if [ $(CMAKE_MAJOR_VERSION) -ge 4 ]; then echo "CMAKE_POLICY_VERSION_MINIMUM=3.5"; fi)
+# --- End CMake Version Check ---
+
 default: suitesparse tecio metis
 
 .phony: suitesparse
@@ -11,7 +24,7 @@ suitesparse: # Allowed to fail since SuiteSparse/AMD is optional
 .phony: metis
 metis:
 	tar -xzf metis*.tar.gz;
-	cd `ls -d metis-*/` && make config prefix=${METIS_DIR} CFLAGS="-O3 -fPIC" && make install;
+	cd `ls -d metis-*/` && make config prefix=${METIS_DIR} CFLAGS="-O3 -fPIC" ${CMAKE_POLICY_FLAG} && make install;
 
 .phony: tecio
 tecio: # Allowed to fail since TECIO is optional


### PR DESCRIPTION
Had some issues building TACS this morning because my computer had updated to GCC 15 and CMake 4:

- CMake 4 cannot configure projects that ask for CMake<3.5, METIS asks for 2.8, I added some code to the extern Makefile that will add the necessary flag to the METIS config command if you have CMake>=4
- Older versions of `SuiteSparse_config.h` include `omp.h` inside an `extern "C"` block, which tells the compiler to treat everything inside it as C code, not C++`. In GCC, `omp.h` now includes C++ templates so cannot be treated as C code. Updating to the latest release of SuiteSparse (7.10.3) fixed this. I updated the version mentioned in the docs and in the Makefile.in template