### PR TITLE
fixing bug in xpt sens for StiffenerLengthConstraint

### DIFF
--- a/tacs/constraints/stiffener_length.py
+++ b/tacs/constraints/stiffener_length.py
@@ -278,7 +278,7 @@ class StiffenerLengthConstraint(TACSConstraint):
         Examples
         --------
         >>> funcs = {}
-        >>> plConstraint.evalConstraints(funcs, 'LE_SPAR')
+        >>> plConstraint.evalConstraints(funcs, "LE_SPAR")
         >>> funcs
         >>> # Result will look like (if PanelLengthConstraint has name of 'c1'):
         >>> # {'c1_LE_SPAR': array([1.325, 2.1983645, 3.1415926, ...])}
@@ -324,7 +324,7 @@ class StiffenerLengthConstraint(TACSConstraint):
         Examples
         --------
         >>> funcsSens = {}
-        >>> adjConstraint.evalConstraintsSens(funcsSens, 'LE_SPAR')
+        >>> adjConstraint.evalConstraintsSens(funcsSens, "LE_SPAR")
         >>> funcsSens
         >>> # Result will look like (if AdjacencyConstraint has name of 'c1'):
         >>> # {'c1_LE_SPAR':{'struct':<50x242 sparse matrix of type '<class 'numpy.float64'>' with 100 stored elements in Compressed Sparse Row format>}}
@@ -433,12 +433,13 @@ class SparseLengthConstraint(object):
         array_like
             Constraint values (difference between DV lengths and exact lengths)
         """
-        Lexact = self._computeExactLength(Xpts)
+        dX = self._computeStiffenerVectors(Xpts)
+        Lexact = np.sqrt(np.sum(dX * dX, axis=1))
         Ldv = self._getDVLengths(x)
         Ldiff = Ldv - Lexact
         return Ldiff
 
-    def _computeExactLength(self, Xpts):
+    def _computeStiffenerVectors(self, Xpts):
         """
         Compute the exact geometric length of each stiffener.
 
@@ -461,9 +462,7 @@ class SparseLengthConstraint(object):
                         3 * localNodeID : 3 * localNodeID + 3
                     ]
         stiffenerEndLocations = self.comm.allreduce(stiffenerEndLocations)
-        dX = stiffenerEndLocations[:, 1, :] - stiffenerEndLocations[:, 0, :]
-        Lexact = np.sqrt(np.sum(dX * dX, axis=1))
-        return Lexact
+        return stiffenerEndLocations[:, 1, :] - stiffenerEndLocations[:, 0, :]
 
     def _getDVLengths(self, x):
         """
@@ -509,17 +508,7 @@ class SparseLengthConstraint(object):
         coordJacVals = []
         coordJacRows = []
         coordJacCols = []
-        # Need end node positions to form dX for the sensitivity
-        stiffenerEndLocations = np.zeros([self.nCon, 2, 3], dtype=self.dtype)
-        for con_i in range(self.nCon):
-            for end_j in range(2):
-                if self.allEndNodeOwnerProc[con_i, end_j] == self.comm.rank:
-                    localNodeID = self.allEndNodeLocalIDs[con_i, end_j]
-                    stiffenerEndLocations[con_i, end_j, :] = Xpts[
-                        3 * localNodeID : 3 * localNodeID + 3
-                    ]
-        stiffenerEndLocations = self.comm.allreduce(stiffenerEndLocations)
-        dX = stiffenerEndLocations[:, 1, :] - stiffenerEndLocations[:, 0, :]
+        dX = self._computeStiffenerVectors(Xpts)
         Lexact = np.sqrt(np.sum(dX * dX, axis=1))
 
         for con_i in range(self.nCon):

--- a/tacs/constraints/stiffener_length.py
+++ b/tacs/constraints/stiffener_length.py
@@ -509,7 +509,18 @@ class SparseLengthConstraint(object):
         coordJacVals = []
         coordJacRows = []
         coordJacCols = []
-        Lexact = self._computeExactLength(Xpts)
+        # Need end node positions to form dX for the sensitivity
+        stiffenerEndLocations = np.zeros([self.nCon, 2, 3], dtype=self.dtype)
+        for con_i in range(self.nCon):
+            for end_j in range(2):
+                if self.allEndNodeOwnerProc[con_i, end_j] == self.comm.rank:
+                    localNodeID = self.allEndNodeLocalIDs[con_i, end_j]
+                    stiffenerEndLocations[con_i, end_j, :] = Xpts[
+                        3 * localNodeID : 3 * localNodeID + 3
+                    ]
+        stiffenerEndLocations = self.comm.allreduce(stiffenerEndLocations)
+        dX = stiffenerEndLocations[:, 1, :] - stiffenerEndLocations[:, 0, :]
+        Lexact = np.sqrt(np.sum(dX * dX, axis=1))
 
         for con_i in range(self.nCon):
             # Sensitivity w.r.t. design variables (derivative = 1.0)
@@ -519,13 +530,13 @@ class SparseLengthConstraint(object):
                 dvJacCols.append(self.lengthLocalDVNums[con_i])
 
             # Sensitivity w.r.t. node coordinates
+            # d(Ldiff)/d(X_end1) = -dX/L,  d(Ldiff)/d(X_end0) = +dX/L
             for end_j in range(2):
                 if self.allEndNodeOwnerProc[con_i, end_j] == self.comm.rank:
                     localNodeID = self.allEndNodeLocalIDs[con_i, end_j]
-                    # Derivative of length w.r.t. node coordinates
-                    val = -Xpts[3 * localNodeID : 3 * localNodeID + 3] / Lexact[con_i]
+                    val = -dX[con_i] / Lexact[con_i]
                     if end_j == 0:
-                        val *= -1
+                        val = -val
                     coordJacVals.extend(val)
                     coordJacRows.extend([con_i, con_i, con_i])
                     coordJacCols.extend(

--- a/tests/integration_tests/input_files/beam_model_translated.bdf
+++ b/tests/integration_tests/input_files/beam_model_translated.bdf
@@ -1,0 +1,77 @@
+INIT MASTER(S)
+NASTRAN SYSTEM(442)=-1,SYSTEM(319)=1
+ID FEMAP,FEMAP
+SOL SESTATIC
+CEND
+  TITLE = Beam Test
+  ECHO = NONE
+  DISPLACEMENT(PLOT) = ALL
+  SPCFORCE(PLOT) = ALL
+  OLOAD(PLOT) = ALL
+  FORCE(PLOT,CORNER) = ALL
+  STRESS(PLOT,CORNER) = ALL
+SUBCASE 1
+  SUBTITLE = z-shear
+  SPC = 1
+  LOAD = 1
+SUBCASE 2
+  SUBTITLE = y-shear
+  SPC = 1
+  LOAD = 2
+SUBCASE 3
+  SUBTITLE = x-axial
+  SPC = 1
+  LOAD = 3
+SUBCASE 4
+  SUBTITLE = x-torsion
+  SPC = 1
+  LOAD = 4
+BEGIN BULK
+$ ***************************************************************************
+$   Written by : Femap
+$   Version    : 2021.1.0
+$   Translator : Simcenter Nastran
+$   From Model : 
+$   Date       : Wed Apr 20 10:23:42 2022
+$   Output To  : C:\Users\trbrooks\AppData\Local\Temp\3\
+$ ***************************************************************************
+$
+PARAM,PRGPST,YES
+PARAM,POST,-1
+PARAM,OGEOM,NO
+PARAM,AUTOSPC,YES
+PARAM,K6ROT,100.
+PARAM,GRDPNT,0
+CORD2C         1       0      0.      0.      0.      0.      0.      1.+FEMAPC1
++FEMAPC1      1.      0.      1.        
+CORD2S         2       0      0.      0.      0.      0.      0.      1.+FEMAPC2
++FEMAPC2      1.      0.      1.        
+$ Femap Load Set 1 : Shear
+FORCE          1       6       0      1.      0.      0.     1.0
+$ Femap Load Set 2 : y-shear
+FORCE          2       6       0      1.      0.     1.0      0.
+$ Femap Load Set 3 : x-axial
+FORCE          3       6       0      1.     1.0      0.      0.
+$ Femap Load Set 4 : x-torsion
+MOMENT         4       6       0      1.     1.0      0.      0.
+$ Femap Constraint Set 1 : Case 1
+SPC1           1  123456       1
+$ Femap Property 1 : Beam
+PBAR           1       1      .1      .2      .3      .4      0.        +
++             0.      0.      0.      0.      0.      0.      0.      0.+
++                             .1
+$ Femap Material 1 : Aluminum
+MAT1           1     1.0              .3     2.7      0.      0.        +
++          0.027
+GRID           1       0      1.      1.     -1.       0
+GRID           2       0     1.2      1.     -1.       0
+GRID           3       0     1.4      1.     -1.       0
+GRID           4       0     1.6      1.     -1.       0
+GRID           5       0     1.8      1.     -1.       0
+GRID           6       0      2.      1.     -1.       0
+CBAR           1       1       1       2      0.      1.      0.
+CBAR           2       1       2       3      0.      1.      0.
+CBAR           3       1       3       4      0.      1.      0.
+CBAR           4       1       4       5      0.      1.      0.
+CBAR           5       1       5       6      0.      1.      0.
+ENDDATA e0194509

--- a/tests/integration_tests/test_rectangle_beam_buckling.py
+++ b/tests/integration_tests/test_rectangle_beam_buckling.py
@@ -17,7 +17,7 @@ We also apply a constraint on the beam length using the stiffener length constra
 """
 
 base_dir = os.path.dirname(os.path.abspath(__file__))
-bdf_file = os.path.join(base_dir, "./input_files/beam_model.bdf")
+bdf_file = os.path.join(base_dir, "./input_files/beam_model_translated.bdf")
 
 ksweight = 10.0
 


### PR DESCRIPTION
The node coordinate sensitivities in SparseLengthConstraint.evalConSens were computed using raw node coordinates instead of the displacement vector dX = X_end1 - X_end0. The correct derivative of L = |dX| w.r.t. an end node position requires dX/L, not the node's absolute position. This produced wrong gradients whenever the stiffener was not centered at the origin.

The existing gradient check in test_rectangle_beam_buckling.py failed to catch this because the test mesh (beam_model_translated.bdf) had one of the end nodes located at (0, 0, 0) and so the error canceled out. Updated the example mesh so that issue won't be missed in future.