### PR TITLE
Fix sign error in B matrix export for PSHELL cards

### DIFF
--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -934,12 +934,12 @@ cdef class ShellConstitutive(Constitutive):
 
         # MAT2 entry for coupling stiffness (the B matrix)
         matProps.append(MAT2MaterialProperties(
-                E1=np.real(B[0] / t2),
-                G12=np.real(B[1] / t2),
-                G13=np.real(B[2] / t2),
-                E2=np.real(B[3] / t2),
-                G23=np.real(B[4] / t2),
-                E3=np.real(B[5] / t2),
+                E1=-np.real(B[0] / t2),
+                G12=-np.real(B[1] / t2),
+                G13=-np.real(B[2] / t2),
+                E2=-np.real(B[3] / t2),
+                G23=-np.real(B[4] / t2),
+                E3=-np.real(B[5] / t2),
                 rho=np.real(rho)
             )
         )

--- a/tacs/constitutive.pyx
+++ b/tacs/constitutive.pyx
@@ -933,6 +933,7 @@ cdef class ShellConstitutive(Constitutive):
         )
 
         # MAT2 entry for coupling stiffness (the B matrix)
+        # NASTRAN uses the opposite sign convention for the B matrix so we export the negative of the TACS B matrix
         matProps.append(MAT2MaterialProperties(
                 E1=-np.real(B[0] / t2),
                 G12=-np.real(B[1] / t2),


### PR DESCRIPTION
Nastran uses a negative sign convention for the shell coupling terms (a.k.a the B matrix) compared to TACS
<img width="1746" height="1379" alt="image" src="https://github.com/user-attachments/assets/21eaf8bc-6b5b-4f8d-8988-1473c5d1451c" />

In the general shell property BDF export implemented in #387, we use MAT2 cards to export the A, B, D matrices more or less directly. However we didn't account for the negative sign on the B matrix, leading to incorrect results when a TACS model is written to a BDF file and analysed using Nastran.

For example, the `stiffened_plate` example subjects a blade stiffened panel to purely in-plane compression and shear loads, because of the offset of the stiffeners, the B matrix of the shell is non-zero, leading to out of plane deformations:

<img width="2833" height="1618" alt="image" src="https://github.com/user-attachments/assets/26a51f17-4b09-4e59-af36-926a95f6f27b" />

Previously, when analysed in Nastran, the vertical deformation of the plate is in the opposite direction:
<img width="1535" height="651" alt="image" src="https://github.com/user-attachments/assets/8f557de6-84f9-4a3a-84ec-3ed6d60656e8" />

With the change in this PR, the plate deforms correctly:
<img width="1535" height="651" alt="image" src="https://github.com/user-attachments/assets/6c74a787-01b1-4565-8ff7-2fc4ef810f17" />

