### PR TITLE
Make LP constraint mask across ranks consistent, return explicit zero xpt sens array, update tests

### DIFF
--- a/tacs/constraints/lam_param_full.py
+++ b/tacs/constraints/lam_param_full.py
@@ -333,19 +333,25 @@ class LamParamFullConstraint(TACSConstraint):
         # Otherwise, output them all
         evalCons = self._processEvalCons(evalCons)
 
-        if includeDVSens:
-            # Get number of nodes coords on this proc
-            nCoords = self.getNumCoordinates()
-
-            # Loop through each requested constraint set
-            for conName in evalCons:
-                key = f"{self.name}_{conName}"
+        # Loop through each requested constraint set
+        for conName in evalCons:
+            key = f"{self.name}_{conName}"
+            funcsSens[key] = {}
+            if includeDVSens:
                 # Get sparse Jacobian for dv sensitivity
-                funcsSens[key] = {}
                 funcsSens[key][self.varName] = (
                     self.constraintList[conName]
                     .evalConSens(self.x.getArray())
                     .toarray()
+                )
+
+            if includeXptSens:
+                # Nodal sensitivities are always zero for this constraint.
+                # Add an empty sparse matrix
+                nCoords = self.getNumCoordinates()
+                nCon = self.constraintList[conName].nCon
+                funcsSens[key][self.coordName] = sp.sparse.csr_matrix(
+                    (nCon, nCoords), dtype=self.dtype
                 )
 
 

--- a/tacs/constraints/lam_param_full.py
+++ b/tacs/constraints/lam_param_full.py
@@ -433,7 +433,9 @@ class SparseLamParamFullConstraint(object):
         # row_nnz is length nComps * nLP
         rowNnz = np.diff(self.A_lp.indptr)
         # Get a boolean array of shape (nComps, nLP) indicating presence
-        self.present = rowNnz.reshape(self.nComps, self.nLP) > 0
+        # Allreduce so that ranks owning no DVs still know which LP slots are
+        # globally occupied.
+        self.present = comm.allreduce(rowNnz.reshape(self.nComps, self.nLP)) > 0
 
         # Save bound information (apply to each constraint)
         if isinstance(lb, np.ndarray) and len(lb) == self.nCon:

--- a/tests/integration_tests/test_shell_comp_lam_param_full.py
+++ b/tests/integration_tests/test_shell_comp_lam_param_full.py
@@ -57,6 +57,7 @@ class ProblemTest(PyTACSTestCase.PyTACSTest):
         "pressure_x_disp": -7.438494264988578e-16,
         "pressure_y_disp": -7.438494264988578e-16,
         "pressure_z_disp": 0.17668717737166387,
+        "lam_param_con_full_ALL": np.array([0.12, 0.72, 1.296]),
     }
 
     def setup_tacs_problems(self, comm):


### PR DESCRIPTION
## Description
This pull request makes several improvements to the LP full constraint
* updated `evalConstraintsSens` to always include nodal sensitivity outputs (empty sparse matrix) for constraints, explicitly indicating zero nodal sensitivities. 
* make sure that all ranks have a consistent view of which local parameter (LP) slots are globally occupied. Updated the construction of the `self.present` boolean array to use `comm.allreduce`, ensuring all MPI ranks are aware of globally occupied LP slots, not just those with local DVs.

The integration tests are also updated to include the `lam_param_con_full_ALL` output, reflecting changes to the constraint evaluation logic.
