### PR TITLE
Use externalForce vector for load norm and BDF load export in StaticProblem

### DIFF
--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -925,12 +925,13 @@ class StaticProblem(TACSProblem):
         # Get current residual
         self.getResidual(self.res, Fext=Fext)
 
-        # Get rhs vector
-        self.K.mult(self.u, self.rhs)
-        self.rhs.axpy(-1.0, self.res)
-
-        # Set initnorm as the norm of rhs
-        self.initNorm = np.real(self.rhs.norm())
+        # Compute the internal and external force components of the residual at the current point
+        self.getForces(
+            externalForceVec=self.externalForce,
+            internalForceVec=self.internalForce,
+            Fext=Fext,
+        )
+        self.initNorm = np.real(self.externalForce.norm())
 
         # Starting Norm for this computation
         self.startNorm = np.real(self.res.norm())
@@ -1939,7 +1940,7 @@ class StaticProblem(TACSProblem):
         """
 
         # Grab RHS vector from previous solve
-        F = self.rhs
+        F = self.externalForce
         F_array = np.real(F.getArray())
 
         # Get local force info for each processor

--- a/tacs/problems/static.py
+++ b/tacs/problems/static.py
@@ -872,6 +872,14 @@ class StaticProblem(TACSProblem):
 
         initSolveTime = time.time()
 
+        # Compute the internal and external force components of the residual at the current point
+        self.getForces(
+            externalForceVec=self.externalForce,
+            internalForceVec=self.internalForce,
+            Fext=Fext,
+        )
+        self.initNorm = np.real(self.externalForce.norm())
+
         if self.isNonlinear:
             hasConverged = self._solveNonlinear(Fext)
         else:
@@ -925,14 +933,6 @@ class StaticProblem(TACSProblem):
         # Get current residual
         self.getResidual(self.res, Fext=Fext)
 
-        # Compute the internal and external force components of the residual at the current point
-        self.getForces(
-            externalForceVec=self.externalForce,
-            internalForceVec=self.internalForce,
-            Fext=Fext,
-        )
-        self.initNorm = np.real(self.externalForce.norm())
-
         # Starting Norm for this computation
         self.startNorm = np.real(self.res.norm())
 
@@ -971,14 +971,6 @@ class StaticProblem(TACSProblem):
         bool
             Flag indicating whether the solver converged
         """
-        # Compute the internal and external force components of the residual at the current point
-        self.getForces(
-            externalForceVec=self.externalForce,
-            internalForceVec=self.internalForce,
-            Fext=Fext,
-        )
-        self.initNorm = np.real(self.externalForce.norm())
-
         if self.getOption("writeNLIterSolutions"):
             self.writeSolution(baseName=f"{self.name}-000-NLIter", number=0)
 


### PR DESCRIPTION
- Replaces the manual K·u - res computation used to initialize the solver convergence norm with a call to getForces(), which cleanly separates the external and internal force components of the residual
- Uses externalForce.norm() as initNorm instead of the previously computed rhs norm, making the convergence criterion more physically meaningful (normalized against the applied load magnitude)
- Updates writeLoadToBDF to pull the load vector from self.externalForce rather than self.rhs, which more correctly represents the externally applied loads rather than the solver RHS (which could include solver-internal modifications)