### PR TITLE
Refactor ply stress and strain transformations

### DIFF
--- a/src/constitutive/TACSMaterialProperties.cpp
+++ b/src/constitutive/TACSMaterialProperties.cpp
@@ -1873,46 +1873,40 @@ void TACSOrthotropicPly::printProperties() {
   printf("F66  = %15.5e \n", TacsRealPart(F66));
 }
 
-// First, the stress transformations
-// Transform stress from the global to the local frame
-void TACSOrthotropicPly::transformStressGlobal2Ply(TacsScalar angle,
-                                                   const TacsScalar global[],
-                                                   TacsScalar plyStress[]) {
-  TacsScalar cos1 = cos(angle);
-  TacsScalar sin1 = sin(angle);
+// Compute out = T(angle) * in
+void TACSOrthotropicPly::applyTransform(const TacsScalar angle,
+                                        const TacsScalar in[],
+                                        TacsScalar out[]) {
+  const TacsScalar cos1 = cos(angle);
+  const TacsScalar sin1 = sin(angle);
 
-  TacsScalar cos2 = cos1 * cos1;
-  TacsScalar sin2 = sin1 * sin1;
+  const TacsScalar cos2 = cos1 * cos1;
+  const TacsScalar sin2 = sin1 * sin1;
 
-  plyStress[0] =
-      cos2 * global[0] + sin2 * global[1] + 2.0 * sin1 * cos1 * global[2];
-  plyStress[1] =
-      sin2 * global[0] + cos2 * global[1] - 2.0 * sin1 * cos1 * global[2];
-  plyStress[2] =
-      sin1 * cos1 * (-global[0] + global[1]) + (cos2 - sin2) * global[2];
+  out[0] = cos2 * in[0] + sin2 * in[1] + 2.0 * sin1 * cos1 * in[2];
+  out[1] = sin2 * in[0] + cos2 * in[1] - 2.0 * sin1 * cos1 * in[2];
+  out[2] = sin1 * cos1 * (-in[0] + in[1]) + (cos2 - sin2) * in[2];
 }
 
-// Transform stress from the ply frame to the global frame
-void TACSOrthotropicPly::transformStressPly2Global(TacsScalar angle,
-                                                   const TacsScalar plyStress[],
-                                                   TacsScalar global[]) {
-  TacsScalar cos1 = cos(angle);
-  TacsScalar sin1 = sin(angle);
+// Compute out = T(angle)^T * in
+void TACSOrthotropicPly::applyTransformTranspose(const TacsScalar angle,
+                                                 const TacsScalar in[],
+                                                 TacsScalar out[]) {
+  const TacsScalar cos1 = cos(angle);
+  const TacsScalar sin1 = sin(angle);
 
-  TacsScalar cos2 = cos1 * cos1;
-  TacsScalar sin2 = sin1 * sin1;
+  const TacsScalar cos2 = cos1 * cos1;
+  const TacsScalar sin2 = sin1 * sin1;
 
-  global[0] = cos2 * plyStress[0] + sin2 * plyStress[1] -
-              2.0 * sin1 * cos1 * plyStress[2];
-  global[1] = sin2 * plyStress[0] + cos2 * plyStress[1] +
-              2.0 * sin1 * cos1 * plyStress[2];
-  global[2] = sin1 * cos1 * (plyStress[0] - plyStress[1]) +
-              (cos2 - sin2) * plyStress[2];
+  out[0] = cos2 * in[0] + sin2 * in[1] + sin1 * cos1 * in[2];
+  out[1] = sin2 * in[0] + cos2 * in[1] - sin1 * cos1 * in[2];
+  out[2] = 2.0 * sin1 * cos1 * (in[1] - in[0]) + (cos2 - sin2) * in[2];
 }
 
-// The sensitivity of the transformation of
+// Stress transformation angle sensitivities
+// ------------------------------------------
 void TACSOrthotropicPly::transformStressGlobal2PlyAngleSens(
-    TacsScalar angle, const TacsScalar global[], TacsScalar plyStress[]) {
+    const TacsScalar angle, const TacsScalar global[], TacsScalar plyStress[]) {
   TacsScalar cos1 = cos(angle);
   TacsScalar sin1 = sin(angle);
 
@@ -1928,9 +1922,8 @@ void TACSOrthotropicPly::transformStressGlobal2PlyAngleSens(
       s_sincos * (global[1] - global[0]) + (s_cos2 - s_sin2) * global[2];
 }
 
-// Transform stress from the ply frame to the global frame
 void TACSOrthotropicPly::transformStressPly2GlobalAngleSens(
-    TacsScalar angle, const TacsScalar plyStress[], TacsScalar global[]) {
+    const TacsScalar angle, const TacsScalar plyStress[], TacsScalar global[]) {
   TacsScalar cos1 = cos(angle);
   TacsScalar sin1 = sin(angle);
 
@@ -1946,44 +1939,10 @@ void TACSOrthotropicPly::transformStressPly2GlobalAngleSens(
               (s_cos2 - s_sin2) * plyStress[2];
 }
 
-// Next, the strain transformations
-// Transform strain from the global to the local frame
-void TACSOrthotropicPly::transformStrainGlobal2Ply(TacsScalar angle,
-                                                   const TacsScalar global[],
-                                                   TacsScalar plyStrain[]) {
-  TacsScalar cos1 = cos(angle);
-  TacsScalar sin1 = sin(angle);
-
-  TacsScalar cos2 = cos1 * cos1;
-  TacsScalar sin2 = sin1 * sin1;
-
-  plyStrain[0] = cos2 * global[0] + sin2 * global[1] + sin1 * cos1 * global[2];
-  plyStrain[1] = sin2 * global[0] + cos2 * global[1] - sin1 * cos1 * global[2];
-  plyStrain[2] =
-      2.0 * sin1 * cos1 * (global[1] - global[0]) + (cos2 - sin2) * global[2];
-}
-
-// Transform stress from the ply frame to the global frame
-void TACSOrthotropicPly::transformStrainPly2Global(TacsScalar angle,
-                                                   const TacsScalar plyStrain[],
-                                                   TacsScalar global[]) {
-  TacsScalar cos1 = cos(angle);
-  TacsScalar sin1 = sin(angle);
-
-  TacsScalar cos2 = cos1 * cos1;
-  TacsScalar sin2 = sin1 * sin1;
-
-  global[0] =
-      cos2 * plyStrain[0] + sin2 * plyStrain[1] - sin1 * cos1 * plyStrain[2];
-  global[1] =
-      sin2 * plyStrain[0] + cos2 * plyStrain[1] + sin1 * cos1 * plyStrain[2];
-  global[2] = 2.0 * sin1 * cos1 * (plyStrain[0] - plyStrain[1]) +
-              (cos2 - sin2) * plyStrain[2];
-}
-
-// The sensitivity of the transformation to the
+// Strain transformation angle sensitivities
+// ------------------------------------------
 void TACSOrthotropicPly::transformStrainGlobal2PlyAngleSens(
-    TacsScalar angle, const TacsScalar global[], TacsScalar plyStrain[]) {
+    const TacsScalar angle, const TacsScalar global[], TacsScalar plyStrain[]) {
   TacsScalar cos1 = cos(angle);
   TacsScalar sin1 = sin(angle);
 
@@ -1997,9 +1956,8 @@ void TACSOrthotropicPly::transformStrainGlobal2PlyAngleSens(
       2.0 * s_sincos * (-global[0] + global[1]) + (s_cos2 - s_sin2) * global[2];
 }
 
-// Transform stress from the ply frame to the global frame
 void TACSOrthotropicPly::transformStrainPly2GlobalAngleSens(
-    TacsScalar angle, const TacsScalar plyStrain[], TacsScalar global[]) {
+    const TacsScalar angle, const TacsScalar plyStrain[], TacsScalar global[]) {
   TacsScalar cos1 = cos(angle);
   TacsScalar sin1 = sin(angle);
 

--- a/src/constitutive/TACSMaterialProperties.cpp
+++ b/src/constitutive/TACSMaterialProperties.cpp
@@ -1049,7 +1049,7 @@ TacsScalar TACSOrthotropicPly::failureStrainSens(TacsScalar angle,
     TacsScalar sSens[3];
     getPlyStress(sens, sSens);
 
-    transformStressPly2Global(angle, sSens, sens);
+    transformStrainSensPly2Global(angle, sSens, sens);
   } else if (failureCriterion == CUNTZE_UD) {
     TacsScalar s[3];  // Ply stress
     getPlyStress(e, s);
@@ -1114,7 +1114,7 @@ TacsScalar TACSOrthotropicPly::failureStrainSens(TacsScalar angle,
     TacsScalar sSens[3];
     getPlyStress(sens, sSens);
 
-    transformStressPly2Global(angle, sSens, sens);
+    transformStrainSensPly2Global(angle, sSens, sens);
 
   } else if (failureCriterion == CUNTZE_WOVEN) {
     TacsScalar s[3];  // Ply stress
@@ -1188,7 +1188,7 @@ TacsScalar TACSOrthotropicPly::failureStrainSens(TacsScalar angle,
     TacsScalar sSens[3];
     getPlyStress(sens, sSens);
 
-    transformStressPly2Global(angle, sSens, sens);
+    transformStrainSensPly2Global(angle, sSens, sens);
 
   } else if (failureCriterion == MAX_STRAIN) {
     // Calculate the values of each of the failure criteria
@@ -1220,7 +1220,7 @@ TacsScalar TACSOrthotropicPly::failureStrainSens(TacsScalar angle,
     sSens[1] = (fexp[2] * eYc - fexp[3] * eYt) / (ksSum * eYt * eYc);
     sSens[2] = (fexp[4] - fexp[5]) / (ksSum * eS12);
 
-    transformStressPly2Global(angle, sSens, sens);
+    transformStrainSensPly2Global(angle, sSens, sens);
   }
 
   return fail;
@@ -1691,8 +1691,8 @@ TacsScalar TACSOrthotropicPly::calculateFailLoadStrainSens(
   getPlyStress(cSens, cstrSens);
   getPlyStress(lSens, lstrSens);
 
-  transformStressPly2Global(angle, cstrSens, cSens);
-  transformStressPly2Global(angle, lstrSens, lSens);
+  transformStrainSensPly2Global(angle, cstrSens, cSens);
+  transformStrainSensPly2Global(angle, lstrSens, lSens);
 
   return pos;
 }

--- a/src/constitutive/TACSMaterialProperties.h
+++ b/src/constitutive/TACSMaterialProperties.h
@@ -263,50 +263,49 @@ class TACSOrthotropicPly : public TACSObject {
 
   // Transform the stress and strain between global/local frames
   // -----------------------------------------------------------
-/*
-  For a ply at an angle t, the stress in the local ply frame is computed from
-  the stress in the global frame as:
+  /*
+    For a ply at an angle t, the stress in the local ply frame is computed from
+    the stress in the global frame as:
 
-  s_local = T(t) * s_global
+    s_local = T(t) * s_global
 
-  where T is the transformation matrix:
+    where T is the transformation matrix:
 
-  T(t) =
-      [c^2  s^2        2*s*c ]
-      [s^2  c^2        -2*s*c]
-      [s*c (c^2 - s^2) s*c   ]
+    T(t) =
+        [c^2  s^2        2*s*c ]
+        [s^2  c^2        -2*s*c]
+        [s*c (c^2 - s^2) s*c   ]
 
-  where c = cos(t) and s = sin(t)
+    where c = cos(t) and s = sin(t)
 
-  The strain in the local ply frame is computed from the transposed
-  transformation matrix (because we use engineering shear strain rather than
-  tensorial shear strain):
+    The strain in the local ply frame is computed from the transposed
+    transformation matrix (because we use engineering shear strain rather than
+    tensorial shear strain):
 
-  e_local = T(t)^T * e_global
+    e_local = T(t)^T * e_global
 
-  The transformation from the local ply frame to the global frame can be
-  computed by simply replacing t with -t in the transformation matrix:
+    The transformation from the local ply frame to the global frame can be
+    computed by simply replacing t with -t in the transformation matrix:
 
-  s_global = T(-t) * s_local
+    s_global = T(-t) * s_local
 
-  e_global = T(-t)^T * e_local
+    e_global = T(-t)^T * e_local
 
-  Sensitivities w.r.t local or global stresses and strains can be transformed
-  using the transpose of the relevant transformation matrix, e.g:
+    Sensitivities w.r.t local or global stresses and strains can be transformed
+    using the transpose of the relevant transformation matrix, e.g:
 
-  e_local = T(t)^T * e_global
-  e_global = T(-t)^T * e_local
-  df/de_local = T(t) * df/de_global
-  df/de_global = T(-t) * df/de_local
-*/
+    e_local = T(t)^T * e_global
+    e_global = T(-t)^T * e_local
+    df/de_local = T(t) * df/de_global
+    df/de_global = T(-t) * df/de_local
+  */
 
   // Generic transformations
   // -----------------------
   /**
-   * @brief Compute out = T(angle) * in, where T is the transformation matrix
-   * described in the class docstring
+   * @brief Compute out = T(angle) * in
    *
-   * @param angle Angle between ply and global frame in radians
+   * @param angle Transformation angle
    * @param in 3-component input vector
    * @param out 3-component output vector
    */
@@ -314,10 +313,9 @@ class TACSOrthotropicPly : public TACSObject {
                              TacsScalar out[]);
 
   /**
-   * @brief Compute out = T(angle)^T * in, where T is the transformation matrix
-   * described in the class docstring
+   * @brief Compute out = T(angle)^T * in
    *
-   * @param angle Angle between ply and global frame in radians
+   * @param angle Transformation angle
    * @param in 3-component input vector
    * @param out 3-component output vector
    */
@@ -439,9 +437,8 @@ class TACSOrthotropicPly : public TACSObject {
   // Strain sensitivity transformations
   // ----------------------------------
   /**
-   * @brief Given the sensitivity of a function with respect to the strain in
-   * the global frame, determine the sensitivity with respect to the strain in
-   * the local ply frame
+   * @brief Transform a sensitivity w.r.t the global strain to a sensitivity
+   * w.r.t the ply strain
    *
    * @param angle Angle between ply and global frame in radians
    * @param globalStrainSens Sensitivity w.r.t. strain in the global frame
@@ -456,9 +453,8 @@ class TACSOrthotropicPly : public TACSObject {
   }
 
   /**
-   * @brief Given the sensitivity of a function with respect to the strain in
-   * the local ply frame, determine the sensitivity with respect to the strain
-   * in the global frame
+   * @brief Transform a sensitivity w.r.t the ply strain to a sensitivity w.r.t
+   * the global strain
    *
    * @param angle Angle between ply and global frame in radians
    * @param plyStrainSens Sensitivity w.r.t. strain in the local ply frame

--- a/src/constitutive/TACSMaterialProperties.h
+++ b/src/constitutive/TACSMaterialProperties.h
@@ -259,30 +259,218 @@ class TACSOrthotropicPly : public TACSObject {
                                         const TacsScalar cstrain[],
                                         const TacsScalar lstrain[],
                                         TacsScalar *posSens);
+  void getPlyStress(const TacsScalar strain[], TacsScalar stress[]);
 
   // Transform the stress and strain between global/local frames
   // -----------------------------------------------------------
-  void getPlyStress(const TacsScalar strain[], TacsScalar stress[]);
-  void transformStressGlobal2Ply(TacsScalar angle, const TacsScalar global[],
-                                 TacsScalar plyStress[]);
-  void transformStressPly2Global(TacsScalar angle, const TacsScalar plyStress[],
-                                 TacsScalar global[]);
-  void transformStressGlobal2PlyAngleSens(TacsScalar angle,
-                                          const TacsScalar global[],
-                                          TacsScalar plyStress[]);
-  void transformStressPly2GlobalAngleSens(TacsScalar angle,
-                                          const TacsScalar plyStress[],
-                                          TacsScalar global[]);
-  void transformStrainGlobal2Ply(TacsScalar angle, const TacsScalar global[],
-                                 TacsScalar plyStrain[]);
-  void transformStrainPly2Global(TacsScalar angle, const TacsScalar plyStrain[],
-                                 TacsScalar global[]);
-  void transformStrainGlobal2PlyAngleSens(TacsScalar angle,
-                                          const TacsScalar global[],
-                                          TacsScalar plyStrain[]);
-  void transformStrainPly2GlobalAngleSens(TacsScalar angle,
-                                          const TacsScalar plyStrain[],
-                                          TacsScalar global[]);
+/*
+  For a ply at an angle t, the stress in the local ply frame is computed from
+  the stress in the global frame as:
+
+  s_local = T(t) * s_global
+
+  where T is the transformation matrix:
+
+  T(t) =
+      [c^2  s^2        2*s*c ]
+      [s^2  c^2        -2*s*c]
+      [s*c (c^2 - s^2) s*c   ]
+
+  where c = cos(t) and s = sin(t)
+
+  The strain in the local ply frame is computed from the transposed
+  transformation matrix (because we use engineering shear strain rather than
+  tensorial shear strain):
+
+  e_local = T(t)^T * e_global
+
+  The transformation from the local ply frame to the global frame can be
+  computed by simply replacing t with -t in the transformation matrix:
+
+  s_global = T(-t) * s_local
+
+  e_global = T(-t)^T * e_local
+
+  Sensitivities w.r.t local or global stresses and strains can be transformed
+  using the transpose of the relevant transformation matrix, e.g:
+
+  e_local = T(t)^T * e_global
+  e_global = T(-t)^T * e_local
+  df/de_local = T(t) * df/de_global
+  df/de_global = T(-t) * df/de_local
+*/
+
+  // Generic transformations
+  // -----------------------
+  /**
+   * @brief Compute out = T(angle) * in, where T is the transformation matrix
+   * described in the class docstring
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param in 3-component input vector
+   * @param out 3-component output vector
+   */
+  static void applyTransform(const TacsScalar angle, const TacsScalar in[],
+                             TacsScalar out[]);
+
+  /**
+   * @brief Compute out = T(angle)^T * in, where T is the transformation matrix
+   * described in the class docstring
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param in 3-component input vector
+   * @param out 3-component output vector
+   */
+  static void applyTransformTranspose(const TacsScalar angle,
+                                      const TacsScalar in[], TacsScalar out[]);
+
+  // Stress transformations
+  // ----------------------
+  /**
+   * @brief Given the stress in the global frame, determine the stress in the
+   * local ply frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param global Stress in the global frame (s11, s22, s12)
+   * @param plyStress Stress in the local ply frame (s1, s2, s12)
+   */
+  static void transformStressGlobal2Ply(const TacsScalar angle,
+                                        const TacsScalar global[],
+                                        TacsScalar plyStress[]) {
+    applyTransform(angle, global, plyStress);
+  }
+
+  /**
+   * @brief Given the stress in the local ply frame, determine the stress in the
+   * global frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param plyStress Stress in the local ply frame (s1, s2, s12)
+   * @param global Stress in the global frame (s11, s22, s12)
+   */
+  static void transformStressPly2Global(const TacsScalar angle,
+                                        const TacsScalar plyStress[],
+                                        TacsScalar global[]) {
+    applyTransform(-angle, plyStress, global);
+  }
+
+  /**
+   * @brief Compute the derivative of the ply-frame stress with respect to the
+   * ply angle
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param global Stress in the global frame (s11, s22, s12)
+   * @param plyStress Derivative of the ply-frame stress with respect to the ply
+   * angle (ds1/dt, ds2/dt, ds12/dt)
+   */
+  static void transformStressGlobal2PlyAngleSens(const TacsScalar angle,
+                                                 const TacsScalar global[],
+                                                 TacsScalar plyStress[]);
+
+  /**
+   * @brief Compute the derivative of the global-frame stress with respect to
+   * the ply angle
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param plyStress Stress in the local ply frame (s1, s2, s12)
+   * @param global Derivative of the global-frame stress with respect to the ply
+   * angle (ds11/dt, ds22/dt, ds12/dt)
+   */
+  static void transformStressPly2GlobalAngleSens(const TacsScalar angle,
+                                                 const TacsScalar plyStress[],
+                                                 TacsScalar global[]);
+
+  // Strain transformations
+  // ----------------------
+  /**
+   * @brief Given the strain in the global frame, determine the strain in the
+   * local ply frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param global Strain in the global frame (e11, e22, gamma12)
+   * @param plyStrain Strain in the local ply frame (e1, e2, gamma12)
+   */
+  static void transformStrainGlobal2Ply(const TacsScalar angle,
+                                        const TacsScalar global[],
+                                        TacsScalar plyStrain[]) {
+    applyTransformTranspose(angle, global, plyStrain);
+  }
+
+  /**
+   * @brief Given the strain in the local ply frame, determine the strain in the
+   * global frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param plyStrain Strain in the local ply frame (e1, e2, gamma12)
+   * @param global Strain in the global frame (e11, e22, gamma12)
+   */
+  static void transformStrainPly2Global(const TacsScalar angle,
+                                        const TacsScalar plyStrain[],
+                                        TacsScalar global[]) {
+    applyTransformTranspose(-angle, plyStrain, global);
+  }
+
+  /**
+   * @brief Compute the derivative of the ply-frame strain with respect to the
+   * ply angle
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param global Strain in the global frame (e11, e22, gamma12)
+   * @param plyStrain Derivative of the ply-frame strain with respect to the ply
+   * angle (de1/dt, de2/dt, dgamma12/dt)
+   */
+  static void transformStrainGlobal2PlyAngleSens(const TacsScalar angle,
+                                                 const TacsScalar global[],
+                                                 TacsScalar plyStrain[]);
+
+  /**
+   * @brief Compute the derivative of the global-frame strain with respect to
+   * the ply angle
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param plyStrain Strain in the local ply frame (e1, e2, gamma12)
+   * @param global Derivative of the global-frame strain with respect to the ply
+   * angle (de11/dt, de22/dt, dgamma12/dt)
+   */
+  static void transformStrainPly2GlobalAngleSens(const TacsScalar angle,
+                                                 const TacsScalar plyStrain[],
+                                                 TacsScalar global[]);
+
+  // Strain sensitivity transformations
+  // ----------------------------------
+  /**
+   * @brief Given the sensitivity of a function with respect to the strain in
+   * the global frame, determine the sensitivity with respect to the strain in
+   * the local ply frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param globalStrainSens Sensitivity w.r.t. strain in the global frame
+   * (df/de11, df/de22, df/dgamma12)
+   * @param plyStrainSens Sensitivity w.r.t. strain in the local ply frame
+   * (df/de1, df/de2, df/dgamma12)
+   */
+  static void transformStrainSensGlobal2Ply(const TacsScalar angle,
+                                            const TacsScalar globalStrainSens[],
+                                            TacsScalar plyStrainSens[]) {
+    applyTransform(angle, globalStrainSens, plyStrainSens);
+  }
+
+  /**
+   * @brief Given the sensitivity of a function with respect to the strain in
+   * the local ply frame, determine the sensitivity with respect to the strain
+   * in the global frame
+   *
+   * @param angle Angle between ply and global frame in radians
+   * @param plyStrainSens Sensitivity w.r.t. strain in the local ply frame
+   * (df/de1, df/de2, df/dgamma12)
+   * @param globalStrainSens Sensitivity w.r.t. strain in the global frame
+   * (df/de11, df/de22, df/dgamma12)
+   */
+  static void transformStrainSensPly2Global(const TacsScalar angle,
+                                            const TacsScalar plyStrainSens[],
+                                            TacsScalar globalStrainSens[]) {
+    applyTransform(-angle, plyStrainSens, globalStrainSens);
+  }
 
   // Get or print other information
   // ------------------------------


### PR DESCRIPTION
In the `TACSOrthotropicPly` class there are a lot of different stress and strain transformation methods that essentially all just multiply a vector by $T(\theta)$ or $T^T(\theta)$ but all have their own implementation.

This PR refactors these transformation methods to reduce code duplication while improving code readability:
- Add new general transformation methods `applyTransform` and `applyTransformTranspose` for computing $T(\theta)x$ or $T^T(\theta)x$
- Refactors existing methods such as `transformStressPly2Global` and `transformStrainGlobal2Ply` to use `applyTransform` and `applyTransformTranspose`. These methods are now implemented in the header, meaning they will be inlined and there should be no additional function call overhead.
- Transformation methods are all marked as static
- Adds new `transformStrainSensGlobal2Ply` and `transformStrainSensPly2Global` for transforming between sensitivities w.r.t global and ply frame strains. Previously these sensitivity transformations have been done using `transformStressPly2Global`, which is mathematically correct, but not intuitive when reading the code.
- Adds a large docstring explaining transformations, and doxygen docstrings for each method

I didn't refactor the `AngleSens` methods as the math is a bit more complicated, but I could do it if there's demand.