### PR TITLE
Make `evalConstraintsSens` compatible with `DVGeometryMulti`

### DIFF
--- a/tacs/mach/struct_problem.py
+++ b/tacs/mach/struct_problem.py
@@ -691,7 +691,6 @@ class StructProblem(BaseStructProblem):
         # Compute the DVGeo sensitivities if requested
         if self.DVGeo is not None:
             coordName = self.staticProblem.getCoordName()
-            self.DVGeo.computeTotalJacobian(self.ptSetName, config=self.name)
             for conKey in sens:
                 if coordName in sens[conKey]:
                     # Pop out the constraint sensitivities wrt TACS coords
@@ -701,16 +700,14 @@ class StructProblem(BaseStructProblem):
                     if total_nnz == 0:
                         # if so, skip DVGeo sensitivities
                         continue
-                    # Get the Jacobian
-                    Jacobian = self.DVGeo.JT[self.ptSetName]
-                    # Compute the local Jacobian product
-                    dIdx_local = dIdpt.dot(Jacobian.T)
-                    # Add dvgeo contribution across all procs
-                    dIdx = self.comm.allreduce(dIdx_local.toarray(), op=MPI.SUM)
-                    # Convert to dict
-                    dIdx_dict = self.DVGeo.convertSensitivityToDict(np.atleast_2d(dIdx))
-                    # Update sensitivity dict with new DVGeo sensitivities
-                    sens[conKey].update(dIdx_dict)
+
+                    # pyGeo expects dIdpt to be a 3D array for multiple constraints, can only do this if we make it dense.
+                    dIdpt = dIdpt.toarray().reshape((dIdpt.shape[0], -1, 3))
+                    sens[conKey].update(
+                        self.DVGeo.totalSensitivity(
+                            dIdpt, self.ptSetName, comm=self.comm, config=self.name
+                        )
+                    )
 
         fconSens.update(sens)
 


### PR DESCRIPTION
The TACS MACH wrapper currently converts constraint sensitivities w.r.t node coordinates to sensitivities w.r.t geometric DVs by directly accessing the DVGeo object's jacobian and performing the Jac-Vec product and parallel accumulation itself. Unfortunately this doesn't work with `DVGeoMulti` for 2 reasons:

1. `DVGeoMulti` doesn't have a public `computeTotalJacobian` method, it instead has a private `_computeTotalJacobian` method
2. `DVGeoMulti`'s "total jacobian" doesn't actually seem to contain all the data necessary for computing accurate derivatives (see https://github.com/mdolab/pygeo/blob/176f3d0053ddd3e28357f1cac6b4867bf2cdcf87/pygeo/parameterization/DVGeoMulti.py#L642)

The solution is to use the `totalSensitivity` method instead, which is the standard API for converting sensitivities w.r.t node coordinates to sensitivities w.r.t geometric DVs for all of pyGeo's parameterisation classes. This is already what we use in `evalFunctionsSens`. 

The downside of this is that `totalSensitivity` expects the nodal coordinate sensitivities to be passed in as a 3D array, which means we have to convert the sparse 2D TACS sensitivity arrays into dense 3D arrays. In future this could be avoided by making changes to pyGeo.