### PR TITLE
Add checkSolutionFailure method to MACH wrapper

### DIFF
--- a/tacs/mach/struct_problem.py
+++ b/tacs/mach/struct_problem.py
@@ -71,6 +71,7 @@ class StructProblem(BaseStructProblem):
         self.ptSetName = None
         self.loadFile = loadFile
         self.constraints = []
+        self.solveFailed = False
 
         if self.staticProblem.assembler != self.FEAAssembler.assembler:
             raise RuntimeError(
@@ -528,7 +529,7 @@ class StructProblem(BaseStructProblem):
         self.staticProblem.getVariables(u0)
 
         # Solve static problem w/o damping
-        successFlag = self.staticProblem.solve(Fext=self._Fext)
+        self.solveFailed = not self.staticProblem.solve(Fext=self._Fext)
 
         # Compute undamped update
         self.staticProblem.getVariables(self.update)
@@ -564,6 +565,21 @@ class StructProblem(BaseStructProblem):
         self.staticProblem.setLoadScale(loadScale0)
 
         return damp
+
+    def checkSolutionFailure(self, funcs: dict) -> None:
+        """
+        Check whether the last structural solve failed and accumulate into funcs.
+
+        Parameters
+        ----------
+        funcs : dict
+            Dictionary of functions. A ``"fail"`` key is set (or OR-ed) with the
+            failure flag from the most recent call to :meth:`solve`.
+        """
+        if "fail" in funcs:
+            funcs["fail"] = funcs["fail"] or self.solveFailed
+        else:
+            funcs["fail"] = self.solveFailed
 
     @updateDVGeo
     def evalFunctions(self, funcs, evalFuncs=None, ignoreMissing=False):


### PR DESCRIPTION
## Description
This PR adds convergence failure tracking to the MACH `StructProblem` wrapper. It follows a similar pattern used by `AeroSolver`.

Summary of changes:
- A new flag `self.solveFailed` (bool, default `False`) is added and initialized in `__init__` and updated on every call to `solve()`, reflecting whether the underlying `StaticProblem` converged.
- `checkSolutionFailure(funcs)` accumulates the failure flag into a `funcs["fail"]` entry using logical OR, consistent with how AeroSolver.checkSolutionFailure operates.

This is convenient when the `StructProblem` is used in structural optimization workflows where this information is passed to the optimizer (e.g. pyOptSparse) and it can use this to know whether a function evaluation is valid. 

This will also help address changes needed in the upcoming #433.