### PR TITLE
Fix non-deterministic boundary node ordering in panel-type constraints

### DIFF
--- a/tacs/constraints/panel_length.py
+++ b/tacs/constraints/panel_length.py
@@ -755,8 +755,8 @@ class PanelLengthConstraint(TACSConstraint):
                                     allEdges.add(key)
                                 else:
                                     dupEdges.add(key)
-                # Now get a list of all the edges that aren't duplicated, these are the boundary edges
-                boundaryEdges = list(allEdges - dupEdges)
+                # Now get a sorted list of all the edges that aren't duplicated, these are the boundary edges
+                boundaryEdges = sorted(allEdges - dupEdges)
 
                 # Create a nodeToElem Pointer using a dictionary:
                 nodeToElem = {}


### PR DESCRIPTION
`_getComponentBoundaryNodes` built the boundary edge list by calling list() on a set difference (allEdges - dupEdges). Python set iteration order is an implementation detail that varies with Python version — the tuple hash algorithm changed between 3.7 and 3.8 — so the "first" boundary edge, and therefore the rotational ordering of the resulting node chain, was not guaranteed to be the same across environments.

This caused tests that compare ordered constraint-value arrays against hardcoded references to fail on CI while passing locally when the two environments ran different Python versions.

Change: Replace list(allEdges - dupEdges) with sorted(allEdges - dupEdges). Sorting by (min_node_id, max_node_id) is entirely deterministic regardless of Python version or hash seed, and has no effect on correctness — boundary node connectivity is unchanged, only the starting point of the traversal is now fixed.