### PR TITLE
Add excludeWRT option to mach StructProblem.addConstraintsPyOpt

### DIFF
--- a/tacs/mach/struct_problem.py
+++ b/tacs/mach/struct_problem.py
@@ -444,7 +444,9 @@ class StructProblem(BaseStructProblem):
                 dvName, ndv, "c", value=value, lower=lb, upper=ub, scale=scale
             )
 
-    def addConstraintsPyOpt(self, optProb, nonLinear=True, linear=True):
+    def addConstraintsPyOpt(
+        self, optProb, nonLinear=True, linear=True, excludeWRT=None
+    ):
         """
         Add any linear constraints that were generated during setup to
         the specified pyOpt problem.
@@ -457,6 +459,12 @@ class StructProblem(BaseStructProblem):
             Flag to include non-linear constraints.
         linear : bool
             Flag to include linear constraints.
+        excludeWRT : list of str or str, optional
+            Additional DV names to remove from the ``wrt`` list for every
+            constraint.  Useful for DVs whose structural sensitivity is
+            analytically zero and should not contribute a Jacobian block,
+            e.g. geometric DVs when a DVGeo is attached to the StructProblem
+            but the geometric DVs are not part of the optimization.
         """
         fcon = {}
         fconSens = {}
@@ -480,6 +488,17 @@ class StructProblem(BaseStructProblem):
 
                 # Just evaluate the constraint to get the jacobian structure
                 wrt = list(fconSens[conName].keys())
+
+                # we may want to remove specific dvs from the wrt list
+                if excludeWRT is not None:
+                    if isinstance(excludeWRT, str):
+                        excludeWRT = [excludeWRT]
+
+                    for name in excludeWRT:
+                        if name in wrt:
+                            wrt.remove(name)
+                            fconSens[conName].pop(name)
+
                 optProb.addConGroup(
                     conName,
                     nCon,


### PR DESCRIPTION
## Description
This PR adds a new optional argument `excludeWRT` to the MACH ` StructProblem.addConstraintsPyOpt`. It allows callers to remove specific DV names from the wrt list (and the corresponding Jacobian blocks) of every constraint registered with pyOptSparse.

This is needed when a `DVGeo` is attached to the `StructProblem` but the geometric DVs are not part of the optimization (e.g. structural sizing at a frozen jig shape), since the constraint sensitivities then also contain the geometric DV groups.

The parameter name and semantics are extracted from `aux_elem_dv_clean` development branch (see [PR here](https://github.com/smdogroup/tacs/pull/463)), so this can be used independently now.
