### PR TITLE
Fix loadFile only applying to the first StructProblem per assembler

### DIFF
--- a/tacs/mach/struct_problem.py
+++ b/tacs/mach/struct_problem.py
@@ -1524,6 +1524,11 @@ class StructProblem(BaseStructProblem):
         # Step 2: Overwrite bdfInfo loads with forceInfo loads
         bdfInfo.loads = copy.deepcopy(forceInfo.loads)
         bdfInfo.load_combinations = copy.deepcopy(forceInfo.load_combinations)
+        # The newly assigned loads are not cross-referenced (node_ref etc. are None),
+        # so force a re-cross-reference on the next addLoadFromBDF call. bdfInfo is
+        # shared across all problems from the same meshLoader, so it may already be
+        # marked as cross-referenced from a previously constructed problem.
+        bdfInfo.is_xrefed = False
 
         # Create a copy of the internal loads already added to model
         F = self.staticProblem.F
@@ -1540,3 +1545,6 @@ class StructProblem(BaseStructProblem):
         # Step 3: Restore original loads back into bdfInfo
         bdfInfo.loads = originalLoads
         bdfInfo.load_combinations = originalLoadCombinations
+        # The restored loads are an un-cross-referenced deepcopy, so force a
+        # re-cross-reference on the next addLoadFromBDF call.
+        bdfInfo.is_xrefed = False

--- a/tests/integration_tests/test_mach_beam_load_file.py
+++ b/tests/integration_tests/test_mach_beam_load_file.py
@@ -31,10 +31,16 @@ class TestMACHBeamExample(MACHStructProblemTestCase.MACHStructProblemTest):
 
     N_PROCS = 2
 
-    # Reference values for regression testing
+    # Reference values for regression testing.
+    # The second problem is identical to the first (same load file, same assembler),
+    # so it should produce the same function values. It exists to guard against a
+    # regression where loading forces from a file only worked for the first
+    # StructProblem sharing a given assembler/meshLoader (see readExternalForceFile).
     FUNC_REFS = {
         "tip_shear_ks_vmfailure": 2.492124644887184,
         "tip_shear_mass": 2.7799999999999963,
+        "tip_shear_2_ks_vmfailure": 2.492124644887184,
+        "tip_shear_2_mass": 2.7799999999999963,
     }
 
     def setup_struct_problems(self, comm):
@@ -81,4 +87,18 @@ class TestMACHBeamExample(MACHStructProblemTestCase.MACHStructProblemTest):
         # Create MACH StructProblem
         structProb = StructProblem(staticProb, FEAAssembler, loadFile=load_file)
 
-        return [structProb]
+        # Create a second, identical static problem from the same assembler and
+        # wrap it in another StructProblem that also loads forces from a file.
+        # Because the bdfInfo is shared across problems from the same meshLoader,
+        # this exercises the code path where the load file must be applied to more
+        # than one StructProblem.
+        staticProb2 = FEAAssembler.createStaticProblem("tip_shear_2")
+        staticProb2.addFunction("mass", functions.StructuralMass)
+        staticProb2.addFunction(
+            "ks_vmfailure", functions.KSFailure, safetyFactor=1.0, ksWeight=ksweight
+        )
+        staticProb2.setOption("L2Convergence", 1e-20)
+        staticProb2.setOption("L2ConvergenceRel", 1e-20)
+        structProb2 = StructProblem(staticProb2, FEAAssembler, loadFile=load_file)
+
+        return [structProb, structProb2]


### PR DESCRIPTION
## Bug

When multiple `StructProblem` instances are created from the same `pyTACS` assembler/meshLoader and each is passed a `loadFile` at construction, only the **first** problem's loads are applied correctly. Constructing the second (and any subsequent) problem raises:

```
AttributeError: 'NoneType' object has no attribute 'nid'
```

from `loadInfo.node_ref.nid` inside `TACSProblem._addLoadFromBDF`.

### Root cause

`meshLoader.getBDFInfo()` returns the **shared** `bdfInfo` object, so every problem built from the same assembler shares it. `StructProblem.readExternalForceFile` temporarily overwrites `bdfInfo.loads` with an un-cross-referenced `deepcopy` of the force-file loads, then calls `addLoadFromBDF`. That method only cross-references `bdfInfo` when `is_xrefed is False`.

The first problem finds `is_xrefed == False`, cross-references (populating `node_ref` etc.), and sets `is_xrefed = True`. Subsequent problems then assign fresh, un-cross-referenced loads but `addLoadFromBDF` skips the re-cross-reference because `is_xrefed` is still `True`, leaving `loadInfo.node_ref is None`.

## Fix

Set `bdfInfo.is_xrefed = False` after **both** points in `readExternalForceFile` where `bdfInfo.loads` is reassigned:

1. After overwriting with the force-file loads, so the next `addLoadFromBDF` re-cross-references the new loads.
2. After restoring the original loads (also an un-cross-referenced deepcopy), so the next consumer re-cross-references them too.

## Test

Added a second `StructProblem` sharing the same assembler and load file in `tests/integration_tests/test_mach_beam_load_file.py`. This reproduces the crash before the fix and confirms the second problem produces the same regression values as the first afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)