### PR TITLE
Alternative implementation for constitutive model design variable groups

### DIFF
--- a/src/constitutive/TACSBladeStiffenedShellConstitutive.cpp
+++ b/src/constitutive/TACSBladeStiffenedShellConstitutive.cpp
@@ -215,6 +215,22 @@ TACSBladeStiffenedShellConstitutive::TACSBladeStiffenedShellConstitutive(
   // Arrays for storing ply failure sensitivities
   this->panelPlyFailSens = new TacsScalar[2 * this->numPanelPlies];
   this->stiffenerPlyFailSens = new TacsScalar[2 * this->numStiffenerPlies];
+
+  registerScalarDesignVarGroup("panelLength", &this->panelLength,
+                               &this->panelLengthNum);
+  registerScalarDesignVarGroup("stiffenerPitch", &this->stiffenerPitch,
+                               &this->stiffenerPitchNum);
+  registerScalarDesignVarGroup("panelThick", &this->panelThick,
+                               &this->panelThickNum);
+  registerArrayDesignVarGroup("panelPlyFracs", this->numPanelPlies,
+                              this->panelPlyFracs, this->panelPlyFracNums);
+  registerScalarDesignVarGroup("stiffenerHeight", &this->stiffenerHeight,
+                               &this->stiffenerHeightNum);
+  registerScalarDesignVarGroup("stiffenerThick", &this->stiffenerThick,
+                               &this->stiffenerThickNum);
+  registerArrayDesignVarGroup("stiffenerPlyFracs", this->numStiffenerPlies,
+                              this->stiffenerPlyFracs,
+                              this->stiffenerPlyFracNums);
 }
 
 // ==============================================================================
@@ -500,122 +516,6 @@ int TACSBladeStiffenedShellConstitutive::getDesignVarRange(int elemIndex,
     }
   }
   return this->numDesignVars;
-}
-
-// Get the number of design variable groups
-int TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups() { return 7; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments and are reported in the same order the DVs
-// are registered in the constructor
-const char *TACSBladeStiffenedShellConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "panelLength";
-    case 1:
-      return "stiffenerPitch";
-    case 2:
-      return "panelThick";
-    case 3:
-      return "panelPlyFracs";
-    case 4:
-      return "stiffenerHeight";
-    case 5:
-      return "stiffenerThick";
-    case 6:
-      return "stiffenerPlyFracs";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSBladeStiffenedShellConstitutive::getDesignVarGroupSize(int groupIndex) {
-  switch (groupIndex) {
-    case 3:
-      return this->numPanelPlies;
-    case 6:
-      return this->numStiffenerPlies;
-    case 0:
-    case 1:
-    case 2:
-    case 4:
-    case 5:
-      return 1;
-    default:
-      return 0;
-  }
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSBladeStiffenedShellConstitutive::isDesignVarGroupScalar(
-    int groupIndex) {
-  return groupIndex != 3 && groupIndex != 6;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSBladeStiffenedShellConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  switch (groupIndex) {
-    case 0:
-      values[0] = this->panelLength;
-      break;
-    case 1:
-      values[0] = this->stiffenerPitch;
-      break;
-    case 2:
-      values[0] = this->panelThick;
-      break;
-    case 3:
-      for (int ii = 0; ii < this->numPanelPlies; ii++) {
-        values[ii] = this->panelPlyFracs[ii];
-      }
-      break;
-    case 4:
-      values[0] = this->stiffenerHeight;
-      break;
-    case 5:
-      values[0] = this->stiffenerThick;
-      break;
-    case 6:
-      for (int ii = 0; ii < this->numStiffenerPlies; ii++) {
-        values[ii] = this->stiffenerPlyFracs[ii];
-      }
-      break;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSBladeStiffenedShellConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                                int dvNums[]) {
-  switch (groupIndex) {
-    case 0:
-      dvNums[0] = this->panelLengthNum;
-      break;
-    case 1:
-      dvNums[0] = this->stiffenerPitchNum;
-      break;
-    case 2:
-      dvNums[0] = this->panelThickNum;
-      break;
-    case 3:
-      for (int ii = 0; ii < this->numPanelPlies; ii++) {
-        dvNums[ii] = this->panelPlyFracNums[ii];
-      }
-      break;
-    case 4:
-      dvNums[0] = this->stiffenerHeightNum;
-      break;
-    case 5:
-      dvNums[0] = this->stiffenerThickNum;
-      break;
-    case 6:
-      for (int ii = 0; ii < this->numStiffenerPlies; ii++) {
-        dvNums[ii] = this->stiffenerPlyFracNums[ii];
-      }
-      break;
-  }
 }
 
 // ==============================================================================

--- a/src/constitutive/TACSBladeStiffenedShellConstitutive.h
+++ b/src/constitutive/TACSBladeStiffenedShellConstitutive.h
@@ -321,14 +321,6 @@ class TACSBladeStiffenedShellConstitutive : public TACSShellConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   /**
    * @brief Get the number of panel plies
    */

--- a/src/constitutive/TACSConstitutive.cpp
+++ b/src/constitutive/TACSConstitutive.cpp
@@ -135,3 +135,76 @@ void TACSConstitutive::getFailureEnvelope(
   delete[] y_strain;
   delete[] C;
 }
+
+void TACSConstitutive::registerScalarDesignVarGroup(const char *name,
+                                                    TacsScalar *value,
+                                                    int *dvNum) {
+  DesignVarGroup group;
+  group.name = name;
+  group.size = 1;
+  group.isScalar = true;
+  group.values = value;
+  group.dvNums = dvNum;
+  designVarGroups.push_back(group);
+}
+
+void TACSConstitutive::registerArrayDesignVarGroup(const char *name, int size,
+                                                   TacsScalar *values,
+                                                   int *dvNums) {
+  DesignVarGroup group;
+  group.name = name;
+  group.size = size;
+  group.isScalar = false;
+  group.values = values;
+  group.dvNums = dvNums;
+  designVarGroups.push_back(group);
+}
+
+int TACSConstitutive::getNumDesignVarGroups() {
+  return static_cast<int>(designVarGroups.size());
+}
+
+const char *TACSConstitutive::getDesignVarGroupName(int groupIndex) {
+  if (groupIndex >= 0 &&
+      groupIndex < static_cast<int>(designVarGroups.size())) {
+    return designVarGroups[groupIndex].name;
+  }
+  return NULL;
+}
+
+int TACSConstitutive::getDesignVarGroupSize(int groupIndex) {
+  if (groupIndex >= 0 &&
+      groupIndex < static_cast<int>(designVarGroups.size())) {
+    return designVarGroups[groupIndex].size;
+  }
+  return 0;
+}
+
+bool TACSConstitutive::isDesignVarGroupScalar(int groupIndex) {
+  if (groupIndex >= 0 &&
+      groupIndex < static_cast<int>(designVarGroups.size())) {
+    return designVarGroups[groupIndex].isScalar;
+  }
+  return true;
+}
+
+void TACSConstitutive::getDesignVarGroupValues(int groupIndex,
+                                               TacsScalar values[]) {
+  if (groupIndex >= 0 &&
+      groupIndex < static_cast<int>(designVarGroups.size())) {
+    const DesignVarGroup &group = designVarGroups[groupIndex];
+    for (int ii = 0; ii < group.size; ii++) {
+      values[ii] = group.values[ii];
+    }
+  }
+}
+
+void TACSConstitutive::getDesignVarGroupNums(int groupIndex, int dvNums[]) {
+  if (groupIndex >= 0 &&
+      groupIndex < static_cast<int>(designVarGroups.size())) {
+    const DesignVarGroup &group = designVarGroups[groupIndex];
+    for (int ii = 0; ii < group.size; ii++) {
+      dvNums[ii] = group.dvNums[ii];
+    }
+  }
+}

--- a/src/constitutive/TACSConstitutive.h
+++ b/src/constitutive/TACSConstitutive.h
@@ -131,7 +131,7 @@ class TACSConstitutive : public TACSObject {
 
     @return The number of design variable groups
   */
-  virtual int getNumDesignVarGroups();
+  int getNumDesignVarGroups();
 
   /**
     Get the name of a design variable group
@@ -139,7 +139,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return The group name, or NULL if groupIndex is out of range
   */
-  virtual const char *getDesignVarGroupName(int groupIndex);
+  const char *getDesignVarGroupName(int groupIndex);
 
   /**
     Get the number of entries in a design variable group
@@ -147,7 +147,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return The number of entries in the group, or 0 if out of range
   */
-  virtual int getDesignVarGroupSize(int groupIndex);
+  int getDesignVarGroupSize(int groupIndex);
 
   /**
     Is this design variable group a scalar quantity?
@@ -159,7 +159,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return True if the group is a scalar quantity
   */
-  virtual bool isDesignVarGroupScalar(int groupIndex);
+  bool isDesignVarGroupScalar(int groupIndex);
 
   /**
     Get the values of all entries in a design variable group
@@ -171,7 +171,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @param values The design variable group values
   */
-  virtual void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
+  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
 
   /**
     Get the design variable numbers of all entries in a design variable
@@ -184,7 +184,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @param dvNums The design variable numbers
   */
-  virtual void getDesignVarGroupNums(int groupIndex, int dvNums[]);
+  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
 
   /**
     Evaluate the mass per unit length, area or volume for the element

--- a/src/constitutive/TACSConstitutive.h
+++ b/src/constitutive/TACSConstitutive.h
@@ -19,6 +19,8 @@
 #ifndef TACS_CONSTITUTIVE_H
 #define TACS_CONSTITUTIVE_H
 
+#include <vector>  // std::vector
+
 #include "TACSObject.h"
 
 /**
@@ -109,6 +111,7 @@ class TACSConstitutive : public TACSObject {
     return 0;
   }
 
+  // --- Design variable group API (implemented in TACSConstitutive.cpp) ---
   /**
     Get the number of logical design variable groups defined by this
     constitutive object
@@ -128,7 +131,7 @@ class TACSConstitutive : public TACSObject {
 
     @return The number of design variable groups
   */
-  virtual int getNumDesignVarGroups() { return 0; }
+  virtual int getNumDesignVarGroups();
 
   /**
     Get the name of a design variable group
@@ -136,7 +139,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return The group name, or NULL if groupIndex is out of range
   */
-  virtual const char *getDesignVarGroupName(int groupIndex) { return NULL; }
+  virtual const char *getDesignVarGroupName(int groupIndex);
 
   /**
     Get the number of entries in a design variable group
@@ -144,7 +147,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return The number of entries in the group, or 0 if out of range
   */
-  virtual int getDesignVarGroupSize(int groupIndex) { return 0; }
+  virtual int getDesignVarGroupSize(int groupIndex);
 
   /**
     Is this design variable group a scalar quantity?
@@ -156,7 +159,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @return True if the group is a scalar quantity
   */
-  virtual bool isDesignVarGroupScalar(int groupIndex) { return true; }
+  virtual bool isDesignVarGroupScalar(int groupIndex);
 
   /**
     Get the values of all entries in a design variable group
@@ -168,7 +171,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @param values The design variable group values
   */
-  virtual void getDesignVarGroupValues(int groupIndex, TacsScalar values[]) {}
+  virtual void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
 
   /**
     Get the design variable numbers of all entries in a design variable
@@ -181,7 +184,7 @@ class TACSConstitutive : public TACSObject {
     @param groupIndex The index of the design variable group
     @param dvNums The design variable numbers
   */
-  virtual void getDesignVarGroupNums(int groupIndex, int dvNums[]) {}
+  virtual void getDesignVarGroupNums(int groupIndex, int dvNums[]);
 
   /**
     Evaluate the mass per unit length, area or volume for the element
@@ -680,8 +683,43 @@ class TACSConstitutive : public TACSObject {
                           const TacsScalar y_stress[], TacsScalar x_vals[],
                           TacsScalar y_vals[]);
 
+ protected:
+  /**
+    Register a scalar design variable group backed by single members.
+
+    @param name The group name; must match the Python constructor kwarg
+    @param value Pointer to the group's live value member
+    @param dvNum Pointer to the group's live design variable number member
+  */
+  void registerScalarDesignVarGroup(const char *name, TacsScalar *value,
+                                    int *dvNum);
+
+  /**
+    Register an array design variable group backed by contiguous storage.
+
+    @param name The group name; must match the Python constructor kwarg
+    @param size The number of entries in the group
+    @param values Pointer to the group's live value storage
+    @param dvNums Pointer to the group's live design variable numbers
+  */
+  void registerArrayDesignVarGroup(const char *name, int size,
+                                   TacsScalar *values, int *dvNums);
+
  private:
   static const char *constName;
+
+  // A registered design variable group: a named quantity backed by live
+  // storage in the subclass. Scalar groups have size 1 and isScalar true.
+  struct DesignVarGroup {
+    const char *name;
+    int size;
+    bool isScalar;
+    TacsScalar *values;
+    int *dvNums;
+  };
+
+  // Design variable groups registered by the subclass, in registration order.
+  std::vector<DesignVarGroup> designVarGroups;
 };
 
 #endif  // TACS_CONSTITUTIVE_H

--- a/src/constitutive/TACSGPBladeStiffenedShellConstitutive.cpp
+++ b/src/constitutive/TACSGPBladeStiffenedShellConstitutive.cpp
@@ -63,6 +63,8 @@ TACSGPBladeStiffenedShellConstitutive::TACSGPBladeStiffenedShellConstitutive(
   }
   this->panelWidthLowerBound = 0.000;
   this->panelWidthUpperBound = 1e20;
+  registerScalarDesignVarGroup("panelWidth", &this->panelWidth,
+                               &this->panelWidthNum);
 
   // set whether to use CPT stiffener crippling from Sean's paper vs.
   //    experimental DOD manuscript crippling solution from Ali's superclass
@@ -1245,80 +1247,6 @@ int TACSGPBladeStiffenedShellConstitutive::getDesignVarRange(int elemIndex,
     }
   }
   return this->numDesignVars;
-}
-
-// Get the number of design variable groups: all parent groups plus panelWidth
-int TACSGPBladeStiffenedShellConstitutive::getNumDesignVarGroups() {
-  return TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups() + 1;
-}
-
-// Get the name of each design variable group; the panelWidth group is
-// appended after the parent class groups, matching the DV registration order
-const char *TACSGPBladeStiffenedShellConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  int numParentGroups =
-      TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups();
-  if (groupIndex < numParentGroups) {
-    return TACSBladeStiffenedShellConstitutive::getDesignVarGroupName(
-        groupIndex);
-  }
-  if (groupIndex == numParentGroups) {
-    return "panelWidth";
-  }
-  return NULL;
-}
-
-// Get the number of entries in each design variable group
-int TACSGPBladeStiffenedShellConstitutive::getDesignVarGroupSize(
-    int groupIndex) {
-  int numParentGroups =
-      TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups();
-  if (groupIndex < numParentGroups) {
-    return TACSBladeStiffenedShellConstitutive::getDesignVarGroupSize(
-        groupIndex);
-  }
-  if (groupIndex == numParentGroups) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSGPBladeStiffenedShellConstitutive::isDesignVarGroupScalar(
-    int groupIndex) {
-  int numParentGroups =
-      TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups();
-  if (groupIndex < numParentGroups) {
-    return TACSBladeStiffenedShellConstitutive::isDesignVarGroupScalar(
-        groupIndex);
-  }
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSGPBladeStiffenedShellConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  int numParentGroups =
-      TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups();
-  if (groupIndex < numParentGroups) {
-    TACSBladeStiffenedShellConstitutive::getDesignVarGroupValues(groupIndex,
-                                                                 values);
-  } else if (groupIndex == numParentGroups) {
-    values[0] = this->panelWidth;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSGPBladeStiffenedShellConstitutive::getDesignVarGroupNums(
-    int groupIndex, int dvNums[]) {
-  int numParentGroups =
-      TACSBladeStiffenedShellConstitutive::getNumDesignVarGroups();
-  if (groupIndex < numParentGroups) {
-    TACSBladeStiffenedShellConstitutive::getDesignVarGroupNums(groupIndex,
-                                                               dvNums);
-  } else if (groupIndex == numParentGroups) {
-    dvNums[0] = this->panelWidthNum;
-  }
 }
 
 // ==============================================================================

--- a/src/constitutive/TACSGPBladeStiffenedShellConstitutive.h
+++ b/src/constitutive/TACSGPBladeStiffenedShellConstitutive.h
@@ -214,14 +214,6 @@ class TACSGPBladeStiffenedShellConstitutive
   TacsScalar evalDesignFieldValue(int elemIndex, const double pt[],
                                   const TacsScalar X[], int index) override;
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // set the KS weight for the failure constraints and the GP models (if GP
   // models are active)
   void setKSWeight(double ksWeight);

--- a/src/constitutive/TACSIsoRectangleBeamConstitutive.cpp
+++ b/src/constitutive/TACSIsoRectangleBeamConstitutive.cpp
@@ -34,6 +34,10 @@ TACSIsoRectangleBeamConstitutive::TACSIsoRectangleBeamConstitutive(
   kcorr = 10.0 * (1.0 + nu) / (12.0 + 11.0 * nu);
 
   ks_weight = 100.0;
+
+  registerScalarDesignVarGroup("w", &width, &width_num);
+  registerScalarDesignVarGroup("t", &thickness, &thickness_num);
+  registerScalarDesignVarGroup("Lb", &buckle_length, &buckle_length_num);
 }
 
 TACSIsoRectangleBeamConstitutive::~TACSIsoRectangleBeamConstitutive() {
@@ -121,71 +125,6 @@ int TACSIsoRectangleBeamConstitutive::getDesignVarRange(int elemIndex,
     index++;
   }
   return index;
-}
-
-// Get the number of design variable groups
-int TACSIsoRectangleBeamConstitutive::getNumDesignVarGroups() { return 3; }
-
-// Get the name of each design variable group. Group names match the Python
-// constructor keyword arguments, which differ from the C++ member names here
-// ("w" is `width`, "t" is `thickness`, "Lb" is `buckle_length`)
-const char *TACSIsoRectangleBeamConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "w";
-    case 1:
-      return "t";
-    case 2:
-      return "Lb";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSIsoRectangleBeamConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex >= 0 && groupIndex < 3) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSIsoRectangleBeamConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSIsoRectangleBeamConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  switch (groupIndex) {
-    case 0:
-      values[0] = width;
-      break;
-    case 1:
-      values[0] = thickness;
-      break;
-    case 2:
-      values[0] = buckle_length;
-      break;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSIsoRectangleBeamConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                             int dvNums[]) {
-  switch (groupIndex) {
-    case 0:
-      dvNums[0] = width_num;
-      break;
-    case 1:
-      dvNums[0] = thickness_num;
-      break;
-    case 2:
-      dvNums[0] = buckle_length_num;
-      break;
-  }
 }
 
 void TACSIsoRectangleBeamConstitutive::evalMassMoments(int elemIndex,

--- a/src/constitutive/TACSIsoRectangleBeamConstitutive.h
+++ b/src/constitutive/TACSIsoRectangleBeamConstitutive.h
@@ -57,14 +57,6 @@ class TACSIsoRectangleBeamConstitutive : public TACSBeamConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the material density
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/src/constitutive/TACSIsoShellConstitutive.cpp
+++ b/src/constitutive/TACSIsoShellConstitutive.cpp
@@ -40,6 +40,8 @@ TACSIsoShellConstitutive::TACSIsoShellConstitutive(
   tOffset = _tOffset;
   kcorr = _kcorr;
   ksWeight = 100.0;
+
+  registerScalarDesignVarGroup("t", &t, &tNum);
 }
 
 TACSIsoShellConstitutive::~TACSIsoShellConstitutive() {
@@ -94,47 +96,6 @@ int TACSIsoShellConstitutive::getDesignVarRange(int elemIndex, int dvLen,
     return 1;
   }
   return 0;
-}
-
-// Get the number of design variable groups
-int TACSIsoShellConstitutive::getNumDesignVarGroups() { return 1; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSIsoShellConstitutive::getDesignVarGroupName(int groupIndex) {
-  if (groupIndex == 0) {
-    return "t";
-  }
-  return NULL;
-}
-
-// Get the number of entries in each design variable group
-int TACSIsoShellConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex == 0) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSIsoShellConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSIsoShellConstitutive::getDesignVarGroupValues(int groupIndex,
-                                                       TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = t;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSIsoShellConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                     int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = tNum;
-  }
 }
 
 // Evaluate the material density

--- a/src/constitutive/TACSIsoShellConstitutive.h
+++ b/src/constitutive/TACSIsoShellConstitutive.h
@@ -49,14 +49,6 @@ class TACSIsoShellConstitutive : public TACSShellConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the material density
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/src/constitutive/TACSIsoTubeBeamConstitutive.cpp
+++ b/src/constitutive/TACSIsoTubeBeamConstitutive.cpp
@@ -15,6 +15,9 @@ TACSIsoTubeBeamConstitutive::TACSIsoTubeBeamConstitutive(
   innerUb = inner_ub;
   wallLb = wall_lb;
   wallUb = wall_ub;
+
+  registerScalarDesignVarGroup("d", &inner, &innerDV);
+  registerScalarDesignVarGroup("t", &wall, &wallDV);
 }
 
 TACSIsoTubeBeamConstitutive::~TACSIsoTubeBeamConstitutive() { props->decref(); }
@@ -80,57 +83,6 @@ int TACSIsoTubeBeamConstitutive::getDesignVarRange(int elemIndex, int dvLen,
     index++;
   }
   return index;
-}
-
-// Get the number of design variable groups
-int TACSIsoTubeBeamConstitutive::getNumDesignVarGroups() { return 2; }
-
-// Get the name of each design variable group. Group names match the Python
-// constructor keyword arguments, which differ from the C++ member names here
-// ("d" is the inner diameter member `inner`, "t" is the wall thickness
-// member `wall`)
-const char *TACSIsoTubeBeamConstitutive::getDesignVarGroupName(int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "d";
-    case 1:
-      return "t";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSIsoTubeBeamConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex == 0 || groupIndex == 1) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSIsoTubeBeamConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSIsoTubeBeamConstitutive::getDesignVarGroupValues(int groupIndex,
-                                                          TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = inner;
-  } else if (groupIndex == 1) {
-    values[0] = wall;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSIsoTubeBeamConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                        int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = innerDV;
-  } else if (groupIndex == 1) {
-    dvNums[0] = wallDV;
-  }
 }
 
 void TACSIsoTubeBeamConstitutive::evalMassMoments(int elemIndex,

--- a/src/constitutive/TACSIsoTubeBeamConstitutive.h
+++ b/src/constitutive/TACSIsoTubeBeamConstitutive.h
@@ -44,14 +44,6 @@ class TACSIsoTubeBeamConstitutive : public TACSBeamConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the material density
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/src/constitutive/TACSLamParamFullShellConstitutive.cpp
+++ b/src/constitutive/TACSLamParamFullShellConstitutive.cpp
@@ -70,6 +70,9 @@ TACSLamParamFullShellConstitutive::TACSLamParamFullShellConstitutive(
   // The invariant coefficients for the shear coefficients
   U6 = (Q44 + Q55) / 2.0;
   U7 = (Q44 - Q55) / 2.0;
+
+  registerScalarDesignVarGroup("t", &t, &tNum);
+  registerArrayDesignVarGroup("lp", NUM_LAM_PARAMS, lp, lpNums);
 }
 
 TACSLamParamFullShellConstitutive::~TACSLamParamFullShellConstitutive() {
@@ -162,65 +165,6 @@ int TACSLamParamFullShellConstitutive::getDesignVarRange(int elemIndex,
     }
   }
   return numDesignVars;
-}
-
-// Get the number of design variable groups
-int TACSLamParamFullShellConstitutive::getNumDesignVarGroups() { return 2; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments. Note the "lp" values cannot be set through
-// the constructor; use setLaminationParameters to restore them.
-const char *TACSLamParamFullShellConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "t";
-    case 1:
-      return "lp";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSLamParamFullShellConstitutive::getDesignVarGroupSize(int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return 1;
-    case 1:
-      return NUM_LAM_PARAMS;
-    default:
-      return 0;
-  }
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSLamParamFullShellConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return groupIndex == 0;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSLamParamFullShellConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = t;
-  } else if (groupIndex == 1) {
-    for (int k = 0; k < NUM_LAM_PARAMS; k++) {
-      values[k] = lp[k];
-    }
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSLamParamFullShellConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                              int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = tNum;
-  } else if (groupIndex == 1) {
-    for (int k = 0; k < NUM_LAM_PARAMS; k++) {
-      dvNums[k] = lpNums[k];
-    }
-  }
 }
 
 /*!

--- a/src/constitutive/TACSLamParamFullShellConstitutive.h
+++ b/src/constitutive/TACSLamParamFullShellConstitutive.h
@@ -80,14 +80,6 @@ class TACSLamParamFullShellConstitutive : public TACSShellConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // -------------------------------------
   // Evaluate mass properties
   // -------------------------------------

--- a/src/constitutive/TACSLamParamSmearedShellConstitutive.cpp
+++ b/src/constitutive/TACSLamParamSmearedShellConstitutive.cpp
@@ -119,6 +119,13 @@ TACSLamParamSmearedShellConstitutive::TACSLamParamSmearedShellConstitutive(
   // The invariant coefficients for the shear coefficients
   U6 = (Q44 + Q55) / 2.0;
   U7 = (Q44 - Q55) / 2.0;
+
+  registerScalarDesignVarGroup("t", &t, &tNum);
+  registerScalarDesignVarGroup("f0", &f0, &n0);
+  registerScalarDesignVarGroup("f45", &f45, &n45);
+  registerScalarDesignVarGroup("f90", &f90, &n90);
+  registerScalarDesignVarGroup("W1", &W1, &nW1);
+  registerScalarDesignVarGroup("W3", &W3, &nW3);
 }
 
 TACSLamParamSmearedShellConstitutive::~TACSLamParamSmearedShellConstitutive() {
@@ -255,96 +262,6 @@ int TACSLamParamSmearedShellConstitutive::getDesignVarRange(int elemIndex,
     i++;
   }
   return numDesignVars;
-}
-
-// Get the number of design variable groups
-int TACSLamParamSmearedShellConstitutive::getNumDesignVarGroups() { return 6; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSLamParamSmearedShellConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "t";
-    case 1:
-      return "f0";
-    case 2:
-      return "f45";
-    case 3:
-      return "f90";
-    case 4:
-      return "W1";
-    case 5:
-      return "W3";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSLamParamSmearedShellConstitutive::getDesignVarGroupSize(
-    int groupIndex) {
-  if (groupIndex >= 0 && groupIndex < 6) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSLamParamSmearedShellConstitutive::isDesignVarGroupScalar(
-    int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSLamParamSmearedShellConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  switch (groupIndex) {
-    case 0:
-      values[0] = t;
-      break;
-    case 1:
-      values[0] = f0;
-      break;
-    case 2:
-      values[0] = f45;
-      break;
-    case 3:
-      values[0] = f90;
-      break;
-    case 4:
-      values[0] = W1;
-      break;
-    case 5:
-      values[0] = W3;
-      break;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSLamParamSmearedShellConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                                 int dvNums[]) {
-  switch (groupIndex) {
-    case 0:
-      dvNums[0] = tNum;
-      break;
-    case 1:
-      dvNums[0] = n0;
-      break;
-    case 2:
-      dvNums[0] = n45;
-      break;
-    case 3:
-      dvNums[0] = n90;
-      break;
-    case 4:
-      dvNums[0] = nW1;
-      break;
-    case 5:
-      dvNums[0] = nW3;
-      break;
-  }
 }
 
 /*!

--- a/src/constitutive/TACSLamParamSmearedShellConstitutive.h
+++ b/src/constitutive/TACSLamParamSmearedShellConstitutive.h
@@ -61,14 +61,6 @@ class TACSLamParamSmearedShellConstitutive : public TACSShellConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the mass per unit area
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/src/constitutive/TACSPhaseChangeMaterialConstitutive.cpp
+++ b/src/constitutive/TACSPhaseChangeMaterialConstitutive.cpp
@@ -63,6 +63,8 @@ TACSPhaseChangeMaterialConstitutive::TACSPhaseChangeMaterialConstitutive(
              // Tm+dT]
   b = 2.0 * tan(0.99 * M_PI /
                 2.0);  // constant used to evaluate transition boundaries
+
+  registerScalarDesignVarGroup("t", &t, &tNum);
 }
 
 TACSPhaseChangeMaterialConstitutive::~TACSPhaseChangeMaterialConstitutive() {
@@ -124,49 +126,6 @@ int TACSPhaseChangeMaterialConstitutive::getDesignVarRange(int elemIndex,
     return 1;
   }
   return 0;
-}
-
-// Get the number of design variable groups
-int TACSPhaseChangeMaterialConstitutive::getNumDesignVarGroups() { return 1; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSPhaseChangeMaterialConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  if (groupIndex == 0) {
-    return "t";
-  }
-  return NULL;
-}
-
-// Get the number of entries in each design variable group
-int TACSPhaseChangeMaterialConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex == 0) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSPhaseChangeMaterialConstitutive::isDesignVarGroupScalar(
-    int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSPhaseChangeMaterialConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = t;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSPhaseChangeMaterialConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                                int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = tNum;
-  }
 }
 
 // Compute the phase change coefficient

--- a/src/constitutive/TACSPhaseChangeMaterialConstitutive.h
+++ b/src/constitutive/TACSPhaseChangeMaterialConstitutive.h
@@ -51,14 +51,6 @@ class TACSPhaseChangeMaterialConstitutive : public TACSConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Compute the phase change coefficient
   TacsScalar evalTransitionCoef(const TacsScalar T);
 

--- a/src/constitutive/TACSPlaneStressConstitutive.cpp
+++ b/src/constitutive/TACSPlaneStressConstitutive.cpp
@@ -36,6 +36,8 @@ TACSPlaneStressConstitutive::TACSPlaneStressConstitutive(
   tNum = _tNum;
   tlb = _tlb;
   tub = _tub;
+
+  registerScalarDesignVarGroup("t", &t, &tNum);
 }
 
 TACSPlaneStressConstitutive::~TACSPlaneStressConstitutive() {
@@ -92,47 +94,6 @@ int TACSPlaneStressConstitutive::getDesignVarRange(int elemIndex, int dvLen,
     return 1;
   }
   return 0;
-}
-
-// Get the number of design variable groups
-int TACSPlaneStressConstitutive::getNumDesignVarGroups() { return 1; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSPlaneStressConstitutive::getDesignVarGroupName(int groupIndex) {
-  if (groupIndex == 0) {
-    return "t";
-  }
-  return NULL;
-}
-
-// Get the number of entries in each design variable group
-int TACSPlaneStressConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex == 0) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSPlaneStressConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSPlaneStressConstitutive::getDesignVarGroupValues(int groupIndex,
-                                                          TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = t;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSPlaneStressConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                        int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = tNum;
-  }
 }
 
 // Evaluate the material density

--- a/src/constitutive/TACSPlaneStressConstitutive.h
+++ b/src/constitutive/TACSPlaneStressConstitutive.h
@@ -51,14 +51,6 @@ class TACSPlaneStressConstitutive : public TACSConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the material density
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/src/constitutive/TACSPointMassConstitutive.cpp
+++ b/src/constitutive/TACSPointMassConstitutive.cpp
@@ -63,6 +63,14 @@ TACSPointMassConstitutive::TACSPointMassConstitutive(
   I13ub = _I13ub;
   I23lb = _I23lb;
   I23ub = _I23ub;
+
+  registerScalarDesignVarGroup("m", &m, &mNum);
+  registerScalarDesignVarGroup("I11", &I11, &I11Num);
+  registerScalarDesignVarGroup("I22", &I22, &I22Num);
+  registerScalarDesignVarGroup("I33", &I33, &I33Num);
+  registerScalarDesignVarGroup("I12", &I12, &I12Num);
+  registerScalarDesignVarGroup("I13", &I13, &I13Num);
+  registerScalarDesignVarGroup("I23", &I23, &I23Num);
 }
 
 // Retrieve the global design variable numbers
@@ -281,100 +289,5 @@ void TACSPointMassConstitutive::addMassMatrixDVSensInnerProduct(
   if (I23Num >= 0) {
     dfdx[index] += scale * (psi[4] * phi[5] + psi[5] * phi[4]);
     index++;
-  }
-}
-
-// Get the number of design variable groups
-int TACSPointMassConstitutive::getNumDesignVarGroups() { return 7; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSPointMassConstitutive::getDesignVarGroupName(int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "m";
-    case 1:
-      return "I11";
-    case 2:
-      return "I22";
-    case 3:
-      return "I33";
-    case 4:
-      return "I12";
-    case 5:
-      return "I13";
-    case 6:
-      return "I23";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSPointMassConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex >= 0 && groupIndex < 7) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSPointMassConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSPointMassConstitutive::getDesignVarGroupValues(int groupIndex,
-                                                        TacsScalar values[]) {
-  switch (groupIndex) {
-    case 0:
-      values[0] = m;
-      break;
-    case 1:
-      values[0] = I11;
-      break;
-    case 2:
-      values[0] = I22;
-      break;
-    case 3:
-      values[0] = I33;
-      break;
-    case 4:
-      values[0] = I12;
-      break;
-    case 5:
-      values[0] = I13;
-      break;
-    case 6:
-      values[0] = I23;
-      break;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSPointMassConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                      int dvNums[]) {
-  switch (groupIndex) {
-    case 0:
-      dvNums[0] = mNum;
-      break;
-    case 1:
-      dvNums[0] = I11Num;
-      break;
-    case 2:
-      dvNums[0] = I22Num;
-      break;
-    case 3:
-      dvNums[0] = I33Num;
-      break;
-    case 4:
-      dvNums[0] = I12Num;
-      break;
-    case 5:
-      dvNums[0] = I13Num;
-      break;
-    case 6:
-      dvNums[0] = I23Num;
-      break;
   }
 }

--- a/src/constitutive/TACSPointMassConstitutive.h
+++ b/src/constitutive/TACSPointMassConstitutive.h
@@ -56,14 +56,6 @@ class TACSPointMassConstitutive : public TACSGeneralMassConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the mass matrix
   void evalMassMatrix(int elemIndex, const double pt[], const TacsScalar X[],
                       TacsScalar M[]);

--- a/src/constitutive/TACSSmearedCompositeShellConstitutive.cpp
+++ b/src/constitutive/TACSSmearedCompositeShellConstitutive.cpp
@@ -85,6 +85,10 @@ TACSSmearedCompositeShellConstitutive::TACSSmearedCompositeShellConstitutive(
   for (int i = 0; i < nfvals; i++) {
     dfvals[i] = new TacsScalar[NUM_STRESSES];
   }
+
+  registerScalarDesignVarGroup("thickness", &thickness, &thickness_dv_num);
+  registerArrayDesignVarGroup("ply_fractions", num_plies, ply_fractions,
+                              ply_fraction_dv_nums);
 }
 
 TACSSmearedCompositeShellConstitutive::
@@ -178,66 +182,6 @@ int TACSSmearedCompositeShellConstitutive::getDesignVarRange(int elemIndex,
     }
   }
   return index;
-}
-
-// Get the number of design variable groups
-int TACSSmearedCompositeShellConstitutive::getNumDesignVarGroups() { return 2; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSSmearedCompositeShellConstitutive::getDesignVarGroupName(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return "thickness";
-    case 1:
-      return "ply_fractions";
-    default:
-      return NULL;
-  }
-}
-
-// Get the number of entries in each design variable group
-int TACSSmearedCompositeShellConstitutive::getDesignVarGroupSize(
-    int groupIndex) {
-  switch (groupIndex) {
-    case 0:
-      return 1;
-    case 1:
-      return num_plies;
-    default:
-      return 0;
-  }
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSSmearedCompositeShellConstitutive::isDesignVarGroupScalar(
-    int groupIndex) {
-  return groupIndex == 0;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSSmearedCompositeShellConstitutive::getDesignVarGroupValues(
-    int groupIndex, TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = thickness;
-  } else if (groupIndex == 1) {
-    for (int i = 0; i < num_plies; i++) {
-      values[i] = ply_fractions[i];
-    }
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSSmearedCompositeShellConstitutive::getDesignVarGroupNums(
-    int groupIndex, int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = thickness_dv_num;
-  } else if (groupIndex == 1) {
-    for (int i = 0; i < num_plies; i++) {
-      dvNums[i] = ply_fraction_dv_nums[i];
-    }
-  }
 }
 
 // Evaluate the material density

--- a/src/constitutive/TACSSmearedCompositeShellConstitutive.h
+++ b/src/constitutive/TACSSmearedCompositeShellConstitutive.h
@@ -46,14 +46,6 @@ class TACSSmearedCompositeShellConstitutive : public TACSShellConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Retrieve the design variable for plotting purposes
   TacsScalar evalDesignFieldValue(int elemIndex, const double pt[],
                                   const TacsScalar X[], int index);

--- a/src/constitutive/TACSSolidConstitutive.cpp
+++ b/src/constitutive/TACSSolidConstitutive.cpp
@@ -43,6 +43,7 @@ TACSSolidConstitutive::TACSSolidConstitutive(TACSMaterialProperties *props,
   tNum = _tNum;
   tlb = _tlb;
   tub = _tub;
+  registerScalarDesignVarGroup("t", &t, &tNum);
 }
 
 TACSSolidConstitutive::~TACSSolidConstitutive() {
@@ -98,47 +99,6 @@ int TACSSolidConstitutive::getDesignVarRange(int elemIndex, int dvLen,
     return 1;
   }
   return 0;
-}
-
-// Get the number of design variable groups
-int TACSSolidConstitutive::getNumDesignVarGroups() { return 1; }
-
-// Get the name of each design variable group; group names match the Python
-// constructor keyword arguments
-const char *TACSSolidConstitutive::getDesignVarGroupName(int groupIndex) {
-  if (groupIndex == 0) {
-    return "t";
-  }
-  return NULL;
-}
-
-// Get the number of entries in each design variable group
-int TACSSolidConstitutive::getDesignVarGroupSize(int groupIndex) {
-  if (groupIndex == 0) {
-    return 1;
-  }
-  return 0;
-}
-
-// Is the design variable group a scalar quantity?
-bool TACSSolidConstitutive::isDesignVarGroupScalar(int groupIndex) {
-  return true;
-}
-
-// Get the values of a design variable group, whether active or not
-void TACSSolidConstitutive::getDesignVarGroupValues(int groupIndex,
-                                                    TacsScalar values[]) {
-  if (groupIndex == 0) {
-    values[0] = t;
-  }
-}
-
-// Get the design variable numbers of a design variable group
-void TACSSolidConstitutive::getDesignVarGroupNums(int groupIndex,
-                                                  int dvNums[]) {
-  if (groupIndex == 0) {
-    dvNums[0] = tNum;
-  }
 }
 
 // Evaluate the material density

--- a/src/constitutive/TACSSolidConstitutive.h
+++ b/src/constitutive/TACSSolidConstitutive.h
@@ -51,14 +51,6 @@ class TACSSolidConstitutive : public TACSConstitutive {
   int getDesignVarRange(int elemIndex, int dvLen, TacsScalar lb[],
                         TacsScalar ub[]);
 
-  // Design variable group API
-  int getNumDesignVarGroups();
-  const char *getDesignVarGroupName(int groupIndex);
-  int getDesignVarGroupSize(int groupIndex);
-  bool isDesignVarGroupScalar(int groupIndex);
-  void getDesignVarGroupValues(int groupIndex, TacsScalar values[]);
-  void getDesignVarGroupNums(int groupIndex, int dvNums[]);
-
   // Evaluate the material density
   TacsScalar evalDensity(int elemIndex, const double pt[],
                          const TacsScalar X[]);

--- a/tests/constitutive_tests/test_dv_groups.py
+++ b/tests/constitutive_tests/test_dv_groups.py
@@ -552,5 +552,138 @@ class TestPointMassDVGroups(DVGroupTestCase):
         )
 
 
+class TestDesignVarGroupNameContract(DVGroupTestCase):
+    """Group names must be valid Python constructor kwargs (the BDF-card contract).
+
+    Every group name returned by ``getDesignVarGroups()`` is contractually required to match a
+    keyword argument of the owning class's Python constructor, since BDF-card generation feeds
+    the group dict straight back into the constructor. Each test below reconstructs a
+    constitutive object from another instance's group dict and checks that the reconstruction
+    succeeds and the group values round-trip.
+    """
+
+    def test_scalar_group_name_is_constructor_kwarg(self):
+        """
+        Given an IsoShellConstitutive with a single scalar "t" group,
+        when its group dict is fed back into the constructor as kwargs,
+        then reconstruction succeeds and the "t" group round-trips to the same value.
+        """
+        props = makeIsoMaterial()
+        con = constitutive.IsoShellConstitutive(props, t=0.1, tNum=0)
+        groups = con.getDesignVarGroups()
+
+        rebuilt = constitutive.IsoShellConstitutive(props, **groups)
+        rebuiltGroups = rebuilt.getDesignVarGroups()
+
+        self.assertEqual(list(rebuiltGroups.keys()), list(groups.keys()))
+        np.testing.assert_allclose(rebuiltGroups["t"], groups["t"], rtol=1e-12)
+
+    def test_beam_group_names_differing_from_member_names_are_constructor_kwargs(self):
+        """
+        Given an IsoTubeBeamConstitutive whose "d" and "t" group names don't match any
+        underlying member name,
+        when its group dict is fed back into the constructor as kwargs,
+        then reconstruction succeeds and both the "d" and "t" groups round-trip to the same
+        values.
+        """
+        props = makeIsoMaterial()
+        con = constitutive.IsoTubeBeamConstitutive(props, d=1.0, dNum=0, t=0.1, tNum=1)
+        groups = con.getDesignVarGroups()
+
+        rebuilt = constitutive.IsoTubeBeamConstitutive(props, **groups)
+        rebuiltGroups = rebuilt.getDesignVarGroups()
+
+        self.assertEqual(list(rebuiltGroups.keys()), list(groups.keys()))
+        np.testing.assert_allclose(rebuiltGroups["d"], groups["d"], rtol=1e-12)
+        np.testing.assert_allclose(rebuiltGroups["t"], groups["t"], rtol=1e-12)
+
+    def test_array_group_name_is_constructor_kwarg(self):
+        """
+        Given a SmearedCompositeShellConstitutive with a scalar "thickness" group and an array
+        "ply_fractions" group,
+        when its group dict is fed back into the constructor as kwargs,
+        then reconstruction succeeds and both the "thickness" and "ply_fractions" groups
+        round-trip to the same values.
+        """
+        ply = constitutive.OrthotropicPly(0.1, makeOrthoMaterial())
+        plyAngles = np.deg2rad([0.0, 45.0, 90.0]).astype(self.dtype)
+        plyFracs = np.array([0.5, 0.25, 0.25], dtype=self.dtype)
+        plyFracNums = np.array([1, 2, 3], dtype=np.intc)
+        con = constitutive.SmearedCompositeShellConstitutive(
+            [ply] * 3, 0.1, plyAngles, plyFracs, 0, plyFracNums
+        )
+        groups = con.getDesignVarGroups()
+
+        rebuilt = constitutive.SmearedCompositeShellConstitutive(
+            ply_list=[ply] * 3, ply_angles=plyAngles, **groups
+        )
+        rebuiltGroups = rebuilt.getDesignVarGroups()
+
+        self.assertEqual(list(rebuiltGroups.keys()), list(groups.keys()))
+        np.testing.assert_allclose(
+            rebuiltGroups["thickness"], groups["thickness"], rtol=1e-12
+        )
+        np.testing.assert_allclose(
+            rebuiltGroups["ply_fractions"], groups["ply_fractions"], rtol=1e-12
+        )
+
+    def test_point_mass_group_names_are_constructor_kwargs(self):
+        """
+        Given a PointMassConstitutive with seven scalar mass/inertia groups,
+        when its group dict is fed back into the constructor as kwargs,
+        then reconstruction succeeds and every group round-trips to the same value.
+        """
+        con = constitutive.PointMassConstitutive(
+            m=2.0,
+            I11=1.0,
+            I22=1.0,
+            I33=1.0,
+            I12=0.5,
+            I13=0.5,
+            I23=0.5,
+            mNum=0,
+            I11Num=1,
+            I22Num=2,
+            I33Num=3,
+            I12Num=4,
+            I13Num=5,
+            I23Num=6,
+        )
+        groups = con.getDesignVarGroups()
+
+        rebuilt = constitutive.PointMassConstitutive(**groups)
+        rebuiltGroups = rebuilt.getDesignVarGroups()
+
+        self.assertEqual(list(rebuiltGroups.keys()), list(groups.keys()))
+        for name in groups:
+            np.testing.assert_allclose(
+                rebuiltGroups[name], groups[name], rtol=1e-12, err_msg=name
+            )
+
+    def test_lam_param_full_shell_lp_is_excluded_from_round_trip(self):
+        """
+        Given a LamParamFullShellConstitutive with a scalar "t" group and an array "lp" group,
+        when the DV group API is queried,
+        then "t" is confirmed to be a valid constructor kwarg that round-trips, while "lp" is
+        excluded from the round-trip check because lamination parameters cannot be set through
+        the constructor (they are only restored via setLaminationParameters), even though "lp"
+        is still reported as a group name.
+        """
+        ply = constitutive.OrthotropicPly(0.1, makeOrthoMaterial())
+        lpNums = np.array([1, 2, 3, 4, 5, 6], dtype=np.intc)
+        con = constitutive.LamParamFullShellConstitutive(ply, 0.1, 0, 0.05, 0.2, lpNums)
+        groups = con.getDesignVarGroups()
+
+        self.assertEqual(list(groups.keys()), ["t", "lp"])
+
+        # Only "t" is round-tripped through the constructor here; "lp" is deliberately not
+        # passed back in, since it isn't a valid constructor kwarg despite being a group name.
+        rebuilt = constitutive.LamParamFullShellConstitutive(
+            ply, t=groups["t"], tNum=0, tlb=0.05, tub=0.2, lpNums=lpNums
+        )
+        rebuiltGroups = rebuilt.getDesignVarGroups()
+        np.testing.assert_allclose(rebuiltGroups["t"], groups["t"], rtol=1e-12)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
#462 adds new methods to pyTACS that produce user-friendly dictionaries containing the values and indices for all design variables associated with each component in a model. Behind the scenes that was enabled by implementing 6 new methods in every constitutive class:

- `getNumDesignVarGroups`
- `getDesignVarGroupName`
- `getDesignVarGroupSize`
- `isDesignVarGroupScalar`
- `getDesignVarGroupValues`
- `getDesignVarGroupNums`

This PR provides the same public API with a new implementation that reduces the amount of code that needs to be implemented in each constitutive model.

Information about a constitutive model's design variable groups are now stored in a "table" (really a `std::vector<DesignVarGroup>`), each constitutive model populates this table using these two methods:

```cpp
void registerScalarDesignVarGroup(const char *name, TacsScalar *value, int *dvNum);
void registerArrayDesignVarGroup(const char *name, int size, TacsScalar *values, int *dvNums);
```

The six methods above, that used to have to be implemented by every constitutive model, are now non-virtual methods of the base `TACSConstitutive` class.
