### PR TITLE
Restrict UCX transports in the conda test environment

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -98,6 +98,11 @@ test:
     - test -f $PREFIX/bin/f5totec
     - export OMPI_MCA_btl=self,tcp
     - export OMPI_MCA_rmaps_base_oversubscribe=1
+    # The mpich variants use the UCX netmod, which aborts MPI_Init if it finds an
+    # RDMA device it can't open (e.g. Azure's mana_0 on some CI runners). Restrict
+    # UCX to loopback transports since these tests are single-node.
+    - export UCX_TLS=tcp,self,sm
+    - export UCX_NET_DEVICES=lo
     - rm tests/integration_tests/test_mphys*
     - testflo --pre_announce --timeout 120 tests/ # [linux64]
 


### PR DESCRIPTION
The mpich variants abort in MPI_Init when UCX finds an RDMA device it cannot open, which has failed the linux-64 complex deploy since v3.12.2.