### PR TITLE
Initialize the quadrature point array in TACSInertialForce2D

### DIFF
--- a/src/elements/TACSInertialForce2D.cpp
+++ b/src/elements/TACSInertialForce2D.cpp
@@ -105,7 +105,7 @@ void TACSInertialForce2D::addResidual(
   // Loop over each quadrature point and add the residual contribution
   for (int n = 0; n < nquad; n++) {
     // Get the quadrature weight
-    double pt[3];
+    double pt[3] = {0.0, 0.0, 0.0};
     double weight = basis->getQuadraturePoint(n, pt);
 
     // Get the face normal
@@ -150,7 +150,7 @@ void TACSInertialForce2D::addJacobian(int elemIndex, double time,
   // Loop over each quadrature point and add the residual contribution
   for (int n = 0; n < nquad; n++) {
     // Get the quadrature weight
-    double pt[3];
+    double pt[3] = {0.0, 0.0, 0.0};
     double weight = basis->getQuadraturePoint(n, pt);
 
     // Get the face normal


### PR DESCRIPTION
## Description
Both quadrature loops in `TACSInertialForce2D` declare `double pt[3];` and fill it with `basis->getQuadraturePoint(n, pt)`, which writes only `pt[0]` and `pt[1]` for 2D bases, but its third entry is never initialized.

This PR initializes those to zero matching the convention elsewhere, e.g., `TACSMassInertialForce::addResidual`, the mass-element analogue of this element. For a 2D element the third parametric coordinate is meaningless, so `0.0` is the natural value.

## Further details
This was uncovered when building with `icpx` (2024.2.1.20240711) at `-O2`/`-O3` and the `test_inertial_force_2d.py::test_element_jacobian` tests are all failing with the same error (only one of ten shown below)
```
./tests/element_tests/test_inertial_force_2d.py:ElementTest.test_element_jacobian (basis=<tacs.elements.LinearTriangleBasis object at 0x764727fbdc30>, model=<tacs.elements.LinearElasticity2D object at 0x7647775ac6d0>) ... FAIL (00:00:0.00, 253 MB)
Traceback (most recent call last):
  File "./tests/element_tests/test_inertial_force_2d.py", line 116, in test_element_jacobian
    self.assertFalse(fail)
AssertionError: 1 is not false
```

The `addResidual` and `addJacobian`, whose residual loops are identical, return different values for identical inputs, but initializing `pt` fixes this issue. I think its likely some type of compiler bug since pt[2] is never read, and setting it to some very large value (1e300) rather than leaving it uninitialized still gives correct results at every -O level. So nothing is reading the value, yet initializing the array changes the generated code.

With it uninitialized, compiling with `-O0`, `-O1` and `-fno-unroll-loops` is correct, but `-O2`/`-O3` are wrong, and every floating-point control (`-fp-model=precise` etc.) also leaves it wrong, so its probably related to the loop unroller. GCC 13.3 is correct at `-O3` and stays correct with `-funroll-all-loops`.  Setting `-fno-unroll-loops` would be possible, but I don't think that is the right approach, as it's an optimization penalty for the entire code for this one loop. Initializing these small arrays is the correct approach.

I did a quick scan of the source, and there are multiple instances elsewhere that are missing initialization like this. However, I only changed what was needed for the affecting test since I don't know if other places have any issues. We can, and probably should, apply the same init elsewhere in this PR or in a follow-up one. Just let me know.
