### PR TITLE
Install tecio into its own conda env to fix macOS CI

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -115,11 +115,15 @@ jobs:
           make ${{ matrix.OPTIONAL }} TACS_DIR=$TACS_DIR METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
       - name: Install f5totec/f5tovtk
         run: |
-          # Sometimes needed for macos runner to prevent it from pulling numpy 2 when installing tecio later
-          mamba install -c smdogroup -c conda-forge tecio "numpy>=2" -q -y;
+          set -e
+          # conda-forge has an unrelated package also named tecio, so name the channel
+          # explicitly and keep tecio in its own env, out of the test env's solve.
+          mamba create -n tecio -c smdogroup -c conda-forge smdogroup::tecio -y
+          TECIO_PREFIX="$(conda info --base)/envs/tecio"
+          ls -l "${TECIO_PREFIX}/include/TECIO.h" "${TECIO_PREFIX}/lib/libtecio.a"
           # Compile f5totec/f5tovtk
           cd $TACS_DIR/extern/f5totec;
-          make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${CONDA_PREFIX}/include/ TECIO_LIB=${CONDA_PREFIX}/lib/libtecio.a\
+          make TACS_DIR=$TACS_DIR TECIO_INCLUDE=-I${TECIO_PREFIX}/include/ TECIO_LIB=${TECIO_PREFIX}/lib/libtecio.a\
             METIS_INCLUDE=-I${CONDA_PREFIX}/include/ METIS_LIB="-L${CONDA_PREFIX}/lib/ -lmetis";
           cd ..;
           cd f5tovtk;


### PR DESCRIPTION
## Description

The macOS CI has been failing with `fatal error: 'TECIO.h' file not found`.

Two different packages are named `tecio`: `smdogroup::tecio` is the Tecplot C library f5totec needs, and `conda-forge::tecio` is an unrelated pure-Python Tecplot reader that ships no headers. Because the install resolves the bare name `tecio` inside the test env, the solver is free to choose between them, and it now picks the conda-forge one. It costs 5 packages and no downgrades, whereas `smdogroup::tecio` pulls `boost` -> `libboost` -> `icu <76` and so requires removing the LLVM 23 toolchain and downgrading icu, libxml2 and libpsl. That branch got more expensive when conda-forge moved to libcxx/LLVM 23.1.0, and the solver flipped. Nothing is unsatisfiable, so there are no errors, but the wrong package installs silently, and the build fails later with a misleading missing-header message.

This PR installs tecio into its own conda environment, with the channel spelled out, and points `TECIO_INCLUDE`/`TECIO_LIB` at it. f5totec only needs the header and static library at build time, so it does not need to share the test env, and tecio no longer competes with the test env's package set. The step also verifies both files exist before compiling, so a wrong package fails at the install rather than as a confusing compile error.

Diagnosis and the full solver output are in #476.

## Note, `smdogroup::tecio` should probably be rebuilt

This PR mitigates the problem but it does not remove the underlying fragility.

`smdogroup::tecio 2021.2` (osx-arm64, built 2022-11-15) declares a run dependency on `boost`. That dependency is what drags in the `libboost` -> `icu <76` chain and makes the package expensive to install, and it is almost certainly a build-time leak: f5totec uses only the C TECIO API, and the package ships a self-contained static library.

Rebuilding tecio without the `boost` run dependency would make it cheap to install alongside a normal test env, and would let the install go back into the test env directly if that is preferred. Worth doing whenever convenient — this PR is not blocked on it.

Note also that the collision with `conda-forge::tecio` is permanent, so the channel should be named explicitly (`smdogroup::tecio`) wherever tecio is installed, on all platforms.
